### PR TITLE
Update build scripts

### DIFF
--- a/hex/build_win.bat
+++ b/hex/build_win.bat
@@ -1,0 +1,20 @@
+@ECHO OFF
+SETLOCAL
+
+@IF EXIST sd_api_v2 CALL :run_build 2
+@IF EXIST sd_api_v3 CALL :run_build 3
+@IF EXIST sd_api_v5 CALL :run_build 5
+@IF EXIST sd_api_v6 CALL :run_build 6
+
+GOTO :EOF
+
+:run_build
+@cd sd_api_v%~1 || GOTO :error
+@build_v%~1_win.bat || GOTO :error
+EXIT /b %errorlevel%
+
+GOTO :EOF
+
+:error
+ECHO Command failed with error code %errorlevel%.
+EXIT /b %errorlevel%

--- a/hex/sd_api_v2/bootstrap_sd_api_v2.sh
+++ b/hex/sd_api_v2/bootstrap_sd_api_v2.sh
@@ -9,4 +9,5 @@ source $ABS_PATH/../bootstrap.sh \
   -l 'https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v11.x.x/nRF5_SDK_11.0.0_89a8197.zip' \
   -f 'https://developer.nordicsemi.com/nRF5_SDK/pieces/nRF_DeviceFamilyPack/NordicSemiconductor.nRF_DeviceFamilyPack.8.5.0.pack' \
   -d "../sdk" \
-  -p 'sd_api_v2/sdk110_connectivity.patch'
+  -p 'sd_api_v2/sdk110_connectivity.patch' \
+  -o

--- a/hex/sd_api_v2/build_v2_win.bat
+++ b/hex/sd_api_v2/build_v2_win.bat
@@ -1,0 +1,55 @@
+@ECHO OFF
+SETLOCAL
+SET startpath=%cd%
+SET scriptpath=%~dp0
+SET rootpath=%scriptpath%..\..
+
+REM Get command line argument
+IF "%1"=="" (SET CONN_VERSION=0.0.0
+) ELSE (SET CONN_VERSION=%1)
+
+ECHO ON
+
+@ECHO Run bootstrap script
+cd %scriptpath% || GOTO :error
+"c:\program files\git\bin\bash.exe" bootstrap_sd_api_v2.sh || GOTO :error
+
+@ECHO Download SDK 12 to get newer softdevice version
+"c:\program files\git\bin\bash.exe" sdk_download.sh || GOTO :error
+
+@ECHO Workaround to reduce path length before build
+cd %rootpath%\sdk || GOTO :error
+rename nRF5_SDK_11.0.0_89a8197 s11 || GOTO :error
+rename nRF5_SDK_12.1.0_0d23e2a s121 || GOTO :error
+
+@ECHO Compile
+cd %rootpath%\sdk\s11\examples\ble_central_and_peripheral\ble_connectivity\pca10028\ser_s130_hci\arm5_no_packs || GOTO :error
+
+\Keil_v5\UV4\UV4.exe -b ble_connectivity_s130_hci_pca10028.uvprojx -j0 -o log_1m.txt
+
+REM Warnings are expected, UV return codes: http://www.keil.com/support/man/docs/uv4/uv4_commandline.htm
+@if %ERRORLEVEL% GTR 1 GOTO :error
+
+@ECHO Merge hex
+"c:\Program Files (x86)\Nordic Semiconductor\nrf5x\bin\mergehex.exe" -m _build\nrf51422_xxac_s130.hex %rootpath%\sdk\s121\components\softdevice\s130\hex\s130_nrf51_2.0.1_softdevice.hex -o %rootpath%\sdk\connectivity_%CONN_VERSION%_1m_with_s130_2.0.1.hex || GOTO :error
+
+@ECHO String replace baudrate
+"c:\program files\git\bin\bash.exe" -c "sed -i -e 's/UART_BAUDRATE_BAUDRATE_Baud1M$/UART_BAUDRATE_BAUDRATE_Baud115200/' ../../../../../../../s11/components/serialization/common/ser_config.h"
+
+@ECHO Compile
+\Keil_v5\UV4\UV4.exe -b ble_connectivity_s130_hci_pca10028.uvprojx -j0 -o log_115k2.txt
+@if %ERRORLEVEL% GTR 1 GOTO :error
+
+@ECHO Merge hex
+"c:\Program Files (x86)\Nordic Semiconductor\nrf5x\bin\mergehex.exe" -m _build\nrf51422_xxac_s130.hex %rootpath%\sdk\s121\components\softdevice\s130\hex\s130_nrf51_2.0.1_softdevice.hex -o %rootpath%\sdk\connectivity_%CONN_VERSION%_115k2_with_s130_2.0.1.hex || GOTO :error
+
+@ECHO Checking that the output files exist
+@IF NOT EXIST %rootpath%\sdk\connectivity_%CONN_VERSION%_1m_with_s130_2.0.1.hex EXIT /b 1
+@IF NOT EXIST %rootpath%\sdk\connectivity_%CONN_VERSION%_115k2_with_s130_2.0.1.hex EXIT /b 1
+@ECHO Success
+
+GOTO :EOF
+
+:error
+ECHO Command failed with error code %errorlevel%.
+EXIT /b %errorlevel%

--- a/hex/sd_api_v2/sdk_download.sh
+++ b/hex/sd_api_v2/sdk_download.sh
@@ -7,4 +7,5 @@ ABS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $ABS_PATH/../bootstrap.sh --source-only
 set_sdk_link 'https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v12.x.x/nRF5_SDK_12.1.0_0d23e2a.zip'
 set_dl_location '../sdk'
+set_legacy_sdk_zipfile_layout
 sdk_download


### PR DESCRIPTION
The build scripts had to be invoked one by one for each version of the connectivity firmware.
This commit adds a batch file that detects SD API version directories in directory hex and starts running build scripts in directories found.

There is a difference in the ZIP file layout between nRF 5 SDK < v14 and >= SDKv14.
Scripts have been adopted to handle both layouts.

The hex/sd_api_v2/build_v2_win.bat file is fetched from branch v2 and tuned.