### PR TITLE
Add fix for spurious condition variable wakeup.

### DIFF
--- a/src/common/ble_common.cpp
+++ b/src/common/ble_common.cpp
@@ -60,8 +60,8 @@ uint32_t encode_decode(adapter_t *adapter, encode_function_t encode_function, de
 
     if (_adapter->isInternalError(err_code))
     {
-        error_message << "Not able to decode packet received from target. Code #" << err_code;
-        _adapter->statusHandler(PKT_DECODE_ERROR, error_message.str().c_str());
+        error_message << "Not able to encode packet received from target. Code #" << err_code;
+        _adapter->statusHandler(PKT_ENCODE_ERROR, error_message.str().c_str());
         return NRF_ERROR_INTERNAL;
     }
 

--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -227,9 +227,17 @@ uint32_t H5Transport::send(std::vector<uint8_t> &data)
         logPacket(true, h5EncodedPacket);
         nextTransportLayer->send(lastPacket);
 
+        const uint8_t seqNumBefore = seqNum;
+
         auto status = ackWaitCondition.wait_for(ackGuard, std::chrono::milliseconds(retransmissionInterval));
 
-        if (status == std::cv_status::no_timeout)
+        // Checking for timeout. Also checking against spurios wakeup by making sure the sequence
+        // number has  actually increased. If the sequence number has not increased, we have not
+        // received an ACK packet, and should not exit the loop (unless timeout).
+        // Ref. spurious wakeup: 
+        // http://en.cppreference.com/w/cpp/thread/condition_variable
+        // https://en.wikipedia.org/wiki/Spurious_wakeup
+        if (status == std::cv_status::no_timeout && seqNum != seqNumBefore)
         {
             lastPacket.clear();
             return NRF_SUCCESS;


### PR DESCRIPTION
There is a bug/feature in the thread locks on Windows and Posix that can cause locks to spuriously be waken up. This PR adds a fix for that in H5Transport::send function.