### PR TITLE
Fix pointer casting so it gives the correct level of indirection

### DIFF
--- a/src/common/ble_gap_impl.cpp
+++ b/src/common/ble_gap_impl.cpp
@@ -512,7 +512,7 @@ uint32_t sd_ble_gap_conn_sec_get(adapter_t *adapter, uint16_t conn_handle, ble_g
         return ble_gap_conn_sec_get_rsp_dec(
             buffer,
             length,
-            (ble_gap_conn_sec_t * *)p_conn_sec,
+            (ble_gap_conn_sec_t * * const)&p_conn_sec,
             result);
     };
 


### PR DESCRIPTION
A cast was being performed on a single-pointer instead of the address of the pointer, resulting in an incorrect level of indirection.