### PR TITLE
heart rate monitor example cleanup/minor fixes

### DIFF
--- a/examples/heart_rate_monitor/CMakeLists.txt
+++ b/examples/heart_rate_monitor/CMakeLists.txt
@@ -29,8 +29,8 @@ endif()
 add_executable(hrm_v2 main.c)
 add_executable(hrm_v3 main.c)
 
-target_compile_definitions(hrm_v2 PRIVATE -DSD_API_V2)
-target_compile_definitions(hrm_v3 PRIVATE -DSD_API_V3)
+target_compile_definitions(hrm_v2 PRIVATE -DNRF_SD_BLE_API=2)
+target_compile_definitions(hrm_v3 PRIVATE -DNRF_SD_BLE_API=3)
 
 target_include_directories(hrm_v2 PRIVATE ../../src/sd_api_v2/sdk/components/softdevice/s132/headers)
 target_include_directories(hrm_v3 PRIVATE ../../src/sd_api_v3/sdk/components/softdevice/s132/headers)

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -73,9 +73,9 @@ static adapter_t * m_adapter = NULL;
 
 static uint32_t advertising_start();
 
-static void status_handler(adapter_t *adapter, sd_rpc_app_status_t code, const char * message)
+static void status_handler(adapter_t * adapter, sd_rpc_app_status_t code, const char * message)
 {
-    printf("Status: %d, message: %s\n", (uint32_t)code, message);
+    printf("Status: %d, message: %s\n", (uint32_t) code, message);
 }
 
 static void log_handler(adapter_t * adapter, sd_rpc_log_severity_t severity, const char * message)
