### PR TITLE
Handle packets states without exit criteria

### DIFF
--- a/include/common/internal/transport/h5_transport.h
+++ b/include/common/internal/transport/h5_transport.h
@@ -79,7 +79,8 @@ using payload_t      = std::vector<uint8_t>;
 /**
  * \brief Singleton that contains data used in a multithreaded context from H5Transport
  *
- * Multi-threaded access to "global" data members requires that threads construct in a synchronized manner.
+ * Multi-threaded access to "global" data members requires that threads construct in a synchronized
+ * manner.
  *
  * This class uses the magic statics approach that is supported in C++11.
  *
@@ -113,8 +114,8 @@ class H5Transport : public Transport
     H5Transport(Transport *nextTransportLayer, const uint32_t retransmission_interval);
     ~H5Transport();
 
-    uint32_t open(status_cb_t status_callback, data_cb_t data_callback,
-                  log_cb_t log_callback) override;
+    uint32_t open(const status_cb_t &status_callback, const data_cb_t &data_callback,
+                  const log_cb_t &log_callback) override;
     uint32_t close() override;
     uint32_t send(const std::vector<uint8_t> &data) override;
 
@@ -129,8 +130,8 @@ class H5Transport : public Transport
                              const payload_t &pattern);
 
   private:
-    void dataHandler(uint8_t *data, size_t length);
-    void statusHandler(sd_rpc_app_status_t code, const char *error);
+    void dataHandler(const uint8_t *data, const size_t length);
+    void statusHandler(const sd_rpc_app_status_t code, const char *error);
     void processPacket(const payload_t &packet);
 
     void sendControlPacket(control_pkt_type type);
@@ -168,8 +169,7 @@ class H5Transport : public Transport
     uint32_t errorPacketCount;
 
     void logPacket(const bool outgoing, const payload_t &packet);
-    void log(std::string &logLine) const;
-    void log(char const *logLine) const;
+    void log(const sd_rpc_log_severity_t &level, const std::string &logLine) const;
     void logStateTransition(const h5_state_t from, const h5_state_t to) const;
     static std::string stateToString(const h5_state_t state);
     static std::string asHex(const payload_t &packet);
@@ -188,7 +188,7 @@ class H5Transport : public Transport
     void startStateMachine();
     void stopStateMachine();
 
-    std::map<h5_state_t, std::unique_ptr<ExitCriterias>> exitCriterias;
+    std::map<h5_state_t, std::shared_ptr<ExitCriterias>> exitCriterias;
 
     void stateMachineWorker();
 

--- a/include/common/internal/transport/serialization_transport.h
+++ b/include/common/internal/transport/serialization_transport.h
@@ -42,15 +42,15 @@
 
 #include "ble.h"
 
-#include <thread>
-#include <mutex>
 #include <condition_variable>
+#include <mutex>
+#include <thread>
 
-#include <queue>
 #include <cstdint>
+#include <queue>
 
-typedef uint32_t(*transport_rsp_handler_t)(const uint8_t *p_buffer, uint16_t length);
-typedef std::function<void(ble_evt_t * p_ble_evt)> evt_cb_t;
+typedef uint32_t (*transport_rsp_handler_t)(const uint8_t *p_buffer, uint16_t length);
+typedef std::function<void(ble_evt_t *p_ble_evt)> evt_cb_t;
 
 struct eventData_t
 {
@@ -58,39 +58,40 @@ struct eventData_t
     uint32_t dataLength;
 };
 
-typedef enum
-{
-    SERIALIZATION_COMMAND = 0,
-    SERIALIZATION_RESPONSE = 1,
-    SERIALIZATION_EVENT = 2,
-    SERIALIZATION_DTM_CMD = 3,      // Direct test mode command
-    SERIALIZATION_DTM_RESP = 4,     // Direct test mode response
+typedef enum {
+    SERIALIZATION_COMMAND   = 0,
+    SERIALIZATION_RESPONSE  = 1,
+    SERIALIZATION_EVENT     = 2,
+    SERIALIZATION_DTM_CMD   = 3, // Direct test mode command
+    SERIALIZATION_DTM_RESP  = 4, // Direct test mode response
     SERIALIZATION_RESET_CMD = 5
 } serialization_pkt_type_t;
 
-class SerializationTransport {
-public:
+class SerializationTransport
+{
+  public:
     SerializationTransport(const SerializationTransport &) = delete;
-    SerializationTransport& operator=(const SerializationTransport &) = delete;
-    SerializationTransport(SerializationTransport &&) = delete;
-    SerializationTransport& operator=(SerializationTransport &&) = delete;
+    SerializationTransport &operator=(const SerializationTransport &) = delete;
+    SerializationTransport(SerializationTransport &&)                 = delete;
+    SerializationTransport &operator=(SerializationTransport &&) = delete;
 
     SerializationTransport(Transport *dataLinkLayer, uint32_t response_timeout);
     ~SerializationTransport() = default;
-    
-    uint32_t open(const status_cb_t &status_callback, const evt_cb_t &event_callback, const log_cb_t &log_callback);
+
+    uint32_t open(const status_cb_t &status_callback, const evt_cb_t &event_callback,
+                  const log_cb_t &log_callback);
     uint32_t close();
     uint32_t send(uint8_t *cmdBuffer, uint32_t cmdLength, uint8_t *rspBuffer, uint32_t *rspLength,
-        serialization_pkt_type_t pktType = SERIALIZATION_COMMAND);
+                  serialization_pkt_type_t pktType = SERIALIZATION_COMMAND);
 
-private:
-    void readHandler(uint8_t *data, size_t length);
+  private:
+    void readHandler(const uint8_t *data, const size_t length);
     void eventHandlingRunner();
 
     status_cb_t statusCallback;
     evt_cb_t eventCallback;
     log_cb_t logCallback;
-    
+
     data_cb_t dataCallback;
 
     std::shared_ptr<Transport> nextTransportLayer;
@@ -105,11 +106,12 @@ private:
     std::mutex responseMutex;
     std::condition_variable responseWaitCondition;
 
-    bool runEventThread; // Variable to control if thread shall run, used in thread to exit/keep running inthread
+    bool runEventThread; // Variable to control if thread shall run, used in thread to exit/keep
+                         // running inthread
     std::mutex eventMutex;
     std::condition_variable eventWaitCondition;
     std::thread eventThread;
     std::queue<eventData_t> eventQueue;
 };
 
-#endif //SERIALIZATION_TRANSPORT_H
+#endif // SERIALIZATION_TRANSPORT_H

--- a/include/common/internal/transport/transport.h
+++ b/include/common/internal/transport/transport.h
@@ -46,14 +46,14 @@
 
 #include <stdint.h>
 
-typedef std::function<void(sd_rpc_app_status_t code, const char *message)> status_cb_t;
-typedef std::function<void(uint8_t *data, size_t length)> data_cb_t;
-typedef std::function<void(sd_rpc_log_severity_t severity, std::string message)> log_cb_t;
+typedef std::function<void(const sd_rpc_app_status_t code, const char *message)> status_cb_t;
+typedef std::function<void(const uint8_t *data, const size_t length)> data_cb_t;
+typedef std::function<void(const sd_rpc_log_severity_t severity, const std::string &message)> log_cb_t;
 
 class Transport {
 public:
     virtual ~Transport();
-    virtual uint32_t open(status_cb_t status_callback, data_cb_t data_callback, log_cb_t log_callback);
+    virtual uint32_t open(const status_cb_t &status_callback, const data_cb_t &data_callback, const log_cb_t &log_callback);
     virtual uint32_t close();
     virtual uint32_t send(const std::vector<uint8_t> &data) = 0;
 

--- a/include/common/internal/transport/uart_boost.h
+++ b/include/common/internal/transport/uart_boost.h
@@ -39,8 +39,8 @@
 #define UART_BOOST_H
 
 #include "transport.h"
-#include "uart_settings_boost.h"
 #include "uart_defines.h"
+#include "uart_settings_boost.h"
 
 #include <asio.hpp>
 
@@ -56,45 +56,54 @@
  */
 class UartBoost : public Transport
 {
-public:
-
-    /**@brief Is called by app_uart_init() stores function pointers and sets up necessary boost variables.
+  public:
+    /**
+     *@brief Is called by app_uart_init() stores function pointers and sets up necessary boost
+     * variables.
      */
     UartBoost(const UartCommunicationParameters &communicationParameters);
 
     ~UartBoost();
 
-    /**@brief Setup of serial port service with parameter data.
+    /**
+     *@brief Setup of serial port service with parameter data.
      */
-    uint32_t open(status_cb_t status_callback, data_cb_t data_callback, log_cb_t log_callback);
+    uint32_t open(const status_cb_t &status_callback, const data_cb_t &data_callback,
+                  const log_cb_t &log_callback) override;
 
-    /**@brief Closes the serial port service.
+    /**
+     *@brief Closes the serial port service.
      */
-    uint32_t close();
+    uint32_t close() override;
 
-    /**@brief sends data to serial port to write.
+    /**
+     *@brief sends data to serial port to write.
      */
-    uint32_t send(const std::vector<uint8_t> &data);
+    uint32_t send(const std::vector<uint8_t> &data) override;
 
-private:
-
-    /**@brief Called when background thread receives bytes from uart.
+  private:
+    /**
+     *@brief Called when background thread receives bytes from uart.
      */
     void readHandler(const asio::error_code &errorCode, const size_t bytesTransferred);
 
-    /**@brief Called when write is finished doing asynchronous write.
+    /**
+     *@brief Called when write is finished doing asynchronous write.
      */
     void writeHandler(const asio::error_code &errorCode, const size_t);
 
-    /**@brief Starts asynchronous read on a background thread.
+    /**
+     *@brief Starts asynchronous read on a background thread.
      */
     void startRead();
 
-    /**@brief Starts an asynchronous read.
+    /**
+     *@brief Starts an asynchronous read.
      */
     void asyncRead();
 
-    /**@brief Starts an asynchronous write.
+    /**
+     *@brief Starts an asynchronous write.
      */
     void asyncWrite();
 
@@ -110,10 +119,10 @@ private:
     bool asyncWriteInProgress;
     std::thread *ioServiceThread;
 
-    asio::io_service* ioService;
-    asio::serial_port* serialPort;
+    asio::io_service *ioService;
+    asio::serial_port *serialPort;
 
-    asio::io_service::work* workNotifier;
+    asio::io_service::work *workNotifier;
 };
 
