### PR TITLE
Add stddef.h as include to heart_rate_monitor example

### DIFF
--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stddef.h>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
Add stddef.h as include to heart_rate_monitor example to make it build on unix.

Macro BLE_EVT_LEN_MAX(ATT_MTU) in ble.h gave an implicit declaration of function 'offsetof'.