### PR TITLE
Fix problem related to control packet state transitions

### DIFF
--- a/hex/sd_api_v2/sdk110_connectivity.patch
+++ b/hex/sd_api_v2/sdk110_connectivity.patch
@@ -144,7 +144,19 @@ diff --git a/components/serialization/common/transport/ser_phy/ser_phy_hci.c b/c
  #define TX_EVT_QUEUE_SIZE            16
  #define RX_EVT_QUEUE_SIZE            16
  #define PKT_TYPE_VENDOR_SPECIFIC     14                                                /**< Packet type vendor specific. */
-@@ -756,6 +758,11 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
+@@ -48,7 +50,11 @@
+ #define INITIAL_SEQ_NUMBER           INITIAL_ACK_NUMBER_EXPECTED                       /**< Initial acknowledge number transmitted. */
+ #define INVALID_PKT_TYPE             0xFFFFFFFFu                                       /**< Internal invalid packet type value. */
+ #define MAX_TRANSMISSION_TIME_ms     (MAX_PACKET_SIZE_IN_BITS * BAUD_TIME_us / 1000uL) /**< Max transmission time of a single application packet over UART in units of mseconds. */
++#if SER_PHY_UART_BAUDRATE == UART_BAUDRATE_BAUDRATE_Baud115200
+ #define RETRANSMISSION_TIMEOUT_IN_ms (10uL * MAX_TRANSMISSION_TIME_ms)                 /**< Retransmission timeout for application packet in units of mseconds. */
++#else
++#define RETRANSMISSION_TIMEOUT_IN_ms (50uL * MAX_TRANSMISSION_TIME_ms)                /**< Retransmission timeout for application packet in units of mseconds. */
++#endif
+ 
+ #ifdef  HCI_LINK_CONTROL
+ #define HCI_PKT_SYNC        0x7E01u                                                    /**< Link Control Packet: type SYNC */
+@@ -756,6 +762,11 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
              event.evt.ser_phy_slip_evt.evt_params.received_pkt.p_buffer,
              event.evt.ser_phy_slip_evt.evt_params.received_pkt.num_of_bytes);
  
@@ -486,7 +498,7 @@ diff --git a/examples/ble_central_and_peripheral/ble_connectivity/main.c b/examp
 +    .revision_hash      = 0,
 +    .version_major      = 2,
 +    .version_minor      = 0,
-+    .version_patch      = 0,
++    .version_patch      = 1,
 +    .rfu1               = 0xFF,
 +    .sd_ble_api_version = 2,
 +    .transport_type     = 1,

--- a/hex/sd_api_v5/sdk140_connectivity.patch
+++ b/hex/sd_api_v5/sdk140_connectivity.patch
@@ -63,27 +63,36 @@ index 9eaf33a..7b4fe8e 100644
  
  #ifdef __cplusplus
 diff --git a/components/serialization/common/transport/ser_phy/ser_phy_hci.c b/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-index 516ebf9..861c34d 100644
+index 216ed97..147d7d5 100644
 --- a/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 +++ b/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-@@ -67,6 +67,8 @@ NRF_LOG_MODULE_REGISTER();
+@@ -39,6 +39,8 @@
                                   (SER_HAL_TRANSPORT_MAX_PKT_SIZE + PKT_HDR_SIZE + PKT_CRC_SIZE))
  #define BAUD_TIME_us            (1000000uL / SER_PHY_UART_BAUDRATE_VAL)
- 
+
 +#define PKT_TYPE_RESET 5
 +
  #define TX_EVT_QUEUE_SIZE            16
  #define RX_EVT_QUEUE_SIZE            16
  #define PKT_TYPE_VENDOR_SPECIFIC     14                                                /**< Packet type vendor specific. */
-@@ -794,6 +796,10 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
- 
-         NRF_LOG_DEBUG("EVT_PKT_RECEIVED 0x%X/%u", packet_type,
+@@ -50,7 +52,7 @@
+ #define INITIAL_SEQ_NUMBER           INITIAL_ACK_NUMBER_EXPECTED                       /**< Initial acknowledge number transmitted. */
+ #define INVALID_PKT_TYPE             0xFFFFFFFFu                                       /**< Internal invalid packet type value. */
+ #define MAX_TRANSMISSION_TIME_ms     (MAX_PACKET_SIZE_IN_BITS * BAUD_TIME_us / 1000uL) /**< Max transmission time of a single application packet over UART in units of mseconds. */
+-#define RETRANSMISSION_TIMEOUT_IN_ms (10uL * MAX_TRANSMISSION_TIME_ms)                 /**< Retransmission timeout for application packet in units of mseconds. */
++#define RETRANSMISSION_TIMEOUT_IN_ms (50uL * MAX_TRANSMISSION_TIME_ms)                 /**< Retransmission timeout for application packet in units of mseconds. */
+
+ #ifdef  HCI_LINK_CONTROL
+ #define HCI_PKT_SYNC        0x7E01u                                                    /**< Link Control Packet: type SYNC */
+@@ -770,6 +772,10 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
+
+         NRF_LOG_DEBUG("EVT_PKT_RECEIVED 0x%X/%u\r\n", packet_type,
              p_event->evt_params.received_pkt.num_of_bytes);
 +        if (packet_type == PKT_TYPE_RESET)
 +        {
 +            NVIC_SystemReset();
 +        }
- 
+
          if (packet_type == PKT_TYPE_ACK )
          {
 diff --git a/components/serialization/connectivity/ser_conn_error_handling.c b/components/serialization/connectivity/ser_conn_error_handling.c
@@ -160,7 +169,7 @@ index bcb67e3..516ccd7 100644
 +    .revision_hash      = 0,
 +    .version_major      = 2,
 +    .version_minor      = 0,
-+    .version_patch      = 0,
++    .version_patch      = 1,
 +    .rfu1               = 0xFF,
 +    .sd_ble_api_version = NRF_SD_BLE_API_VERSION,
 +    .transport_type     = 1,

--- a/include/common/internal/transport/h5_transport.h
+++ b/include/common/internal/transport/h5_transport.h
@@ -130,27 +130,21 @@ class InitializedExitCriterias : public ExitCriterias
 public:
     bool syncConfigSent;
     bool syncConfigRspReceived;
-    bool syncConfigReceived;
-    bool syncConfigRspSent;
 
     InitializedExitCriterias()
         : ExitCriterias(),
         syncConfigSent(false),
-        syncConfigRspReceived(false),
-        syncConfigReceived(false),
-        syncConfigRspSent(false) {}
+        syncConfigRspReceived(false) {}
 
     bool isFullfilled() const override
     {
-        return ioResourceError || close || (syncConfigSent && syncConfigRspReceived && syncConfigReceived && syncConfigRspSent);
+        return ioResourceError || close || (syncConfigSent && syncConfigRspReceived);
     }
 
     void reset() override
     {
         ExitCriterias::reset();
         syncConfigSent = false;
-        syncConfigRspSent = false;
-        syncConfigReceived = false;
         syncConfigRspReceived = false;
     };
 


### PR DESCRIPTION
Modified state transition criterias. According to the Bluetooth specfication (V4.2 [Vol 4, Part D], 8.X) it is sufficient to to receive a SYNC_RESPONSE to transition to initialized state, and CONFIG_RESPONSE to transition to active state.

Added mutex unlocks at reception of some control packets when in uninitized state. This makes the state machine more responive, instead of it silently waiting for certain packets without responding to the incoming packets, or retransmitting according to what packet was expected.

Added response to CONFIG packet in active state, as described in specification.

Increased max number of packet retransmissions to make it more robust against potientially slow response from connectivity firmware.