-#endif //UART_BOOST_H
+#endif // UART_BOOST_H

--- a/src/common/adapter_internal.cpp
+++ b/src/common/adapter_internal.cpp
@@ -44,12 +44,12 @@
 #include <string>
 
 AdapterInternal::AdapterInternal(SerializationTransport *_transport)
-    : eventCallback(nullptr)
+    : transport(_transport)
+    , eventCallback(nullptr)
     , statusCallback(nullptr)
     , logCallback(nullptr)
     , logSeverityFilter(SD_RPC_LOG_TRACE)
     , isOpen(false)
-    , transport(_transport)
 {}
 
 AdapterInternal::~AdapterInternal()

--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -451,7 +451,8 @@ void H5Transport::processPacket(const payload_t &packet)
             try
             {
                 const auto currentExitCriteria = exitCriterias.at(currentState);
-                dynamic_cast<ActiveExitCriterias *>(currentExitCriteria.get())->irrecoverableSyncError = true;
+                dynamic_cast<ActiveExitCriterias *>(currentExitCriteria.get())
+                    ->irrecoverableSyncError = true;
             }
             catch (std::out_of_range &)
             {
@@ -475,7 +476,7 @@ void H5Transport::statusHandler(sd_rpc_app_status_t code, const char *error)
         {
             std::unique_lock<std::mutex> stateMachineLock(stateMachineMutex);
             const auto currentExitCriteria = exitCriterias.at(currentState);
-            const auto exitCriteria = currentExitCriteria.get();
+            const auto exitCriteria        = currentExitCriteria.get();
 
             if (exitCriteria != nullptr)
             {

--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -175,18 +175,18 @@ uint32_t H5Transport::open(const status_cb_t &status_callback, const data_cb_t &
 
     try
     {
-        const auto ec            = exitCriterias.at(currentState);
-        const auto _exitCriteria = dynamic_cast<StartExitCriterias *>(ec.get());
-
         std::unique_lock<std::mutex> stateMachineLock(stateMachineMutex);
+
+        const auto currentExitCriteria = exitCriterias.at(currentState);
+        const auto exitCriteria = dynamic_cast<StartExitCriterias *>(currentExitCriteria.get());
 
         if (errorCode != NRF_SUCCESS)
         {
-            _exitCriteria->ioResourceError = true;
+            exitCriteria->ioResourceError = true;
         }
         else
         {
-            _exitCriteria->isOpened = true;
+            exitCriteria->isOpened = true;
         }
         stateMachineLock.unlock();
         stateMachineChange.notify_all();
@@ -236,8 +236,8 @@ uint32_t H5Transport::close()
     try
     {
         std::unique_lock<std::mutex> stateMachineLock(stateMachineMutex);
-        const auto ec           = exitCriterias.at(currentState);
-        const auto exitCriteria = ec.get();
+        const auto currentExitCriteria = exitCriterias.at(currentState);
+        const auto exitCriteria        = currentExitCriteria.get();
 
         if (exitCriteria != nullptr)
         {
@@ -450,8 +450,8 @@ void H5Transport::processPacket(const payload_t &packet)
         {
             try
             {
-                const auto ec = exitCriterias.at(currentState);
-                dynamic_cast<ActiveExitCriterias *>(ec.get())->irrecoverableSyncError = true;
+                const auto currentExitCriteria = exitCriterias.at(currentState);
+                dynamic_cast<ActiveExitCriterias *>(currentExitCriteria.get())->irrecoverableSyncError = true;
             }
             catch (std::out_of_range &)
             {
@@ -474,8 +474,8 @@ void H5Transport::statusHandler(sd_rpc_app_status_t code, const char *error)
         try
         {
             std::unique_lock<std::mutex> stateMachineLock(stateMachineMutex);
-            const auto ec = exitCriterias.at(currentState);
-            const auto exitCriteria = ec.get();
+            const auto currentExitCriteria = exitCriterias.at(currentState);
+            const auto exitCriteria = currentExitCriteria.get();
 
             if (exitCriteria != nullptr)
             {

--- a/src/common/transport/transport.cpp
+++ b/src/common/transport/transport.cpp
@@ -53,9 +53,9 @@ Transport::~Transport()
     /* Intentional empty */
 }
 
-uint32_t Transport::open(status_cb_t status_callback, data_cb_t data_callback, log_cb_t log_callback)
+uint32_t Transport::open(const status_cb_t &status_callback, const data_cb_t &data_callback, const log_cb_t &log_callback)
 {
-    if (status_callback == nullptr || data_callback == nullptr || log_callback == nullptr)
+    if (!status_callback || !data_callback || !log_callback)
     {
         return NRF_ERROR_INTERNAL;
     }

--- a/test/transport/test_h5_transport.cpp
+++ b/test/transport/test_h5_transport.cpp
@@ -76,7 +76,7 @@ public:
         NRF_LOG("[" << name << "][status] code: " << code << " message: " << message);
     }
 
-    void dataCallback(uint8_t *data, size_t length)
+    void dataCallback(const uint8_t *data, const size_t length)
     {
         incoming.assign(data, data + length);
         NRF_LOG("[" << name << "][data]<- " << testutil::asHex(incoming) << " length: " << length);

--- a/test/transport/test_uart_boost.cpp
+++ b/test/transport/test_uart_boost.cpp
@@ -177,7 +177,7 @@ TEST_CASE("open_close")
 
     b->open(
         status_callback,
-        [&receivedOnB, &portBStats](uint8_t *data, size_t length) -> void
+        [&receivedOnB, &portBStats](const uint8_t *data, const size_t length) -> void
         {
             receivedOnB.insert(receivedOnB.end(), data, data + length);
 
@@ -198,7 +198,7 @@ TEST_CASE("open_close")
 
     a->open(
         status_callback,
-        [&receivedOnA, &portAStats](uint8_t *data, size_t length) -> void
+        [&receivedOnA, &portAStats](const uint8_t *data, const size_t length) -> void
         {
             receivedOnA.insert(receivedOnA.end(), data, data + length);
 

--- a/test/transport/test_virtual_uart.cpp
+++ b/test/transport/test_virtual_uart.cpp
@@ -36,7 +36,7 @@ TEST_CASE("virtual_uart")
 
         const auto dataCallback = [](const std::string name, payload_t &payloadReceived)
         {
-            return [name, &payloadReceived](uint8_t *data, size_t length) -> void
+            return [name, &payloadReceived](const uint8_t *data, const size_t length) -> void
             {
                 payloadReceived.assign(data, data + length);
                 NRF_LOG("[" << name << "][data]<- " << testutil::asHex(payloadReceived) << " length: " << length);
@@ -46,12 +46,12 @@ TEST_CASE("virtual_uart")
         const std::string uartAName = "uartA";
 
         uartA->open(
-            [&uartAName](sd_rpc_app_status_t code, const char *message) -> void
+            [&uartAName](const sd_rpc_app_status_t code, const char *message) -> void
             {
                 NRF_LOG("[" << uartAName << "][status] code: " << code << " message: " << message);
             },
             dataCallback(uartAName, payloadFromB),
-            [&uartAName](sd_rpc_log_severity_t severity, std::string message) -> void
+            [&uartAName](const sd_rpc_log_severity_t severity, const std::string &message) -> void
             {
                 NRF_LOG("[" << uartAName << "][log] severity: " << severity << " message: " << message);
             }

--- a/test/virtual_uart.h
+++ b/test/virtual_uart.h
@@ -43,7 +43,7 @@ public:
         stopAtPktType = stopAtPktType_;
     }
 
-    uint32_t open(status_cb_t status_callback, data_cb_t data_callback, log_cb_t log_callback) override
+    uint32_t open(const status_cb_t &status_callback, const data_cb_t &data_callback, const log_cb_t &log_callback) override
     {
         Transport::open(status_callback, data_callback, log_callback);
 


### PR DESCRIPTION
Packets received in H5Transport states without exit criteria made the library crash with a segfault.

constness has been added to callbacks and arguments in callbacks.
clang-format rules are applied to files affected.