### PR TITLE
Fix memory leak on Linux

### DIFF
--- a/src/common/platform/linux/serial_port_enum.cpp
+++ b/src/common/platform/linux/serial_port_enum.cpp
@@ -157,7 +157,7 @@ uint32_t EnumSerialPorts(std::list<SerialPortDesc*>& descs)
             descs.push_back(resultItem);
         }
 
-        delete device;
+        free(device);
     }
 
     devices->clear();

--- a/src/common/platform/linux/serial_port_enum.cpp
+++ b/src/common/platform/linux/serial_port_enum.cpp
@@ -78,22 +78,22 @@ static adapter_list_t* GetAdapters()
 
     struct udev_list_entry *udev_devices = udev_enumerate_get_list_entry(udev_enum);
     struct udev_list_entry *udev_entry;
-    struct udev_device *udev_dev;
+    struct udev_device *udev_tty_dev, *udev_usb_dev;
 
     udev_list_entry_foreach(udev_entry, udev_devices)
     {
         const char *path = udev_list_entry_get_name(udev_entry);
 
-        udev_dev = udev_device_new_from_syspath(udev_ctx, path);
-        const char *devname = udev_device_get_devnode(udev_dev);
+        udev_tty_dev = udev_device_new_from_syspath(udev_ctx, path);
+        const char *devname = udev_device_get_devnode(udev_tty_dev);
 
-        udev_dev = udev_device_get_parent_with_subsystem_devtype(
-            udev_dev,
+        udev_usb_dev = udev_device_get_parent_with_subsystem_devtype(
+            udev_tty_dev,
             "usb",
             "usb_device"
         );
 
-        const char *idVendor = udev_device_get_sysattr_value(udev_dev, "idVendor");
+        const char *idVendor = udev_device_get_sysattr_value(udev_usb_dev, "idVendor");
 
         // Only add SEGGER and ARM (even though VENDOR_ID is NXPs...) devices to list
         if(idVendor != NULL && ((strcmp(idVendor, SEGGER_VENDOR_ID) == 0) || (strcmp(idVendor, NXP_VENDOR_ID) == 0)))
@@ -104,14 +104,14 @@ static adapter_list_t* GetAdapters()
             strcpy(serial_device->vendorId, idVendor);
             strcpy(serial_device->port, devname);
             strcpy(serial_device->locationId, path);
-            strcpy(serial_device->productId, udev_device_get_sysattr_value(udev_dev, "idProduct"));
-            strcpy(serial_device->manufacturer, udev_device_get_sysattr_value(udev_dev,"manufacturer"));
-            strcpy(serial_device->serialNumber, udev_device_get_sysattr_value(udev_dev, "serial"));
+            strcpy(serial_device->productId, udev_device_get_sysattr_value(udev_usb_dev, "idProduct"));
+            strcpy(serial_device->manufacturer, udev_device_get_sysattr_value(udev_usb_dev,"manufacturer"));
+            strcpy(serial_device->serialNumber, udev_device_get_sysattr_value(udev_usb_dev, "serial"));
 
             devices->push_back(serial_device);
         }
 
-        udev_device_unref(udev_dev);
+        udev_device_unref(udev_tty_dev);
     }
 
     udev_enumerate_unref(udev_enum);


### PR DESCRIPTION
We have observed high memory usage when using pc-ble-driver on Linux. By using Valgrind, I found that udev device resources are not being properly released in `linux/serial_port_enum.cpp`, causing a memory leak.

To test this, I created a simple `test.cpp` file that just calls `EnumSerialPorts()` and prints the serial numbers.

```
#include <stdlib.h>
#include <iostream>
#include "serial_port_enum.cpp"
 
int main()
{
    std::list<SerialPortDesc*> descs;
    uint32_t ret;
    ret = EnumSerialPorts(descs);
    for(auto it = descs.begin(); it != descs.end(); ++it)
    {
        std::cout << (*it)->serialNumber.c_str() << std::endl;
        delete *it;
    }
    return 0;
}
```

I compiled this with `g++ -std=c++11 -o test test.cpp -ludev`, and ran Valgrind. The serial numbers are being printed in the middle of the output.

```
$ valgrind --leak-check=full ./test
==10506== Memcheck, a memory error detector
==10506== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==10506== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==10506== Command: ./test
==10506== 
==10506== Mismatched free() / delete / delete []
==10506==    at 0x4C2F24B: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10506==    by 0x401AB2: EnumSerialPorts(std::__cxx11::list<SerialPortDesc*, std::allocator<SerialPortDesc*> >&) (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506==    by 0x401B42: main (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506==  Address 0x6217140 is 0 bytes inside a block of size 24,576 alloc'd
==10506==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10506==    by 0x401752: GetAdapters() (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506==    by 0x4018BD: EnumSerialPorts(std::__cxx11::list<SerialPortDesc*, std::allocator<SerialPortDesc*> >&) (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506==    by 0x401B42: main (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506== 
000683881373
000682556203
==10506== 
==10506== HEAP SUMMARY:
==10506==     in use at exit: 976,637 bytes in 1,836 blocks
==10506==   total heap usage: 7,230 allocs, 5,394 frees, 7,195,260 bytes allocated
==10506== 
==10506== 791,425 (27,744 direct, 763,681 indirect) bytes in 102 blocks are definitely lost in loss record 54 of 54
==10506==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10506==    by 0x4047517: ??? (in /lib/x86_64-linux-gnu/libudev.so.1.6.4)
==10506==    by 0x4047E1D: udev_device_new_from_syspath (in /lib/x86_64-linux-gnu/libudev.so.1.6.4)
==10506==    by 0x4016C2: GetAdapters() (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506==    by 0x4018BD: EnumSerialPorts(std::__cxx11::list<SerialPortDesc*, std::allocator<SerialPortDesc*> >&) (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506==    by 0x401B42: main (in /home/mrodem/tmp/pc-ble-driver/src/common/platform/linux/test)
==10506== 
==10506== LEAK SUMMARY:
==10506==    definitely lost: 27,744 bytes in 102 blocks
==10506==    indirectly lost: 763,681 bytes in 486 blocks
==10506==      possibly lost: 0 bytes in 0 blocks
==10506==    still reachable: 185,212 bytes in 1,248 blocks
==10506==         suppressed: 0 bytes in 0 blocks
==10506== Reachable blocks (those to which a pointer was found) are not shown.
==10506== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==10506== 
==10506== For counts of detected and suppressed errors, rerun with: -v
==10506== ERROR SUMMARY: 3 errors from 2 contexts (suppressed: 0 from 0)
```

After applying the fix, Valgrind reports no errors, and it still finds the serial numbers.

```
$ valgrind --leak-check=full ./test
==10424== Memcheck, a memory error detector
==10424== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==10424== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==10424== Command: ./test
==10424== 
000683881373
000682556203
==10424== 
==10424== HEAP SUMMARY:
==10424==     in use at exit: 89,088 bytes in 4 blocks
==10424==   total heap usage: 7,230 allocs, 7,226 frees, 7,195,260 bytes allocated
==10424== 
==10424== LEAK SUMMARY:
==10424==    definitely lost: 0 bytes in 0 blocks
==10424==    indirectly lost: 0 bytes in 0 blocks
==10424==      possibly lost: 0 bytes in 0 blocks
==10424==    still reachable: 89,088 bytes in 4 blocks
==10424==         suppressed: 0 bytes in 0 blocks
==10424== Reachable blocks (those to which a pointer was found) are not shown.
==10424== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==10424== 
==10424== For counts of detected and suppressed errors, rerun with: -v
==10424== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```