### PR TITLE
Update patch for new sdk variant

### DIFF
--- a/hex/sd_api_v3/bootstrap_sd_api_v3_usb.sh
+++ b/hex/sd_api_v3/bootstrap_sd_api_v3_usb.sh
@@ -6,7 +6,7 @@
 ABS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source $ABS_PATH/../bootstrap.sh \
-  -l 'https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.0.0_a53641a.zip' \
+  -l 'http://developer.nordicsemi.com/.pc-tools/sdk/nRF5_SDK_15.0.0_743b4d0.zip' \
   -f 'https://developer.nordicsemi.com/nRF5_SDK/pieces/nRF_DeviceFamilyPack/NordicSemiconductor.nRF_DeviceFamilyPack.8.16.0.pack' \
   -d "../sdk" \
-  -p 'sd_api_v3/sdk150_connectivity_a53641a.patch'
+  -p 'sd_api_v3/sdk150_connectivity_743b4d0.patch'

--- a/hex/sd_api_v3/sdk150_connectivity_743b4d0.patch
+++ b/hex/sd_api_v3/sdk150_connectivity_743b4d0.patch
@@ -1,0 +1,15 @@
+--- "nRF5_SDK_15.0.0_743b4d0/examples/connectivity/ble_connectivity/main.c"	2018-05-15 14:52:34.663130300 +0200
++++ "nRF5_SDK_15.0.0_743b4d0/examples/connectivity/ble_connectivity/main.c"	2018-05-15 14:30:43.871942600 +0200
+@@ -161,9 +161,9 @@
+     .struct_version     = 2,
+     .rfu0               = 0xFFFFFF,
+     .revision_hash      = 0,
+-    .version_major      = 2,
+-    .version_minor      = 0,
+-    .version_patch      = 1,
++    .version_major      = 1,
++    .version_minor      = 2,
++    .version_patch      = 2,
+     .rfu1               = 0xFF,
+     .sd_ble_api_version = NRF_SD_BLE_API_VERSION,
+     .transport_type     = 1,


### PR DESCRIPTION
Adding new patch file for new custom sdk variant.
Removing patch against official sdk release, instead using custom variant download directly.