@@ -91,7 +91,7 @@ static void log_handler(adapter_t * adapter, sd_rpc_log_severity_t severity, con
         break;
 
     case SD_RPC_LOG_INFO:
-        printf("Warning: %s\n", message); fflush(stdout);
+        printf("Info: %s\n", message); fflush(stdout);
         break;
 
     default:
@@ -102,6 +102,8 @@ static void log_handler(adapter_t * adapter, sd_rpc_log_severity_t severity, con
 
 static void ble_evt_dispatch(adapter_t * adapter, ble_evt_t * p_ble_evt)
 {
+    uint32_t err_code;
+
     if (p_ble_evt == NULL)
     {
         return;
@@ -127,12 +129,22 @@ static void ble_evt_dispatch(adapter_t * adapter, ble_evt_t * p_ble_evt)
         break;
 
     case BLE_GAP_EVT_SEC_PARAMS_REQUEST:
-        sd_ble_gap_sec_params_reply(adapter, m_connection_handle,
-                                    BLE_GAP_SEC_STATUS_SUCCESS, NULL, NULL);
+        err_code = sd_ble_gap_sec_params_reply(adapter, m_connection_handle,
+                                               BLE_GAP_SEC_STATUS_SUCCESS, NULL, NULL);
+
+        if (err_code != NRF_SUCCESS)
+        {
+            printf("Failed reply with GAP security parameters. Error code: 0x%02X\n", err_code); fflush(stdout);
+        }
         break;
 
     case BLE_GATTS_EVT_SYS_ATTR_MISSING:
-        sd_ble_gatts_sys_attr_set(adapter, m_connection_handle, NULL, 0, 0);
+        err_code = sd_ble_gatts_sys_attr_set(adapter, m_connection_handle, NULL, 0, 0);
+
+        if (err_code != NRF_SUCCESS)
+        {
+            printf("Failed updating persistent sys attr info. Error code: 0x%02X\n", err_code); fflush(stdout);
+        }
         break;
 
     case BLE_GATTS_EVT_WRITE:
@@ -144,7 +156,7 @@ static void ble_evt_dispatch(adapter_t * adapter, ble_evt_t * p_ble_evt)
         break;
 
     default:
-        //printf("Received event with ID: %d\n", p_ble_evt->header.evt_id); fflush(stdout);
+        printf("Received an un-handled event with ID: %d\n", p_ble_evt->header.evt_id); fflush(stdout);
         break;
     }
 }

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -265,7 +265,7 @@ static uint32_t advertising_start()
     ble_gap_adv_params_t adv_params;
 
     adv_params.type        = BLE_GAP_ADV_TYPE_ADV_IND;
-    adv_params.p_peer_addr = NULL;                           // Undirected advertisement.
+    adv_params.p_peer_addr = NULL;                        // Undirected advertisement.
     adv_params.fp          = BLE_GAP_ADV_FP_ANY;
     adv_params.interval    = ADVERTISING_INTERVAL_40_MS;
     adv_params.timeout     = ADVERTISING_TIMEOUT_3_MIN;
@@ -288,15 +288,12 @@ static uint32_t advertising_start()
 static uint8_t heart_rate_measurement_encode(uint8_t * encoded_hrm, uint8_t heart_rate)
 {
     uint8_t flags = 0;
-    uint8_t length = 1;
 
-    // Very simple encoding
-    encoded_hrm[length++] = heart_rate;
-
-    // Add flags
+    // Very simple encoding.
     encoded_hrm[0] = flags;
+    encoded_hrm[1] = heart_rate;
 
-    return length;
+    return 2; // Return length of encoded_hrm
 }
 
 static uint32_t characteristic_init()
@@ -470,14 +467,14 @@ int main(int argc, char *argv[])
         return error_code;
     }
 
-    error_code = services_init();
+    error_code = advertisement_data_set();
 
     if (error_code != NRF_SUCCESS)
     {
         return error_code;
     }
 
-    error_code = advertisement_data_set();
+    error_code = services_init();
 
     if (error_code != NRF_SUCCESS)
     {

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -19,11 +19,7 @@
  */
 
 #include "ble.h"
-#include "ble_types.h"
-#include "ble_l2cap.h"
-#include "ble_gatts.h"
 #include "sd_rpc.h"
-#include "nrf_error.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -351,13 +347,11 @@ static uint32_t characteristic_init()
 
     if (error_code != NRF_SUCCESS)
     {
-        printf("Failed to initialize characteristics. Error code: 0x%02X\n", error_code);
-        fflush(stdout);
+        printf("Failed to initialize characteristics. Error code: 0x%02X\n", error_code); fflush(stdout);
         return error_code;
     }
 
     printf("Characteristics initiated\n"); fflush(stdout);
-
     return NRF_SUCCESS;
 }
 

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -15,7 +15,7 @@
  *
  * This file contains the source code for a sample application using the Heart Rate service.
  * This service exposes heart rate data from a Heart Rate Sensor intended for fitness applications.
- * https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.heart_rate.xml
+ * https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=horg.bluetooth.service.heart_rate.xml
  */
 
 #include "ble.h"
@@ -157,7 +157,7 @@ static void ble_evt_dispatch(adapter_t * adapter, ble_evt_t * p_ble_evt)
         }
         break;
 
-#ifdef SD_API_V3
+#if NRF_SD_BLE_API >= 3
     case BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST:
         err_code = sd_ble_gatts_exchange_mtu_reply(adapter, m_connection_handle, GATT_MTU_SIZE_DEFAULT);
 
@@ -291,7 +291,7 @@ static uint32_t advertising_start()
     adv_params.fp          = BLE_GAP_ADV_FP_ANY;
     adv_params.interval    = ADVERTISING_INTERVAL_40_MS;
     adv_params.timeout     = ADVERTISING_TIMEOUT_3_MIN;
-#ifdef SD_API_V2
+#if NRF_SD_BLE_API == 2
     adv_params.p_whitelist = NULL;
 #endif
 

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -376,15 +376,6 @@ static uint32_t heart_rate_measurement_send()
 
     error_code = sd_ble_gatts_hvx(m_adapter, m_connection_handle, &hvx_params);
 
