### PR TITLE
Use correct config_tag when calling adv_start

### DIFF
--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -398,7 +398,7 @@ static uint32_t advertising_start()
 #if NRF_SD_BLE_API <= 3
     error_code = sd_ble_gap_adv_start(m_adapter, &adv_params);
 #else
-    error_code = sd_ble_gap_adv_start(m_adapter, &adv_params, BLE_CONN_CFG_TAG_DEFAULT);
+    error_code = sd_ble_gap_adv_start(m_adapter, &adv_params, m_config_id);
 #endif
 
     if (error_code != NRF_SUCCESS)


### PR DESCRIPTION
The example was using the default cfg_tag when calling adv_start, instead of the cfg_tag that was used together with cfg_set. This made att_mtu_exchange_reply fail since the connection was not configured with sufficiently large att_mtu.

