### PR TITLE
Fix patch on unix

### DIFF
--- a/hex/bootstrap.sh
+++ b/hex/bootstrap.sh
@@ -110,6 +110,20 @@ function sdk_exists () {
 
 # Patch the downloaded SDK in order to compile the connectivity application
 function sdk_patch () {
+    # Detect which OS is running
+    UNAME="$(uname)"
+    # If OS is Linuix or Darwin
+    # Change the format of line ending to unix
+    if [[ "${UNAME}" == "Linux" ]]; then
+        echo "> Modifying SDK line ending format..."
+        find $DL_LOCATION/$SDK_NAME/ -type f -exec sed -i $'s/\r//' {} \;
+    fi
+    if [[ "${UNAME}" == "Darwin" ]]; then
+        echo "> Modifying SDK line ending format..."
+        LC_CTYPE=C
+        find $DL_LOCATION/$SDK_NAME/ -type f -exec sed -i '' $'s/\r//' {} \;
+    fi
+
     echo "> Applying SDK patch '${PATCH_FILE}'..."
 
     # Apply the patch from the base nRF SDK folder (remove the first portion of the path)

--- a/hex/bootstrap.sh
+++ b/hex/bootstrap.sh
@@ -112,7 +112,7 @@ function sdk_exists () {
 function sdk_patch () {
     # Detect which OS is running
     UNAME="$(uname)"
-    # If OS is Linuix or Darwin
+    # If OS is Linux or Darwin
     # Change the format of line ending to unix
     if [[ "${UNAME}" == "Linux" ]]; then
         echo "> Modifying SDK line ending format..."


### PR DESCRIPTION
This PR is due to fixing fail running patch file on Unix system.
The cause of the problem is different line ending formats on different systems.
Related issue #73 