### PR TITLE
Move reusable test functionality into separate file

### DIFF
--- a/test/test_setup.h
+++ b/test/test_setup.h
@@ -52,6 +52,17 @@
 #include <condition_variable>
 #include <iostream>
 
+#ifdef _WIN32
+#define DEFAULT_BAUD_RATE 1000000 /**< The baud rate to be used for serial communication with nRF5 device. */
+#endif
+#ifdef __APPLE__
+#define DEFAULT_BAUD_RATE 115200 /**< Baud rate 1M is not supported on MacOS. */
+#endif
+#ifdef __linux__
+#define DEFAULT_BAUD_RATE 1000000
+#endif
+
+
 namespace test 
 {
     struct SerialPort
@@ -74,7 +85,7 @@ namespace test
     {
         Environment env;
 
-        auto baudRate = 1000000;
+        auto baudRate = DEFAULT_BAUD_RATE;
         auto envBaudRate = std::getenv("BLE_DRIVER_TEST_BAUD_RATE");
 
         if (envBaudRate != nullptr)

--- a/test/test_util.h
+++ b/test/test_util.h
@@ -3,7 +3,7 @@
 
 namespace testutil
 {
-    std::string convertToString(const std::vector<uint8_t> &data) {
+    static std::string convertToString(const std::vector<uint8_t> &data) {
         std::stringstream ss;
         ss << std::hex << std::setfill('0');
 
@@ -13,6 +13,19 @@ namespace testutil
         }
 
         return ss.str();
+    }
+
+    static std::string ble_address_to_string_convert(ble_gap_addr_t address)
+    {
+        const int address_length = 6;
+        std::stringstream retval;
+
+        for (int i = sizeof(address.addr) - 1; i >= 0; --i)
+        {
+            retval << std::hex << static_cast<unsigned int>(address.addr[i]);
+        }
+        
+        return retval.str();
     }
 }
 


### PR DESCRIPTION
The baud rate and ble_address_to_string_convert is reusable across different tests. Moving functionality to use default platform baudrate and converting BLE address to a header file where it can be reused.
