### PR TITLE
Move static class data members to singleton

### DIFF
--- a/include/common/internal/transport/h5_transport.h
+++ b/include/common/internal/transport/h5_transport.h
@@ -40,19 +40,18 @@
 
 #include "transport.h"
 
-#include <mutex>
 #include <condition_variable>
+#include <mutex>
 
 #include <vector>
 
-#include <stdint.h>
-#include <map>
-#include <thread>
 #include "h5.h"
 #include "h5_transport_exit_criterias.h"
+#include <map>
+#include <stdint.h>
+#include <thread>
 
-typedef enum
-{
+typedef enum {
     STATE_START,
     STATE_RESET,
     STATE_UNINITIALIZED,
@@ -64,26 +63,58 @@ typedef enum
     STATE_UNKNOWN
 } h5_state_t;
 
-constexpr uint8_t SyncFirstByte = 0x01;
-constexpr uint8_t SyncSecondByte = 0x7E;
-constexpr uint8_t SyncRspFirstByte = 0x02;
-constexpr uint8_t SyncRspSecondByte = 0x7D;
-constexpr uint8_t SyncConfigFirstByte = 0x03;
-constexpr uint8_t SyncConfigSecondByte = 0xFC;
-constexpr uint8_t SyncConfigRspFirstByte = 0x04;
+constexpr uint8_t SyncFirstByte           = 0x01;
+constexpr uint8_t SyncSecondByte          = 0x7E;
+constexpr uint8_t SyncRspFirstByte        = 0x02;
+constexpr uint8_t SyncRspSecondByte       = 0x7D;
+constexpr uint8_t SyncConfigFirstByte     = 0x03;
+constexpr uint8_t SyncConfigSecondByte    = 0xFC;
+constexpr uint8_t SyncConfigRspFirstByte  = 0x04;
 constexpr uint8_t SyncConfigRspSecondByte = 0x7B;
-constexpr uint8_t SyncConfigField = 0x11;
+constexpr uint8_t SyncConfigField         = 0x11;
 
 using state_action_t = std::function<h5_state_t()>;
-using payload_t = std::vector<uint8_t>;
+using payload_t      = std::vector<uint8_t>;
 
-class H5Transport : public Transport {
-public:
+/**
+ * \brief Singleton that contains data used in a multithreaded context from H5Transport
+ *
+ * Multi-threaded access to "global" data members requires that threads constructin a synchronized manner.
+ *
+ * This class uses the magic statics approach that is supported in C++11.
+ *
+ * For a good explanation about the approach you can read this article:
+ * http://blog.mbedded.ninja/programming/languages/c-plus-plus/magic-statics
+ */
+class H5TransportSingleton final
+{
+  public:
+    static H5TransportSingleton &get();
+
+    std::map<const control_pkt_type, const payload_t> pkt_pattern;
+    std::map<const h5_state_t, const std::string> stateString;
+    std::map<const h5_pkt_type_t, const std::string> pktTypeString;
+
+  private:
+    H5TransportSingleton();
+    ~H5TransportSingleton() = default;
+
+    // Delete the copy and move constructors
+    H5TransportSingleton(const H5TransportSingleton &) = delete;
+    H5TransportSingleton &operator=(const H5TransportSingleton &) = delete;
+    H5TransportSingleton(H5TransportSingleton &&)                 = delete;
+    H5TransportSingleton &operator=(H5TransportSingleton &&) = delete;
+};
+
+class H5Transport : public Transport
+{
+  public:
     H5Transport() = delete;
     H5Transport(Transport *nextTransportLayer, const uint32_t retransmission_interval);
     ~H5Transport();
-    
-    uint32_t open(status_cb_t status_callback, data_cb_t data_callback, log_cb_t log_callback) override;
+
+    uint32_t open(status_cb_t status_callback, data_cb_t data_callback,
+                  log_cb_t log_callback) override;
     uint32_t close() override;
     uint32_t send(const std::vector<uint8_t> &data) override;
 
@@ -94,11 +125,12 @@ public:
     static bool isSyncConfigPacket(const payload_t &packet, const uint8_t offset = 0);
     static bool isSyncConfigResponsePacket(const payload_t &packet, const uint8_t offset = 0);
     static bool isResetPacket(const payload_t &packet, const uint8_t offset = 0);
-    static bool checkPattern(const payload_t  &packet, const uint8_t offset, const payload_t &pattern);
+    static bool checkPattern(const payload_t &packet, const uint8_t offset,
+                             const payload_t &pattern);
 
-private:
+  private:
     void dataHandler(uint8_t *data, size_t length);
-    void statusHandler(sd_rpc_app_status_t code, const char * error);
+    void statusHandler(sd_rpc_app_status_t code, const char *error);
     void processPacket(const payload_t &packet);
 
     void sendControlPacket(control_pkt_type type);
@@ -122,7 +154,8 @@ private:
     std::vector<uint8_t> unprocessedData;
 
     std::mutex stateMachineMutex; // Mutex controlling access to state machine variables
-    std::condition_variable stateMachineChange; // Condition variable to communicate changes to state machine
+    std::condition_variable
+        stateMachineChange; // Condition variable to communicate changes to state machine
 
     // Variables used in state ACTIVE
     std::chrono::milliseconds retransmissionInterval;
@@ -140,8 +173,8 @@ private:
     void logStateTransition(const h5_state_t from, const h5_state_t to) const;
     static std::string stateToString(const h5_state_t state);
     static std::string asHex(const payload_t &packet);
-    static std::string hciPacketLinkControlToString(const payload_t  &payload);
-    std::string h5PktToString(const bool out, const payload_t  &h5Packet) const;
+    static std::string hciPacketLinkControlToString(const payload_t &payload);
+    std::string h5PktToString(const bool out, const payload_t &h5Packet) const;
     static std::string pktTypeToString(const h5_pkt_type_t pktType);
 
     // State machine related
@@ -159,13 +192,10 @@ private:
 
     void stateMachineWorker();
 
-    std::mutex stateMutex; // Mutex that allows threads to wait for a given state in the state machine
+    std::mutex
+        stateMutex; // Mutex that allows threads to wait for a given state in the state machine
     bool waitForState(h5_state_t state, std::chrono::milliseconds timeout);
     std::condition_variable stateWaitCondition;
-
-    static const std::map<const control_pkt_type, const payload_t> pkt_pattern;
-    static const std::map<const h5_state_t, const std::string> stateString;
-    static const std::map<const h5_pkt_type_t, const std::string> pktTypeString;
 };
 
-#endif //H5_TRANSPORT_H
+#endif // H5_TRANSPORT_H

--- a/include/common/internal/transport/h5_transport.h
+++ b/include/common/internal/transport/h5_transport.h
@@ -79,7 +79,7 @@ using payload_t      = std::vector<uint8_t>;
 /**
  * \brief Singleton that contains data used in a multithreaded context from H5Transport
  *
- * Multi-threaded access to "global" data members requires that threads constructin a synchronized manner.
+ * Multi-threaded access to "global" data members requires that threads construct in a synchronized manner.
  *
  * This class uses the magic statics approach that is supported in C++11.
  *


### PR DESCRIPTION
The static std::map data members in H5Transport is not constructed in a thread safe manner.

By using the magic statics approach in C++11 the construction
is thread safe.

Files affected are formatted using current clang-format rules.