### PR TITLE
Fix sdk path on mac

### DIFF
--- a/hex/bootstrap.sh
+++ b/hex/bootstrap.sh
@@ -158,8 +158,9 @@ function sdk_download () {
     if [ -d $DL_LOCATION/$SDK_NAME/$SDK_NAME ]; then
         echo "> Moving SDK folder..."
         SDK_NAME_TMP=$SDK_NAME"_tmp"
-        mv -T $DL_LOCATION/$SDK_NAME/$SDK_NAME $DL_LOCATION/$SDK_NAME_TMP
-        mv -T $DL_LOCATION/$SDK_NAME_TMP $DL_LOCATION/$SDK_NAME 
+        mv $DL_LOCATION/$SDK_NAME/$SDK_NAME $DL_LOCATION/$SDK_NAME_TMP
+        mv $DL_LOCATION/$SDK_NAME_TMP/* $DL_LOCATION/$SDK_NAME
+        rm -rf $DL_LOCATION/$SDK_NAME_TMP
     fi
 
     echo "> Clean up. Removing SDK zip file..."


### PR DESCRIPTION
This PR is due to MacOS not supporting `-T` flag in command `mv`.
- [x] Tested on Windows
- [x] Tested on Linux
- [x] Tested on MacOS

> Note: the script would work properly after merging into master
> since the line ending format issue has been fixed in master branch.