### PR TITLE
Support compilation with VS 15 2017

### DIFF
--- a/src/common/platform/win/stdstring.h
+++ b/src/common/platform/win/stdstring.h
@@ -99,7 +99,7 @@
 //			- Jim Cline
 //			- Jeff Kohn
 //			- Todd Heckel
-//			- Ullrich Poll‰hne
+//			- Ullrich Poll√§hne
 //			- Joe Vitaterna
 //			- Joe Woodbury
 //			- Aaron (no last name)
@@ -253,7 +253,7 @@
 //	  2000-APR-17 - Thanks to Joe Vitaterna for pointing out that ReverseFind
 //					is supposed to be a const function.
 //
-//	  2000-MAR-07 - Thanks to Ullrich Poll‰hne for catching a range bug in one
+//	  2000-MAR-07 - Thanks to Ullrich Poll√§hne for catching a range bug in one
 //					of the overloads of assign.
 //
 //    2000-FEB-01 - You can now use CStdString on the Mac with CodeWarrior!
@@ -790,11 +790,13 @@ inline const Type& SSMAX(const Type& arg1, const Type& arg2)
 		#endif
 		#define SS_USE_FACET(loc, fac) std::use_facet<fac >(loc)
 
-	#elif defined(_MSC_VER )
-
-		#define SS_USE_FACET(loc, fac) std::_USE(loc, fac)
-
-	// ...and
+    #elif defined(_MSC_VER )
+        #if (_MSC_VER < 1914)
+            #define SS_USE_FACET(loc, fac) std::_USE(loc, fac)
+        #else
+            #define SS_USE_FACET(loc, fac) std::use_facet<fac >(loc)
+        #endif
+    // ...and
 	#elif defined(_RWSTD_NO_TEMPLATE_ON_RETURN_TYPE)
 
         #define SS_USE_FACET(loc, fac) std::use_facet(loc, (fac*)0)
@@ -2320,7 +2322,7 @@ public:
 			// <nChars> or the NULL terminator, whichever comes first.  Since we
 			// are about to call a less forgiving overload (in which <nChars>
 			// must be a valid length), we must adjust the length here to a safe
-			// value.  Thanks to Ullrich Poll‰hne for catching this bug
+			// value.  Thanks to Ullrich Poll√§hne for catching this bug
 
 			nChars		= SSMIN(nChars, str.length() - nStart);
 			MYTYPE strTemp(str.c_str()+nStart, nChars);
@@ -2341,7 +2343,7 @@ public:
 			// <nChars> or the NULL terminator, whichever comes first.  Since we
 			// are about to call a less forgiving overload (in which <nChars>
 			// must be a valid length), we must adjust the length here to a safe
-			// value. Thanks to Ullrich Poll‰hne for catching this bug
+			// value. Thanks to Ullrich Poll√§hne for catching this bug
 
 			nChars		= SSMIN(nChars, str.length() - nStart);
 


### PR DESCRIPTION
Compiling pc-ble-driver with Visual Studio 15 2017 was not possible:

* The  Microsoft proprietary std::_USE is not defined anymore.
In VS 15 2017 the C++ Standard Libraryi std::use_facet shall be used.

There was UTF-8 encoding problem in stdstring.h comments. This is now fixed.