### PR TITLE
sd_ble_gap_sec_params_reply crash when called from event handler

### DIFF
--- a/src/sd_api_v2/sdk/custom/app_ble_gap_sec_keys.cpp
+++ b/src/sd_api_v2/sdk/custom/app_ble_gap_sec_keys.cpp
@@ -36,16 +36,16 @@
  */
 
 /* Copyright (c) 2014 Nordic Semiconductor. All Rights Reserved.
-*
-* The information contained herein is property of Nordic Semiconductor ASA.
-* Terms and conditions of usage are described in detail in NORDIC
-* SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
-*
-* Licensees are granted free, non-transferable use of the information. NO
-* WARRANTY of ANY KIND is provided. This heading must NOT be removed from
-* the file.
-*
-*/
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
 
 #include "app_ble_gap_sec_keys.h"
 #include "nrf_error.h"
@@ -54,46 +54,52 @@
 #include <map>
 #include <mutex>
 
-typedef std::map<uint16_t, ser_ble_gap_app_keyset_t*> connhandle_keyset_t;
+#include <iostream>
+
+typedef std::map<uint16_t, ser_ble_gap_app_keyset_t *> connhandle_keyset_t;
 
 // Map with context, each with a set of conn_handle and each conn_handle a ser_ble_gap_app_keyset_t*
-std::map<void*, connhandle_keyset_t*> m_app_keys_table;
+std::map<void *, connhandle_keyset_t *> m_app_keys_table;
 void *current_context = nullptr;
-std::mutex current_context_mutex;
 
-void app_ble_gap_sec_context_root_set(void *context)
-{
+/**
+ * \brief Recursive mutex that protects the current key context
+ * The mutex needs to be recursive because it can be locked twice: by the event thread in
+ * SerializationTransport::eventHandlingRunner and by the codec in sd_ble_gap_sec_params_reply
+ */
+std::recursive_mutex current_context_mutex;
+
+void app_ble_gap_sec_context_root_set(void *context) {
     current_context_mutex.lock();
     current_context = context;
 }
 
-void app_ble_gap_sec_context_root_release()
-{
+void app_ble_gap_sec_context_root_release() {
     current_context = nullptr;
     current_context_mutex.unlock();
 }
 
-uint32_t app_ble_gap_sec_context_create(uint16_t conn_handle, ser_ble_gap_app_keyset_t **pp_gap_app_keyset)
-{
-    if (current_context == nullptr) return NRF_ERROR_INVALID_DATA;
+uint32_t app_ble_gap_sec_context_create(uint16_t conn_handle,
+                                        ser_ble_gap_app_keyset_t **pp_gap_app_keyset) {
+    if (current_context == nullptr)
+        return NRF_ERROR_INVALID_DATA;
 
     const auto tempRootContext = m_app_keys_table.find(current_context);
 
     auto keyset = new ser_ble_gap_app_keyset_t();
 
     // If current context is not found we have to add it
-    if (tempRootContext == m_app_keys_table.end()) 
+    if (tempRootContext == m_app_keys_table.end())
     {
-        auto connectionAndKeyset = new std::map<uint16_t, ser_ble_gap_app_keyset_t*>{
-            { conn_handle, keyset }
-        };
+        auto connectionAndKeyset =
+            new std::map<uint16_t, ser_ble_gap_app_keyset_t *>{{conn_handle, keyset}};
 
         m_app_keys_table.insert(std::make_pair(current_context, connectionAndKeyset));
     }
     else
     {
         auto connHandleMap = tempRootContext->second;
-        auto connHandle = connHandleMap->find(conn_handle);
+        auto connHandle    = connHandleMap->find(conn_handle);
 
         // If connection handle does not exist from before
         // we create a new ser_ble_gap_app_keyset_t for the connnection handle
@@ -110,30 +116,33 @@ uint32_t app_ble_gap_sec_context_create(uint16_t conn_handle, ser_ble_gap_app_ke
     return NRF_SUCCESS;
 }
 
-uint32_t app_ble_gap_sec_context_destroy(uint16_t conn_handle)
-{
+uint32_t app_ble_gap_sec_context_destroy(uint16_t conn_handle) {
     const auto tempAdapter = m_app_keys_table.find(current_context);
-    if (tempAdapter == m_app_keys_table.end()) return NRF_ERROR_NOT_FOUND;
+    if (tempAdapter == m_app_keys_table.end())
+        return NRF_ERROR_NOT_FOUND;
 
     auto connHandleMap = tempAdapter->second;
-    auto connHandle = connHandleMap->find(conn_handle);
+    auto connHandle    = connHandleMap->find(conn_handle);
 
-    if (connHandle == connHandleMap->end()) return NRF_ERROR_NOT_FOUND;
-    delete connHandle->second; // Delete the ser_ble_gap_app_keyset_t 
+    if (connHandle == connHandleMap->end())
+        return NRF_ERROR_NOT_FOUND;
+    delete connHandle->second; // Delete the ser_ble_gap_app_keyset_t
     connHandleMap->erase(conn_handle);
 
     return NRF_SUCCESS;
 }
 
-uint32_t app_ble_gap_sec_context_find(uint16_t conn_handle, ser_ble_gap_app_keyset_t **pp_gap_app_keyset)
-{
+uint32_t app_ble_gap_sec_context_find(uint16_t conn_handle,
+                                      ser_ble_gap_app_keyset_t **pp_gap_app_keyset) {
     const auto tempAdapter = m_app_keys_table.find(current_context);
-    if (tempAdapter == m_app_keys_table.end()) return NRF_ERROR_NOT_FOUND;
+    if (tempAdapter == m_app_keys_table.end())
+        return NRF_ERROR_NOT_FOUND;
 
-    auto connHandleMap = tempAdapter->second;
+    auto connHandleMap    = tempAdapter->second;
     const auto connHandle = connHandleMap->find(conn_handle);
 
-    if (connHandle == connHandleMap->end()) return NRF_ERROR_NOT_FOUND;
+    if (connHandle == connHandleMap->end())
+        return NRF_ERROR_NOT_FOUND;
     *pp_gap_app_keyset = connHandle->second;
     return NRF_SUCCESS;
 }


### PR DESCRIPTION
If sd_ble_gap_sec_params_reply is called from an event handler
a mutex in app_ble_gap_sec_keys is attempted locked twice from
the same thread, causing an error.

The commit fixes the issue by using a std::recursive_mutex that
resolves the problem.