-    if (error_code == NRF_SUCCESS && (hvx_length != length))
-    {
-        error_code = NRF_ERROR_DATA_SIZE;
-        printf("Failed to send heart rate measurement. Error code: 0x%02X\n", error_code);
-        fflush(stdout);
-        return error_code;
-    }
-
-
     if (error_code != NRF_SUCCESS)
     {
         printf("Failed to send heart rate measurement. Error code: 0x%02X\n", error_code);

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -155,6 +155,17 @@ static void ble_evt_dispatch(adapter_t * adapter, ble_evt_t * p_ble_evt)
         }
         break;
 
+#ifdef SD_API_V3
+    case BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST:
+        err_code = sd_ble_gatts_exchange_mtu_reply(adapter, m_connection_handle, GATT_MTU_SIZE_DEFAULT);
+
+        if (err_code != NRF_SUCCESS)
+        {
+            printf("Failed updating persistent sys attr info. Error code: 0x%02X\n", err_code); fflush(stdout);
+        }
+        break;
+#endif
+
     default:
         printf("Received an un-handled event with ID: %d\n", p_ble_evt->header.evt_id); fflush(stdout);
         break;

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -184,25 +184,25 @@ static uint32_t ble_stack_init()
     ble_enable_params.gatts_enable_params.attr_tab_size = BLE_GATTS_ATTR_TAB_SIZE_DEFAULT;
     ble_enable_params.gatts_enable_params.service_changed = false;
     ble_enable_params.gap_enable_params.periph_conn_count = 1;
-    ble_enable_params.gap_enable_params.central_conn_count = 5;
-    ble_enable_params.gap_enable_params.central_sec_count = 1;
+    ble_enable_params.gap_enable_params.central_conn_count = 0;
+    ble_enable_params.gap_enable_params.central_sec_count = 0;
+    // TODO: set device name in gap_enable_params
     ble_enable_params.common_enable_params.p_conn_bw_counts = NULL;
-    ble_enable_params.common_enable_params.vs_uuid_count = 5;
+    ble_enable_params.common_enable_params.vs_uuid_count = 1;
 
     err_code = sd_ble_enable(m_adapter, &ble_enable_params, app_ram_base);
 
-    if (err_code == NRF_SUCCESS)
-    {
-        return err_code;
+    switch(err_code) {
+        case NRF_SUCCESS:
+            break;
+        case NRF_ERROR_INVALID_STATE:
+            printf("BLE stack already enabled\n"); fflush(stdout);
+            break;
+        default:
+            printf("Failed to enable BLE stack. Error code: %d\n", err_code); fflush(stdout);
+            break;
     }
 
-    if (err_code == NRF_ERROR_INVALID_STATE)
-    {
-        printf("BLE stack already enabled\n"); fflush(stdout);
-        return NRF_SUCCESS;
-    }
-
-    printf("Failed to enable BLE stack. Error code: %d\n", err_code); fflush(stdout);
     return err_code;
 }
 

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -9,6 +9,14 @@
  * the file.
  *
  */
+/** @example examples/heart_rate_monitor
+ *
+ * @brief Heart Rate Service Sample Application main file.
+ *
+ * This file contains the source code for a sample application using the Heart Rate service.
+ * This service exposes heart rate data from a Heart Rate Sensor intended for fitness applications.
+ * https://www.bluetooth.com/specifications/gatt/viewer?attributeXmlFile=org.bluetooth.service.heart_rate.xml
+ */
 
 #include "ble.h"
 #include "ble_types.h"


### PR DESCRIPTION
#### Functionality changes:

`hrm_v3` was not fully functioning with `nRF Connect`. Fixed by responding to exchange mtu request: 6eab351.

Heart rate monitor in `nRF Toolbox` did not identify device b/c heart rate service was not advertised. Added heart rate service to adv data: a855f75

Only send a heart rate measurement every 1s like in nRF5 SDK

The rest is cleanup. Added doc strings. Tried to follow nRF5 SDK coding style and hrm example a bit closer. Some general cleanup, linted.