### PR TITLE
Fix transport cleanup and check if state machine thread exists

### DIFF
--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -652,6 +652,11 @@ void H5Transport::startStateMachine()
     {
         stateMachineThread = new std::thread(std::bind(&H5Transport::stateMachineWorker, this));
     }
+    else
+    {
+        // Terminate if the state machine already exists, this should not happen.
+        std::terminate();
+    }
 }
 
 void H5Transport::stopStateMachine()

--- a/src/common/transport/serialization_transport.cpp
+++ b/src/common/transport/serialization_transport.cpp
@@ -95,10 +95,8 @@ uint32_t SerializationTransport::open(status_cb_t status_callback, evt_cb_t even
 
 uint32_t SerializationTransport::close()
 {
-    eventMutex.lock();
     runEventThread = false;
-    eventWaitCondition.notify_one();
-    eventMutex.unlock();
+    eventWaitCondition.notify_all();
 
     if (eventThread != nullptr)
     {

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -64,10 +64,6 @@ UartBoost::UartBoost(const UartCommunicationParameters &communicationParameters)
 
 UartBoost::~UartBoost()
 {
-    UartBoost::close();
-    workNotifier.~work();
-    ioWorkThread.join();
-    ioService.stop();
 }
 
 uint32_t UartBoost::open(status_cb_t status_callback, data_cb_t data_callback, log_cb_t log_callback)
@@ -174,6 +170,7 @@ uint32_t UartBoost::close()
 {
     try
     {
+        serialPort.cancel();
         serialPort.close();
         ioService.stop();
         ioWorkThread.join();


### PR DESCRIPTION
UartBoost:
closing/thread joining done both in UartBoost::close and destructor, change to be in close
add cancellation of any pending uart operations in UartBoost::close

SerializationTransport:
no need to acquire mutex before notifying other threads about closing of adapter

H5Transport:
terminate if state machine is already present on startup. This is an invalid condition.