### PR TITLE
Add check if adapter is already opened

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ BraceWrapping:
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       false
-  AfterFunction:   false
+  AfterFunction:   true
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     true
@@ -39,7 +39,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true

--- a/include/common/internal/adapter_internal.h
+++ b/include/common/internal/adapter_internal.h
@@ -41,31 +41,36 @@
 #include "sd_rpc_types.h"
 #include "serialization_transport.h"
 
-#include "nrf_error.h"
 #include "ble.h"
+#include "nrf_error.h"
 
 #include <string>
 
-class AdapterInternal {
-    public:
-        explicit AdapterInternal(SerializationTransport *transport);
-        ~AdapterInternal();
-        uint32_t open(const sd_rpc_status_handler_t status_callback, const sd_rpc_evt_handler_t event_callback, const sd_rpc_log_handler_t log_callback);
-        uint32_t close() const;
-        uint32_t logSeverityFilterSet(const sd_rpc_log_severity_t severity_filter);
-        static bool isInternalError(const uint32_t error_code);
+class AdapterInternal
+{
+  public:
+    explicit AdapterInternal(SerializationTransport *transport);
+    ~AdapterInternal();
+    uint32_t open(const sd_rpc_status_handler_t status_callback,
+                  const sd_rpc_evt_handler_t event_callback,
+                  const sd_rpc_log_handler_t log_callback);
+    uint32_t close();
+    uint32_t logSeverityFilterSet(const sd_rpc_log_severity_t severity_filter);
+    static bool isInternalError(const uint32_t error_code);
 
-        void statusHandler(const sd_rpc_app_status_t code, const std::string &error);
-        void eventHandler(ble_evt_t *event);
-        void logHandler(const sd_rpc_log_severity_t severity, const std::string &log_message);
+    void statusHandler(const sd_rpc_app_status_t code, const std::string &error);
+    void eventHandler(ble_evt_t *event);
+    void logHandler(const sd_rpc_log_severity_t severity, const std::string &log_message);
 
-        SerializationTransport *transport;
+    SerializationTransport *transport;
 
-    private:
-        sd_rpc_evt_handler_t eventCallback;
-        sd_rpc_status_handler_t statusCallback;
-        sd_rpc_log_handler_t logCallback;
-        sd_rpc_log_severity_t logSeverityFilter;
+  private:
+    sd_rpc_evt_handler_t eventCallback;
+    sd_rpc_status_handler_t statusCallback;
+    sd_rpc_log_handler_t logCallback;
+    sd_rpc_log_severity_t logSeverityFilter;
+
+    bool isOpen;
 };
 
 #endif // ADAPTER_INTERNAL_H__

--- a/src/common/adapter_internal.cpp
+++ b/src/common/adapter_internal.cpp
@@ -43,58 +43,74 @@
 
 #include <string>
 
-AdapterInternal::AdapterInternal(SerializationTransport *_transport): 
-    eventCallback(nullptr),
-    statusCallback(nullptr),
-    logCallback(nullptr),
-    logSeverityFilter(SD_RPC_LOG_TRACE)
-{
+AdapterInternal::AdapterInternal(SerializationTransport *_transport)
+    : eventCallback(nullptr), statusCallback(nullptr), logCallback(nullptr),
+      logSeverityFilter(SD_RPC_LOG_TRACE), isOpen(false) {
     this->transport = _transport;
 }
-                        
-AdapterInternal::~AdapterInternal()
-{
+
+AdapterInternal::~AdapterInternal() {
     delete transport;
 }
 
-uint32_t AdapterInternal::open(const sd_rpc_status_handler_t status_callback, const sd_rpc_evt_handler_t event_callback, const sd_rpc_log_handler_t log_callback)
-{
-    statusCallback = status_callback;
-    eventCallback = event_callback;
-    logCallback = log_callback;
+uint32_t AdapterInternal::open(const sd_rpc_status_handler_t status_callback,
+                               const sd_rpc_evt_handler_t event_callback,
+                               const sd_rpc_log_handler_t log_callback) {
+    if (isOpen)
+    {
+        return NRF_ERROR_INVALID_STATE;
+    }
 
-    const auto boundStatusHandler = std::bind(&AdapterInternal::statusHandler, this, std::placeholders::_1, std::placeholders::_2);
-    const auto boundEventHandler = std::bind(&AdapterInternal::eventHandler, this, std::placeholders::_1);
-    const auto boundLogHandler = std::bind(&AdapterInternal::logHandler, this, std::placeholders::_1, std::placeholders::_2);
-    return transport->open(boundStatusHandler, boundEventHandler, boundLogHandler);
+    statusCallback = status_callback;
+    eventCallback  = event_callback;
+    logCallback    = log_callback;
+
+    const auto boundStatusHandler = std::bind(&AdapterInternal::statusHandler, this,
+                                              std::placeholders::_1, std::placeholders::_2);
+    const auto boundEventHandler =
+        std::bind(&AdapterInternal::eventHandler, this, std::placeholders::_1);
+    const auto boundLogHandler =
+        std::bind(&AdapterInternal::logHandler, this, std::placeholders::_1, std::placeholders::_2);
+    auto err = transport->open(boundStatusHandler, boundEventHandler, boundLogHandler);
+
+    if (err == NRF_SUCCESS)
+    {
+        isOpen = true;
+    }
+
+    return err;
 }
 
-uint32_t AdapterInternal::close() const
-{
+uint32_t AdapterInternal::close() {
+    if (!isOpen)
+    {
+        return NRF_ERROR_INVALID_STATE;
+    }
+
+    isOpen = false;
+
     return transport->close();
 }
 
-void AdapterInternal::statusHandler(const sd_rpc_app_status_t code, const std::string &message)
-{
+void AdapterInternal::statusHandler(const sd_rpc_app_status_t code, const std::string &message) {
     adapter_t adapter = {};
-    adapter.internal = static_cast<void *>(this);
+    adapter.internal  = static_cast<void *>(this);
     statusCallback(&adapter, code, message.c_str());
 }
 
-void AdapterInternal::eventHandler(ble_evt_t *event)
-{
+void AdapterInternal::eventHandler(ble_evt_t *event) {
     // Event Thread
     adapter_t adapter = {};
-    adapter.internal = static_cast<void *>(this);
+    adapter.internal  = static_cast<void *>(this);
     eventCallback(&adapter, event);
 }
 
-void AdapterInternal::logHandler(const sd_rpc_log_severity_t severity, const std::string &log_message)
-{
+void AdapterInternal::logHandler(const sd_rpc_log_severity_t severity,
+                                 const std::string &log_message) {
     adapter_t adapter = {};
-    adapter.internal = static_cast<void *>(this);
+    adapter.internal  = static_cast<void *>(this);
 
-    if(static_cast<uint32_t>(severity) >= static_cast<uint32_t>(logSeverityFilter))
+    if (static_cast<uint32_t>(severity) >= static_cast<uint32_t>(logSeverityFilter))
     {
         logCallback(&adapter, severity, log_message.c_str());
     }
@@ -104,8 +120,7 @@ bool AdapterInternal::isInternalError(const uint32_t error_code) {
     return error_code != NRF_SUCCESS;
 }
 
-uint32_t AdapterInternal::logSeverityFilterSet(const sd_rpc_log_severity_t severity_filter)
-{
+uint32_t AdapterInternal::logSeverityFilterSet(const sd_rpc_log_severity_t severity_filter) {
     logSeverityFilter = severity_filter;
     return NRF_SUCCESS;
 }

--- a/src/common/adapter_internal.cpp
+++ b/src/common/adapter_internal.cpp
@@ -44,18 +44,23 @@
 #include <string>
 
 AdapterInternal::AdapterInternal(SerializationTransport *_transport)
-    : eventCallback(nullptr), statusCallback(nullptr), logCallback(nullptr),
-      logSeverityFilter(SD_RPC_LOG_TRACE), isOpen(false) {
-    this->transport = _transport;
-}
+    : eventCallback(nullptr)
+    , statusCallback(nullptr)
+    , logCallback(nullptr)
+    , logSeverityFilter(SD_RPC_LOG_TRACE)
+    , isOpen(false)
+    , transport(_transport)
+{}
 
-AdapterInternal::~AdapterInternal() {
+AdapterInternal::~AdapterInternal()
+{
     delete transport;
 }
 
 uint32_t AdapterInternal::open(const sd_rpc_status_handler_t status_callback,
                                const sd_rpc_evt_handler_t event_callback,
-                               const sd_rpc_log_handler_t log_callback) {
+                               const sd_rpc_log_handler_t log_callback)
+{
     if (isOpen)
     {
         return NRF_ERROR_INVALID_STATE;
@@ -81,7 +86,8 @@ uint32_t AdapterInternal::open(const sd_rpc_status_handler_t status_callback,
     return err;
 }
 
-uint32_t AdapterInternal::close() {
+uint32_t AdapterInternal::close()
+{
     if (!isOpen)
     {
         return NRF_ERROR_INVALID_STATE;
@@ -92,13 +98,15 @@ uint32_t AdapterInternal::close() {
     return transport->close();
 }
 
-void AdapterInternal::statusHandler(const sd_rpc_app_status_t code, const std::string &message) {
+void AdapterInternal::statusHandler(const sd_rpc_app_status_t code, const std::string &message)
+{
     adapter_t adapter = {};
     adapter.internal  = static_cast<void *>(this);
     statusCallback(&adapter, code, message.c_str());
 }
 
-void AdapterInternal::eventHandler(ble_evt_t *event) {
+void AdapterInternal::eventHandler(ble_evt_t *event)
+{
     // Event Thread
     adapter_t adapter = {};
     adapter.internal  = static_cast<void *>(this);
@@ -106,7 +114,8 @@ void AdapterInternal::eventHandler(ble_evt_t *event) {
 }
 
 void AdapterInternal::logHandler(const sd_rpc_log_severity_t severity,
-                                 const std::string &log_message) {
+                                 const std::string &log_message)
+{
     adapter_t adapter = {};
     adapter.internal  = static_cast<void *>(this);
 
@@ -116,11 +125,13 @@ void AdapterInternal::logHandler(const sd_rpc_log_severity_t severity,
     }
 }
 
-bool AdapterInternal::isInternalError(const uint32_t error_code) {
+bool AdapterInternal::isInternalError(const uint32_t error_code)
+{
     return error_code != NRF_SUCCESS;
 }
 
-uint32_t AdapterInternal::logSeverityFilterSet(const sd_rpc_log_severity_t severity_filter) {
+uint32_t AdapterInternal::logSeverityFilterSet(const sd_rpc_log_severity_t severity_filter)
+{
     logSeverityFilter = severity_filter;
     return NRF_SUCCESS;
 }

--- a/src/common/sd_rpc_impl.cpp
+++ b/src/common/sd_rpc_impl.cpp
@@ -48,7 +48,8 @@
 
 #include <cstdlib>
 
-uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], uint32_t *size) {
+uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], uint32_t *size)
+{
     if (size == nullptr)
     {
         return NRF_ERROR_NULL;
@@ -81,7 +82,8 @@ uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], 
 
 physical_layer_t *sd_rpc_physical_layer_create_uart(const char *port_name, uint32_t baud_rate,
                                                     sd_rpc_flow_control_t flow_control,
-                                                    sd_rpc_parity_t parity) {
+                                                    sd_rpc_parity_t parity)
+{
     const auto physicalLayer = static_cast<physical_layer_t *>(malloc(sizeof(physical_layer_t)));
 
     UartCommunicationParameters uartSettings = {};
@@ -93,14 +95,18 @@ physical_layer_t *sd_rpc_physical_layer_create_uart(const char *port_name, uint3
         uartSettings.flowControl = UartFlowControlNone;
     }
     else if (flow_control == SD_RPC_FLOW_CONTROL_HARDWARE)
-    { uartSettings.flowControl = UartFlowControlHardware; }
+    {
+        uartSettings.flowControl = UartFlowControlHardware;
+    }
 
     if (parity == SD_RPC_PARITY_NONE)
     {
         uartSettings.parity = UartParityNone;
     }
     else if (parity == SD_RPC_PARITY_EVEN)
-    { uartSettings.parity = UartParityEven; }
+    {
+        uartSettings.parity = UartParityEven;
+    }
 
     uartSettings.stopBits = UartStopBitsOne;
     uartSettings.dataBits = UartDataBitsEight;
@@ -111,7 +117,8 @@ physical_layer_t *sd_rpc_physical_layer_create_uart(const char *port_name, uint3
 }
 
 data_link_layer_t *sd_rpc_data_link_layer_create_bt_three_wire(physical_layer_t *physical_layer,
-                                                               uint32_t retransmission_interval) {
+                                                               uint32_t retransmission_interval)
+{
     const auto dataLinkLayer = static_cast<data_link_layer_t *>(malloc(sizeof(data_link_layer_t)));
     const auto physicalLayer = static_cast<Transport *>(physical_layer->internal);
     const auto h5            = new H5Transport(physicalLayer, retransmission_interval);
@@ -120,7 +127,8 @@ data_link_layer_t *sd_rpc_data_link_layer_create_bt_three_wire(physical_layer_t 
 }
 
 transport_layer_t *sd_rpc_transport_layer_create(data_link_layer_t *data_link_layer,
-                                                 uint32_t response_timeout) {
+                                                 uint32_t response_timeout)
+{
     const auto transportLayer = static_cast<transport_layer_t *>(malloc(sizeof(transport_layer_t)));
     const auto dataLinkLayer  = static_cast<Transport *>(data_link_layer->internal);
     const auto serialization  = new SerializationTransport(dataLinkLayer, response_timeout);
@@ -128,7 +136,8 @@ transport_layer_t *sd_rpc_transport_layer_create(data_link_layer_t *data_link_la
     return transportLayer;
 }
 
-adapter_t *sd_rpc_adapter_create(transport_layer_t *transport_layer) {
+adapter_t *sd_rpc_adapter_create(transport_layer_t *transport_layer)
+{
     const auto adapterLayer   = static_cast<adapter_t *>(malloc(sizeof(adapter_t)));
     const auto transportLayer = static_cast<SerializationTransport *>(transport_layer->internal);
     const auto adapter        = new AdapterInternal(transportLayer);
@@ -136,7 +145,8 @@ adapter_t *sd_rpc_adapter_create(transport_layer_t *transport_layer) {
     return adapterLayer;
 }
 
-void sd_rpc_adapter_delete(adapter_t *adapter) {
+void sd_rpc_adapter_delete(adapter_t *adapter)
+{
     const auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
 
     if (adapterLayer == nullptr)
@@ -149,7 +159,8 @@ void sd_rpc_adapter_delete(adapter_t *adapter) {
 }
 
 uint32_t sd_rpc_open(adapter_t *adapter, sd_rpc_status_handler_t status_handler,
-                     sd_rpc_evt_handler_t event_handler, sd_rpc_log_handler_t log_handler) {
+                     sd_rpc_evt_handler_t event_handler, sd_rpc_log_handler_t log_handler)
+{
     auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
 
     if (adapterLayer == nullptr)
@@ -160,7 +171,8 @@ uint32_t sd_rpc_open(adapter_t *adapter, sd_rpc_status_handler_t status_handler,
     return adapterLayer->open(status_handler, event_handler, log_handler);
 }
 
-uint32_t sd_rpc_close(adapter_t *adapter) {
+uint32_t sd_rpc_close(adapter_t *adapter)
+{
     const auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
 
     if (adapterLayer == nullptr)
@@ -172,7 +184,8 @@ uint32_t sd_rpc_close(adapter_t *adapter) {
 }
 
 uint32_t sd_rpc_log_handler_severity_filter_set(adapter_t *adapter,
-                                                sd_rpc_log_severity_t severity_filter) {
+                                                sd_rpc_log_severity_t severity_filter)
+{
     auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
 
     if (adapterLayer == nullptr)
@@ -183,7 +196,8 @@ uint32_t sd_rpc_log_handler_severity_filter_set(adapter_t *adapter,
     return adapterLayer->logSeverityFilterSet(severity_filter);
 }
 
-uint32_t sd_rpc_conn_reset(adapter_t *adapter, sd_rpc_reset_t reset_mode) {
+uint32_t sd_rpc_conn_reset(adapter_t *adapter, sd_rpc_reset_t reset_mode)
+{
     auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
 
     if (adapterLayer == nullptr)

--- a/src/common/sd_rpc_impl.cpp
+++ b/src/common/sd_rpc_impl.cpp
@@ -38,27 +38,25 @@
 #include "sd_rpc.h"
 
 #include "adapter_internal.h"
-#include "serialization_transport.h"
+#include "ble_common.h"
+#include "conn_systemreset_app.h"
 #include "h5_transport.h"
+#include "serial_port_enum.h"
+#include "serialization_transport.h"
 #include "uart_boost.h"
 #include "uart_settings_boost.h"
-#include "serial_port_enum.h"
-#include "conn_systemreset_app.h"
-#include "ble_common.h"
 
 #include <cstdlib>
 
-
-uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], uint32_t *size)
-{
-    if(size == nullptr)
+uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], uint32_t *size) {
+    if (size == nullptr)
     {
         return NRF_ERROR_NULL;
     }
 
     const std::list<SerialPortDesc> &descs = EnumSerialPorts();
 
-    if(descs.size() > *size)
+    if (descs.size() > *size)
     {
         return NRF_ERROR_DATA_SIZE;
     }
@@ -66,8 +64,8 @@ uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], 
     *size = static_cast<uint32_t>(descs.size());
 
     int i = 0;
-    for(auto &desc : descs)
-        {
+    for (auto &desc : descs)
+    {
         strncpy(serial_port_descs[i].port, desc.comName.c_str(), SD_RPC_MAXPATHLEN);
         strncpy(serial_port_descs[i].manufacturer, desc.manufacturer.c_str(), SD_RPC_MAXPATHLEN);
         strncpy(serial_port_descs[i].serialNumber, desc.serialNumber.c_str(), SD_RPC_MAXPATHLEN);
@@ -81,94 +79,117 @@ uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], 
     return NRF_SUCCESS;
 }
 
-physical_layer_t *sd_rpc_physical_layer_create_uart(const char * port_name, uint32_t baud_rate, sd_rpc_flow_control_t flow_control, sd_rpc_parity_t parity)
-{
+physical_layer_t *sd_rpc_physical_layer_create_uart(const char *port_name, uint32_t baud_rate,
+                                                    sd_rpc_flow_control_t flow_control,
+                                                    sd_rpc_parity_t parity) {
     const auto physicalLayer = static_cast<physical_layer_t *>(malloc(sizeof(physical_layer_t)));
 
     UartCommunicationParameters uartSettings = {};
-    uartSettings.portName = port_name;
-    uartSettings.baudRate = baud_rate;
+    uartSettings.portName                    = port_name;
+    uartSettings.baudRate                    = baud_rate;
 
     if (flow_control == SD_RPC_FLOW_CONTROL_NONE)
     {
         uartSettings.flowControl = UartFlowControlNone;
     }
     else if (flow_control == SD_RPC_FLOW_CONTROL_HARDWARE)
-    {
-        uartSettings.flowControl = UartFlowControlHardware;
-    }
+    { uartSettings.flowControl = UartFlowControlHardware; }
 
     if (parity == SD_RPC_PARITY_NONE)
     {
         uartSettings.parity = UartParityNone;
     }
     else if (parity == SD_RPC_PARITY_EVEN)
-    {
-        uartSettings.parity = UartParityEven;
-    }
+    { uartSettings.parity = UartParityEven; }
 
     uartSettings.stopBits = UartStopBitsOne;
     uartSettings.dataBits = UartDataBitsEight;
 
-    const auto uart = new UartBoost(uartSettings);
+    const auto uart         = new UartBoost(uartSettings);
     physicalLayer->internal = static_cast<void *>(uart);
     return physicalLayer;
 }
 
-data_link_layer_t *sd_rpc_data_link_layer_create_bt_three_wire(physical_layer_t *physical_layer, uint32_t retransmission_interval)
-{
+data_link_layer_t *sd_rpc_data_link_layer_create_bt_three_wire(physical_layer_t *physical_layer,
+                                                               uint32_t retransmission_interval) {
     const auto dataLinkLayer = static_cast<data_link_layer_t *>(malloc(sizeof(data_link_layer_t)));
     const auto physicalLayer = static_cast<Transport *>(physical_layer->internal);
-    const auto h5 = new H5Transport(physicalLayer, retransmission_interval);
-    dataLinkLayer->internal = static_cast<void *>(h5);
+    const auto h5            = new H5Transport(physicalLayer, retransmission_interval);
+    dataLinkLayer->internal  = static_cast<void *>(h5);
     return dataLinkLayer;
 }
 
-transport_layer_t *sd_rpc_transport_layer_create(data_link_layer_t *data_link_layer, uint32_t response_timeout)
-{
+transport_layer_t *sd_rpc_transport_layer_create(data_link_layer_t *data_link_layer,
+                                                 uint32_t response_timeout) {
     const auto transportLayer = static_cast<transport_layer_t *>(malloc(sizeof(transport_layer_t)));
-    const auto dataLinkLayer = static_cast<Transport *>(data_link_layer->internal);
-    const auto serialization = new SerializationTransport(dataLinkLayer, response_timeout);
-    transportLayer->internal = serialization;
+    const auto dataLinkLayer  = static_cast<Transport *>(data_link_layer->internal);
+    const auto serialization  = new SerializationTransport(dataLinkLayer, response_timeout);
+    transportLayer->internal  = serialization;
     return transportLayer;
 }
 
-adapter_t *sd_rpc_adapter_create(transport_layer_t* transport_layer)
-{
-    const auto adapterLayer = static_cast<adapter_t *>(malloc(sizeof(adapter_t)));
+adapter_t *sd_rpc_adapter_create(transport_layer_t *transport_layer) {
+    const auto adapterLayer   = static_cast<adapter_t *>(malloc(sizeof(adapter_t)));
     const auto transportLayer = static_cast<SerializationTransport *>(transport_layer->internal);
-    const auto adapter = new AdapterInternal(transportLayer);
-    adapterLayer->internal = static_cast<void *>(adapter);
+    const auto adapter        = new AdapterInternal(transportLayer);
+    adapterLayer->internal    = static_cast<void *>(adapter);
     return adapterLayer;
 }
 
-void sd_rpc_adapter_delete(adapter_t *adapter)
-{
+void sd_rpc_adapter_delete(adapter_t *adapter) {
     const auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
+
+    if (adapterLayer == nullptr)
+    {
+        return;
+    }
+
     delete adapterLayer;
+    adapter->internal = nullptr;
 }
 
-uint32_t sd_rpc_open(adapter_t *adapter, sd_rpc_status_handler_t status_handler, sd_rpc_evt_handler_t event_handler, sd_rpc_log_handler_t log_handler)
-{
+uint32_t sd_rpc_open(adapter_t *adapter, sd_rpc_status_handler_t status_handler,
+                     sd_rpc_evt_handler_t event_handler, sd_rpc_log_handler_t log_handler) {
     auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
+
+    if (adapterLayer == nullptr)
+    {
+        return NRF_ERROR_INVALID_PARAM;
+    }
+
     return adapterLayer->open(status_handler, event_handler, log_handler);
 }
 
-uint32_t sd_rpc_close(adapter_t *adapter)
-{
-    const auto adapterLayer = static_cast<AdapterInternal*>(adapter->internal);
+uint32_t sd_rpc_close(adapter_t *adapter) {
+    const auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
+
+    if (adapterLayer == nullptr)
+    {
+        return NRF_ERROR_INVALID_PARAM;
+    }
+
     return adapterLayer->close();
 }
 
-uint32_t sd_rpc_log_handler_severity_filter_set(adapter_t *adapter, sd_rpc_log_severity_t severity_filter)
-{
-    auto adapterLayer = static_cast<AdapterInternal*>(adapter->internal);
+uint32_t sd_rpc_log_handler_severity_filter_set(adapter_t *adapter,
+                                                sd_rpc_log_severity_t severity_filter) {
+    auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
+
+    if (adapterLayer == nullptr)
+    {
+        return NRF_ERROR_INVALID_PARAM;
+    }
+
     return adapterLayer->logSeverityFilterSet(severity_filter);
 }
 
-uint32_t sd_rpc_conn_reset(adapter_t *adapter, sd_rpc_reset_t reset_mode)
-{
-    auto adapterLayer = static_cast<AdapterInternal*>(adapter->internal);
+uint32_t sd_rpc_conn_reset(adapter_t *adapter, sd_rpc_reset_t reset_mode) {
+    auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
+
+    if (adapterLayer == nullptr)
+    {
+        return NRF_ERROR_INVALID_PARAM;
+    }
 
     uint32_t tx_buffer_length = 1; // This command has 1 byte payload, hence length 1
     uint32_t rx_buffer_length = 0; // This command does not generate a response, hence length 0
@@ -177,5 +198,5 @@ uint32_t sd_rpc_conn_reset(adapter_t *adapter, sd_rpc_reset_t reset_mode)
     tx_buffer_vector[0] = static_cast<uint8_t>(reset_mode);
 
     return adapterLayer->transport->send(&tx_buffer_vector[0], tx_buffer_length, nullptr,
-        &rx_buffer_length, SERIALIZATION_RESET_CMD);
+                                         &rx_buffer_length, SERIALIZATION_RESET_CMD);
 }

--- a/test/softdevice_api/test_pc_ble_driver_open_close.cpp
+++ b/test/softdevice_api/test_pc_ble_driver_open_close.cpp
@@ -56,13 +56,15 @@
 // occurred in a callback.
 bool error = false;
 
-TEST_CASE("test_pc_ble_driver_open_close") {
+TEST_CASE("test_pc_ble_driver_open_close")
+{
     auto env = ::test::getEnvironment();
     REQUIRE(!env.serialPorts.empty());
     const auto serialPort         = env.serialPorts.at(0);
     const auto numberOfIterations = env.numberOfIterations;
 
-    SECTION("open_already_opened_adapter") {
+    SECTION("open_already_opened_adapter")
+    {
         const auto baudRate = serialPort.baudRate;
 
         INFO("Serial port used: " << serialPort.port);
@@ -80,7 +82,8 @@ TEST_CASE("test_pc_ble_driver_open_close") {
         REQUIRE(sd_rpc_close(c->unwrap()) == NRF_SUCCESS);
     }
 
-    SECTION("close_already_closed_adapter") {
+    SECTION("close_already_closed_adapter")
+    {
         const auto baudRate = serialPort.baudRate;
 
         INFO("Serial port used: " << serialPort.port);
@@ -96,7 +99,8 @@ TEST_CASE("test_pc_ble_driver_open_close") {
         REQUIRE(sd_rpc_close(c->unwrap()) == NRF_ERROR_INVALID_STATE);
     }
 
-    SECTION("open_close_open_iterations") {
+    SECTION("open_close_open_iterations")
+    {
         const auto baudRate = serialPort.baudRate;
 
         INFO("Serial port used: " << serialPort.port);

--- a/test/softdevice_api/test_pc_ble_driver_open_close.cpp
+++ b/test/softdevice_api/test_pc_ble_driver_open_close.cpp
@@ -62,6 +62,40 @@ TEST_CASE("test_pc_ble_driver_open_close") {
     const auto serialPort         = env.serialPorts.at(0);
     const auto numberOfIterations = env.numberOfIterations;
 
+    SECTION("open_already_opened_adapter") {
+        const auto baudRate = serialPort.baudRate;
+
+        INFO("Serial port used: " << serialPort.port);
+        INFO("Baud rate used: " << baudRate);
+
+        auto c = std::unique_ptr<testutil::AdapterWrapper>(
+            new testutil::AdapterWrapper(testutil::Central, serialPort.port, baudRate));
+
+        REQUIRE(sd_rpc_open(c->unwrap(), testutil::statusHandler, testutil::eventHandler,
+                            testutil::logHandler) == NRF_SUCCESS);
+
+        REQUIRE(sd_rpc_open(c->unwrap(), testutil::statusHandler, testutil::eventHandler,
+                            testutil::logHandler) == NRF_ERROR_INVALID_STATE);
+
+        REQUIRE(sd_rpc_close(c->unwrap()) == NRF_SUCCESS);
+    }
+
+    SECTION("close_already_closed_adapter") {
+        const auto baudRate = serialPort.baudRate;
+
+        INFO("Serial port used: " << serialPort.port);
+        INFO("Baud rate used: " << baudRate);
+
+        auto c = std::unique_ptr<testutil::AdapterWrapper>(
+            new testutil::AdapterWrapper(testutil::Central, serialPort.port, baudRate));
+
+        REQUIRE(sd_rpc_close(c->unwrap()) == NRF_ERROR_INVALID_STATE);
+        REQUIRE(sd_rpc_open(c->unwrap(), testutil::statusHandler, testutil::eventHandler,
+                            testutil::logHandler) == NRF_SUCCESS);
+        REQUIRE(sd_rpc_close(c->unwrap()) == NRF_SUCCESS);
+        REQUIRE(sd_rpc_close(c->unwrap()) == NRF_ERROR_INVALID_STATE);
+    }
+
     SECTION("open_close_open_iterations") {
         const auto baudRate = serialPort.baudRate;
 


### PR DESCRIPTION
Previously checks if adapters was already opened or closed was not done. That lead to crashes. This commit adds logic to return status code NRF_ERROR_INVALID_STATE if the state is not valid when calling sd_rpc_open/sd_rpc_close.

Affected files are formatted according to clang-format.