### PR TITLE
Fixed serialization transport to access queue in a safe manner

### DIFF
--- a/src/common/transport/serialization_transport.cpp
+++ b/src/common/transport/serialization_transport.cpp
@@ -160,7 +160,8 @@ uint32_t SerializationTransport::send(uint8_t *cmdBuffer, uint32_t cmdLength, ui
 // Event Thread
 void SerializationTransport::eventHandlingRunner()
 {
-    do {
+    while (runEventThread) {
+
         std::unique_lock<std::mutex> eventLock(eventMutex);
         eventWaitCondition.wait(eventLock);
         while (!eventQueue.empty())
@@ -194,7 +195,7 @@ void SerializationTransport::eventHandlingRunner()
 
             eventLock.lock();
         }
-    } while (runEventThread);
+    }
 }
 
 // Read Thread


### PR DESCRIPTION
Serialization transport event queue was properly locked on push side but not on pop.
All access to queue must be locked to the queue to avoid unexpected behaviour and potential crash.

This is a probable cause and fix for #69 .