### PR TITLE
Fix/keil long paths

### DIFF
--- a/hex/sd_api_v2/sdk110_connectivity.patch
+++ b/hex/sd_api_v2/sdk110_connectivity.patch
@@ -516,3 +516,16 @@ diff --git a/examples/ble_central_and_peripheral/ble_connectivity/main.c b/examp
 
          /* Process received packets.
           * We can NOT add received packets as events to the application scheduler queue because
+diff --git a/examples/ble_central_and_peripheral/ble_connectivity/pca10028/ser_s130_hci/arm5_no_packs/ble_connectivity_s130_hci_pca10028.uvprojx b/examples/ble_central_and_peripheral/ble_connectivity/pca10028/ser_s130_hci/arm5_no_packs/ble_connectivity_s130_hci_pca10028.uvprojx
+index 0f597ba..2f6bfb4 100644
+--- a/examples/ble_central_and_peripheral/ble_connectivity/pca10028/ser_s130_hci/arm5_no_packs/ble_connectivity_s130_hci_pca10028.uvprojx
++++ b/examples/ble_central_and_peripheral/ble_connectivity/pca10028/ser_s130_hci/arm5_no_packs/ble_connectivity_s130_hci_pca10028.uvprojx
+@@ -366,7 +366,7 @@
+             <vShortEn>0</vShortEn>
+             <vShortWch>0</vShortWch>
+             <VariousControls>
+-              <MiscControls></MiscControls>
++              <MiscControls>--reduce_paths</MiscControls>
+               <Define> HCI_TIMER2 BLE_STACK_SUPPORT_REQD __STACK_SIZE=2048 __HEAP_SIZE=1024 BOARD_PCA10028 S130 SER_CONNECTIVITY APP_SCHEDULER_WITH_PAUSE BSP_DEFINES_ONLY NRF51 SOFTDEVICE_PRESENT SWI_DISABLE0</Define>
+               <Undefine></Undefine>
+               <IncludePath>..\..\..\config\ble_connectivity_s130_hci_pca10028;..\..\..\config;..\..\..\..\..\..\components\ble\ble_dtm;..\..\..\..\..\..\components\ble\common;..\..\..\..\..\..\components\drivers_nrf\common;..\..\..\..\..\..\components\drivers_nrf\config;..\..\..\..\..\..\components\drivers_nrf\delay;..\..\..\..\..\..\components\drivers_nrf\hal;..\..\..\..\..\..\components\drivers_nrf\uart;..\..\..\..\..\..\components\libraries\crc16;..\..\..\..\..\..\components\libraries\mailbox;..\..\..\..\..\..\components\libraries\scheduler;..\..\..\..\..\..\components\libraries\timer;..\..\..\..\..\..\components\libraries\uart;..\..\..\..\..\..\components\libraries\util;..\..\..\..\..\..\components\serialization\common;..\..\..\..\..\..\components\serialization\common\struct_ser\s130;..\..\..\..\..\..\components\serialization\common\transport;..\..\..\..\..\..\components\serialization\common\transport\ser_phy;..\..\..\..\..\..\components\serialization\common\transport\ser_phy\config;..\..\..\..\..\..\components\serialization\connectivity;..\..\..\..\..\..\components\serialization\connectivity\codecs\common;..\..\..\..\..\..\components\serialization\connectivity\codecs\s130\middleware;..\..\..\..\..\..\components\serialization\connectivity\codecs\s130\serializers;..\..\..\..\..\..\components\serialization\connectivity\hal;..\..\..\..\..\..\components\softdevice\common\softdevice_handler;..\..\..\..\..\..\components\softdevice\s130\headers;..\..\..\..\..\..\components\softdevice\s130\headers\nrf51;..\..\..\..\..\..\components\toolchain;..\..\..\..\..\bsp</IncludePath>

--- a/hex/sd_api_v3/sdk121_connectivity.patch
+++ b/hex/sd_api_v3/sdk121_connectivity.patch
@@ -147,7 +147,7 @@ diff --git a/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s
 index 0f597ba..2f6bfb4 100644
 --- a/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s132_hci/arm5_no_packs/ble_connectivity_s132_hci_pca10040.uvprojx
 +++ b/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s132_hci/arm5_no_packs/ble_connectivity_s132_hci_pca10040.uvprojx
-@@ -334,8 +334,8 @@
+@@ -329,8 +329,8 @@
                </OCR_RVCT8>
                <OCR_RVCT9>
                  <Type>0</Type>
@@ -158,7 +158,15 @@ index 0f597ba..2f6bfb4 100644
                </OCR_RVCT9>
                <OCR_RVCT10>
                  <Type>0</Type>
-diff --git a/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld b/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -361,7 +361,7 @@
+             <vShortEn>0</vShortEn>
+             <vShortWch>0</vShortWch>
+             <VariousControls>
+-              <MiscControls></MiscControls>
++              <MiscControls>--reduce_paths</MiscControls>
+               <Define> HCI_TIMER2 BLE_STACK_SUPPORT_REQD __STACK_SIZE=2048 __HEAP_SIZE=1024 BOARD_PCA10040 NRF52_PAN_12 NRF52_PAN_15 NRF52_PAN_20 NRF52_PAN_30 NRF52_PAN_31 NRF52_PAN_36 NRF52_PAN_51 NRF52_PAN_53 NRF52_PAN_54 NRF52_PAN_55 NRF52_PAN_58 NRF52_PAN_62 NRF52_PAN_63 NRF52_PAN_64 CONFIG_GPIO_AS_PINRESET S132 NRF_SD_BLE_API_VERSION=3 SER_CONNECTIVITY BSP_DEFINES_ONLY NRF52832 NRF52 SOFTDEVICE_PRESENT SWI_DISABLE0</Define>
+               <Undefine></Undefine>
+               <IncludePath>..\..\..\config;..\..\..\..\..\..\components;..\..\..\..\..\..\components\ble\ble_dtm;..\..\..\..\..\..\components\ble\common;..\..\..\..\..\..\components\drivers_nrf\clock;..\..\..\..\..\..\components\drivers_nrf\common;..\..\..\..\..\..\components\drivers_nrf\delay;..\..\..\..\..\..\components\drivers_nrf\hal;..\..\..\..\..\..\components\drivers_nrf\uart;..\..\..\..\..\..\components\libraries\crc16;..\..\..\..\..\..\components\libraries\log;..\..\..\..\..\..\components\libraries\log\src;..\..\..\..\..\..\components\libraries\mailbox;..\..\..\..\..\..\components\libraries\scheduler;..\..\..\..\..\..\components\libraries\timer;..\..\..\..\..\..\components\libraries\uart;..\..\..\..\..\..\components\libraries\util;..\..\..\..\..\..\components\serialization\common;..\..\..\..\..\..\components\serialization\common\struct_ser\s132;..\..\..\..\..\..\components\serialization\common\transport;..\..\..\..\..\..\components\serialization\common\transport\ser_phy;..\..\..\..\..\..\components\serialization\common\transport\ser_phy\config;..\..\..\..\..\..\components\serialization\connectivity;..\..\..\..\..\..\components\serialization\connectivity\codecs\common;..\..\..\..\..\..\components\serialization\connectivity\codecs\s132\middleware;..\..\..\..\..\..\components\serialization\connectivity\codecs\s132\serializers;..\..\..\..\..\..\components\serialization\connectivity\hal;..\..\..\..\..\..\components\softdevice\common\softdevice_handler;..\..\..\..\..\..\components\softdevice\s132\headers;..\..\..\..\..\..\components\softdevice\s132\headers\nrf52;..\..\..\..\..\..\components\toolchain;..\..\..\..\..\bsp;..\..\..\..\..\..\external\segger_rtt;..\config</IncludePath>
 index 7121bc0..ba41a73 100644
 --- a/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 +++ b/examples/ble_central_and_peripheral/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld


### PR DESCRIPTION
Connectivity keil project fails to compile on build server due to too long paths (Windows limitation). Adding
--reduce-paths option to keil project to mitigate the problem.