### PR TITLE
Extended advertising tests

### DIFF
--- a/src/common/transport/serialization_transport.cpp
+++ b/src/common/transport/serialization_transport.cpp
@@ -219,7 +219,8 @@ void SerializationTransport::eventHandlingRunner()
                 std::stringstream logMessage;
                 logMessage << "Failed to decode event, error code is " << errCode << "."
                            << std::endl;
-                logCallback(SD_RPC_LOG_ERROR, logMessage.str().c_str());
+                logCallback(SD_RPC_LOG_ERROR, logMessage.str());
+                statusCallback(PKT_DECODE_ERROR, logMessage.str());
             }
 
             eventLock.lock();

--- a/test/include/test_util.h
+++ b/test/include/test_util.h
@@ -137,6 +137,25 @@ static void appendRandomData(std::vector<uint8_t> &data, const size_t size)
     data.resize(size);
     std::generate(data.begin(), data.end(), std::rand);
 }
+
+/*
+ * @brief Function that fills a std::vector<uint8_t> with random ASCII values
+ *
+ * @param[in,out] data vector to populate with random ASCII values
+ * @param[in] size number of random values to fill the vector with
+ */
+
+static void appendRandomAlphaNumeric(std::vector<uint8_t> &data, const size_t size)
+{
+    data.resize(size);
+    std::generate(data.begin(), data.end(), [] {
+        uint8_t c;
+        while (!std::isalnum(c = static_cast<uint8_t>(std::rand())))
+            ;
+        return c;
+    });
+}
+
 } // namespace testutil
 
 #endif // TEST_UTIL_H__

--- a/test/include/test_util.h
+++ b/test/include/test_util.h
@@ -126,6 +126,35 @@ static void appendAdvertisingName(std::vector<uint8_t> &advertisingData, const s
     std::copy(name.begin(), name.end(), std::back_inserter(advertisingData));
 }
 
+/**
+ * @brief Function that append flags to advertisement type
+ *
+ * @param[in,out] advertisingData std::vector to append advertisement flags to
+ * @param[in] flags Flags to append to advertisingData
+ */
+static void appendAdvertisementFlags(std::vector<uint8_t> &advertisingData, const uint8_t flags)
+{
+    advertisingData.push_back(2); // Flags field size + flags data size
+    advertisingData.push_back(BLE_GAP_AD_TYPE_FLAGS);
+    advertisingData.push_back(flags);
+}
+
+/**
+ * @brief Function that append manufacturer specifid data to advertisement
+ *
+ * @param[in,out] advertisingData std::vector to append manufacturer specific data to
+ * @param[in] manufacturerSpecificData Manufacturer specific data to append to advertisingData
+ */
+static void appendManufacturerSpecificData(std::vector<uint8_t> &advertisingData,
+                                           const std::vector<uint8_t> manufacturerSpecificData)
+{
+    advertisingData.push_back(1 +
+                              manufacturerSpecificData.size()); // data_size + AD_TYPE_FIELD_SIZE
+    advertisingData.push_back(BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA);
+    std::copy(manufacturerSpecificData.begin(), manufacturerSpecificData.end(),
+              std::back_inserter(advertisingData));
+}
+
 /*
  * @brief Function that fills a std::vector<uint8_t> with random values
  *

--- a/test/include/test_util_adapter_wrapper.h
+++ b/test/include/test_util_adapter_wrapper.h
@@ -289,40 +289,6 @@ class AdapterWrapper
         scratchpad.adv_params.secondary_phy         = secondary_phy;
         scratchpad.adv_params.max_adv_evts          = max_adv_events;
 
-#if 0
-        // From nRF5_SDK_15.2.0_9412b96\components\ble\ble_advertising\ble_advertising.c:
-        //
-        // 'Configure a initial advertising configuration. The advertising data and and advertising
-        // parameters will be changed later when we call @ref ble_advertising_start, but must be set
-        // to legal values here to define an advertising handle.'
-        //
-        // TODO: clarify if they are illegal when setting up extended advertising...
-        ble_gap_adv_params_t initialAdvertisementParams {};
-        initialAdvertisementParams.primary_phy = BLE_GAP_PHY_1MBPS;
-
-        // From nRF5_SDK_15.2.0_9412b96\examples\ble_peripheral\ble_app_rscs\main.c:
-        // APP_ADV_DURATION  18000
-        initialAdvertisementParams.duration = 18000;
-        initialAdvertisementParams.properties.type =
-            BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED;
-        initialAdvertisementParams.p_peer_addr   = nullptr;
-        initialAdvertisementParams.filter_policy = BLE_GAP_ADV_FP_ANY;
-
-        // From nRF5_SDK_15.2.0_9412b96\examples\ble_peripheral\ble_app_rscs\main.c:
-        // APP_ADV_INTERVAL  40
-        initialAdvertisementParams.interval = 40;
-        uint8_t initialAdvertisementHandle  = BLE_GAP_ADV_SET_HANDLE_NOT_SET;
-
-        auto err_code = sd_ble_gap_adv_set_configure(m_adapter, &initialAdvertisementHandle,
-                                                     nullptr, &initialAdvertisementParams);
-
-        if (err_code != NRF_SUCCESS)
-        {
-            NRF_LOG(role() << " Setup of initial advertisement params failed.");
-            return err_code;
-        }
-#endif
-
         // Support only undirected advertisement for now
         if (extended)
         {
@@ -354,10 +320,6 @@ class AdapterWrapper
         auto err_code =
             sd_ble_gap_adv_set_configure(m_adapter, &(scratchpad.adv_handle),
                                          &(scratchpad.adv_report_data), &(scratchpad.adv_params));
-
-/*        err_code =
-            sd_ble_gap_adv_set_configure(m_adapter, &(initialAdvertisementHandle),
-                                         &(scratchpad.adv_report_data), &(scratchpad.adv_params));*/
 #endif
 
         if (err_code != NRF_SUCCESS)

--- a/test/include/test_util_adapter_wrapper.h
+++ b/test/include/test_util_adapter_wrapper.h
@@ -104,6 +104,23 @@ class AdapterWrapper
         }
 #endif
 
+// Store the local address
+#if NRF_SD_BLE_API >= 3
+        error_code = sd_ble_gap_addr_get(m_adapter, &address);
+#else
+        error_code = sd_ble_gap_address_get(m_adapter, &address);
+#endif
+
+        if (error_code != NRF_SUCCESS)
+        {
+            NRF_LOG(role() << " sd_ble_gap_addr_get failed.");
+            return error_code;
+        }
+        else
+        {
+            NRF_LOG(role() << " GAP address is: " << testutil::asText(address));
+        }
+
         return error_code;
     }
 
@@ -839,6 +856,9 @@ class AdapterWrapper
     // There is no encapsulation of the values in the scratchpad and the scratchpad is not
     // thread safe.
     AdapterWrapperScratchpad scratchpad;
+
+    // My address
+    ble_gap_addr_t address;
 
   private:
     // Adapter from pc-ble-driver

--- a/test/include/test_util_adapter_wrapper.h
+++ b/test/include/test_util_adapter_wrapper.h
@@ -189,7 +189,14 @@ class AdapterWrapper
         }
         else
         {
-            NRF_LOG(role() << " Scan started");
+            if (!resume)
+            {
+                NRF_LOG(role() << " Scan resume failed");
+            }
+            else
+            {
+                NRF_LOG(role() << " Scan resumed");
+            }
         }
 
         return error_code;

--- a/test/include/test_util_adapter_wrapper.h
+++ b/test/include/test_util_adapter_wrapper.h
@@ -265,6 +265,40 @@ class AdapterWrapper
         scratchpad.adv_params.secondary_phy         = secondary_phy;
         scratchpad.adv_params.max_adv_evts          = max_adv_events;
 
+#if 0
+        // From nRF5_SDK_15.2.0_9412b96\components\ble\ble_advertising\ble_advertising.c:
+        //
+        // 'Configure a initial advertising configuration. The advertising data and and advertising
+        // parameters will be changed later when we call @ref ble_advertising_start, but must be set
+        // to legal values here to define an advertising handle.'
+        //
+        // TODO: clarify if they are illegal when setting up extended advertising...
+        ble_gap_adv_params_t initialAdvertisementParams {};
+        initialAdvertisementParams.primary_phy = BLE_GAP_PHY_1MBPS;
+
+        // From nRF5_SDK_15.2.0_9412b96\examples\ble_peripheral\ble_app_rscs\main.c:
+        // APP_ADV_DURATION  18000
+        initialAdvertisementParams.duration = 18000;
+        initialAdvertisementParams.properties.type =
+            BLE_GAP_ADV_TYPE_CONNECTABLE_SCANNABLE_UNDIRECTED;
+        initialAdvertisementParams.p_peer_addr   = nullptr;
+        initialAdvertisementParams.filter_policy = BLE_GAP_ADV_FP_ANY;
+
+        // From nRF5_SDK_15.2.0_9412b96\examples\ble_peripheral\ble_app_rscs\main.c:
+        // APP_ADV_INTERVAL  40
+        initialAdvertisementParams.interval = 40;
+        uint8_t initialAdvertisementHandle  = BLE_GAP_ADV_SET_HANDLE_NOT_SET;
+
+        auto err_code = sd_ble_gap_adv_set_configure(m_adapter, &initialAdvertisementHandle,
+                                                     nullptr, &initialAdvertisementParams);
+
+        if (err_code != NRF_SUCCESS)
+        {
+            NRF_LOG(role() << " Setup of initial advertisement params failed.");
+            return err_code;
+        }
+#endif
+
         // Support only undirected advertisement for now
         if (extended)
         {
@@ -296,6 +330,10 @@ class AdapterWrapper
         auto err_code =
             sd_ble_gap_adv_set_configure(m_adapter, &(scratchpad.adv_handle),
                                          &(scratchpad.adv_report_data), &(scratchpad.adv_params));
+
+/*        err_code =
+            sd_ble_gap_adv_set_configure(m_adapter, &(initialAdvertisementHandle),
+                                         &(scratchpad.adv_report_data), &(scratchpad.adv_params));*/
 #endif
 
         if (err_code != NRF_SUCCESS)

--- a/test/include/test_util_adapter_wrapper.h
+++ b/test/include/test_util_adapter_wrapper.h
@@ -140,11 +140,14 @@ class AdapterWrapper
         return sd_rpc_close(m_adapter);
     }
 
-    uint32_t startScan(const bool resume = false)
+    uint32_t startScan(const bool resume = false, const bool extended = false,
+                       const bool incomplete = false)
     {
 #if NRF_SD_BLE_API == 6
-        scratchpad.adv_report_receive_buffer.p_data = scratchpad.adv_report_data_received;
-        scratchpad.adv_report_receive_buffer.len    = sizeof(scratchpad.adv_report_data_received);
+        scratchpad.adv_report_receive_buffer.p_data  = scratchpad.adv_report_data_received;
+        scratchpad.adv_report_receive_buffer.len     = sizeof(scratchpad.adv_report_data_received);
+        scratchpad.scan_param.extended               = extended ? 1 : 0;
+        scratchpad.scan_param.report_incomplete_evts = incomplete ? 1 : 0;
 #endif
 
 #if NRF_SD_BLE_API < 6
@@ -194,7 +197,12 @@ class AdapterWrapper
 
     uint32_t setupAdvertising(const std::vector<uint8_t> &advertisingData  = std::vector<uint8_t>{},
                               const std::vector<uint8_t> &scanResponseData = std::vector<uint8_t>{},
-                              const bool connectable = true, const bool extended = false)
+                              const uint32_t interval = BLE_GAP_ADV_INTERVAL_MIN,
+                              const uint32_t duration = 0, const bool connectable = true,
+                              const bool extended = false, const bool scan_req_notification = false,
+                              const uint8_t set_id = 0, const uint8_t primary_phy = 0,
+                              const uint8_t secondary_phy = 0, const uint8_t filter_policy = 0,
+                              const uint32_t max_adv_events = 0)
     {
 #if NRF_SD_BLE_API <= 5
         const uint8_t *sr_data       = nullptr;
@@ -210,7 +218,7 @@ class AdapterWrapper
 
         if (advertisingDataSize > testutil::ADV_DATA_BUFFER_SIZE)
         {
-            NRF_LOG(role() << " Advertisement data is larger then the buffer set asize.");
+            NRF_LOG(role() << " Advertising data is larger then the buffer set asize.");
             return NRF_ERROR_INVALID_PARAM;
         }
 
@@ -228,11 +236,6 @@ class AdapterWrapper
         }
 
         const auto scanResponseDataSize = scanResponseData.size();
-        if (advertisingDataSize > testutil::ADV_DATA_BUFFER_SIZE)
-        {
-            NRF_LOG(role() << " Scan response data is larger then the buffer set asize.");
-            return NRF_ERROR_INVALID_PARAM;
-        }
 
         if (scanResponseDataSize == 0)
         {
@@ -252,6 +255,15 @@ class AdapterWrapper
         scratchpad.adv_report_data.scan_rsp_data          = scratchpad.adv_report_scan_rsp_data;
         scratchpad.adv_params.properties.anonymous        = 0;
         scratchpad.adv_params.properties.include_tx_power = 0;
+
+        scratchpad.adv_params.set_id                = set_id;
+        scratchpad.adv_params.interval              = interval;
+        scratchpad.adv_params.duration              = duration;
+        scratchpad.adv_params.filter_policy         = filter_policy;
+        scratchpad.adv_params.scan_req_notification = (scan_req_notification ? 1 : 0);
+        scratchpad.adv_params.primary_phy           = primary_phy;
+        scratchpad.adv_params.secondary_phy         = secondary_phy;
+        scratchpad.adv_params.max_adv_evts          = max_adv_events;
 
         // Support only undirected advertisement for now
         if (extended)

--- a/test/include/test_util_adapter_wrapper_scratchpad.h
+++ b/test/include/test_util_adapter_wrapper_scratchpad.h
@@ -23,7 +23,8 @@ namespace testutil {
 #if NRF_SD_BLE_API < 6
 constexpr size_t ADV_DATA_BUFFER_SIZE = BLE_GAP_ADV_MAX_SIZE;
 #else
-constexpr size_t ADV_DATA_BUFFER_SIZE = BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED;
+constexpr size_t ADV_DATA_BUFFER_SIZE =
+    BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED;
 #endif
 
 struct AdapterWrapperScratchpad
@@ -97,20 +98,20 @@ struct AdapterWrapperScratchpad
 
 #if NRF_SD_BLE_API == 6
     // Data members related to receiving advertisement reports
-    ble_data_t adv_report_receive_buffer;
+    ble_data_t adv_report_receive_buffer{};
     uint8_t adv_report_data_received[ADV_DATA_BUFFER_SIZE]; // Data to store advertisement report in
 
     // Data members related to sending advertisement reports
-    uint8_t adv_handle;
-    ble_gap_adv_data_t adv_report_data;                            // Data used for advertising
-    ble_data_t adv_report_adv_data;                                // Advertisement data
-    uint8_t adv_report_adv_data_buffer[ADV_DATA_BUFFER_SIZE];      // Advertisement data buffer
-    uint8_t adv_report_scan_rsp_data_buffer[1000]; // Advertisement data buffer
-    ble_data_t adv_report_scan_rsp_data;                           // Scan report data
-    ble_gap_adv_properties_t adv_properties; // Properties used for advertising
+    uint8_t adv_handle{BLE_GAP_ADV_SET_HANDLE_NOT_SET};
+    ble_gap_adv_data_t adv_report_data{};                       // Data used for advertising
+    ble_data_t adv_report_adv_data{};                           // Advertisement data
+    uint8_t adv_report_adv_data_buffer[ADV_DATA_BUFFER_SIZE]{}; // Advertisement data buffer
+    uint8_t adv_report_scan_rsp_data_buffer[1000]{};            // Advertisement data buffer
+    ble_data_t adv_report_scan_rsp_data{};                      // Scan report data
+    ble_gap_adv_properties_t adv_properties{};                  // Properties used for advertising
 #endif
 
-    ble_gap_adv_params_t adv_params; // Parameters used for advertising
+    ble_gap_adv_params_t adv_params{}; // Parameters used for advertising
 };
 } //  namespace testutil
 

--- a/test/include/test_util_adapter_wrapper_scratchpad.h
+++ b/test/include/test_util_adapter_wrapper_scratchpad.h
@@ -23,7 +23,7 @@ namespace testutil {
 #if NRF_SD_BLE_API < 6
 constexpr size_t ADV_DATA_BUFFER_SIZE = BLE_GAP_ADV_MAX_SIZE;
 #else
-constexpr size_t ADV_DATA_BUFFER_SIZE = BLE_GAP_ADV_SET_DATA_SIZE_MAX;
+constexpr size_t ADV_DATA_BUFFER_SIZE = BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED;
 #endif
 
 struct AdapterWrapperScratchpad
@@ -105,7 +105,7 @@ struct AdapterWrapperScratchpad
     ble_gap_adv_data_t adv_report_data;                            // Data used for advertising
     ble_data_t adv_report_adv_data;                                // Advertisement data
     uint8_t adv_report_adv_data_buffer[ADV_DATA_BUFFER_SIZE];      // Advertisement data buffer
-    uint8_t adv_report_scan_rsp_data_buffer[ADV_DATA_BUFFER_SIZE]; // Advertisement data buffer
+    uint8_t adv_report_scan_rsp_data_buffer[1000]; // Advertisement data buffer
     ble_data_t adv_report_scan_rsp_data;                           // Scan report data
     ble_gap_adv_properties_t adv_properties; // Properties used for advertising
 #endif

--- a/test/include/test_util_adapter_wrapper_scratchpad.h
+++ b/test/include/test_util_adapter_wrapper_scratchpad.h
@@ -24,7 +24,7 @@ namespace testutil {
 constexpr size_t ADV_DATA_BUFFER_SIZE = BLE_GAP_ADV_MAX_SIZE;
 #else
 constexpr size_t ADV_DATA_BUFFER_SIZE =
-    BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED;
+    BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_MAX_SUPPORTED;
 #endif
 
 struct AdapterWrapperScratchpad

--- a/test/include/test_util_conversion.h
+++ b/test/include/test_util_conversion.h
@@ -4,13 +4,16 @@
 #include "ble.h"
 #include "ble_hci.h"
 
+#include <cctype>
+
 namespace testutil {
 /**
  * @brief Function that convert data to string representation
  * @param[in] data Data to represent as a string
  * @return string representation of data
  */
-static std::string asHex(const std::vector<uint8_t> &data) {
+static std::string asHex(const std::vector<uint8_t> &data)
+{
     std::stringstream retval;
 
     for (uint8_t const &value : data)
@@ -21,7 +24,8 @@ static std::string asHex(const std::vector<uint8_t> &data) {
     return retval.str();
 }
 
-static std::string asHex(const uint16_t &data) {
+static std::string asHex(const uint16_t &data)
+{
     std::stringstream retval;
     retval << std::setfill('0') << std::setw(2) << std::hex << data;
     return retval.str();
@@ -33,7 +37,8 @@ static std::string asHex(const uint16_t &data) {
  * @param[in] address Bluetooth Lower Energy address
  * @return string representation of provided address
  */
-static std::string asText(const ble_gap_addr_t &address) {
+static std::string asText(const ble_gap_addr_t &address)
+{
     std::stringstream retval;
 
     for (int i = sizeof(address.addr) - 1; i >= 0; --i)
@@ -78,13 +83,15 @@ static std::string asText(const ble_gap_addr_t &address) {
  *
  * @return textual representation of the error
  */
-static std::string errorToString(const uint32_t error_code) {
+static std::string errorToString(const uint32_t error_code)
+{
     std::stringstream retval;
     retval << "error code: 0x" << std::setfill('0') << std::setw(2) << std::hex << error_code;
     return retval.str();
 }
 
-static std::string ioCapsToString(const uint8_t code) {
+static std::string ioCapsToString(const uint8_t code)
+{
     std::stringstream retval;
 
     switch (code)
@@ -113,7 +120,8 @@ static std::string ioCapsToString(const uint8_t code) {
     return retval.str();
 }
 
-static std::string roleToString(const uint8_t role) {
+static std::string roleToString(const uint8_t role)
+{
     std::stringstream retval;
 
     switch (role)
@@ -135,7 +143,8 @@ static std::string roleToString(const uint8_t role) {
     return retval.str();
 }
 
-static std::string gattAuthErrorSrcToString(const uint8_t errorSrc) {
+static std::string gattAuthErrorSrcToString(const uint8_t errorSrc)
+{
     std::stringstream retval;
 
     switch (errorSrc)
@@ -155,7 +164,8 @@ static std::string gattAuthErrorSrcToString(const uint8_t errorSrc) {
     return retval.str();
 }
 
-static std::string gattAuthStatusToString(const uint8_t authStatus) {
+static std::string gattAuthStatusToString(const uint8_t authStatus)
+{
     std::stringstream retval;
 
     switch (authStatus)
@@ -229,7 +239,8 @@ static std::string gattAuthStatusToString(const uint8_t authStatus) {
     return retval.str();
 }
 
-static std::string hciStatusCodeToString(const uint8_t hciStatusCode) {
+static std::string hciStatusCodeToString(const uint8_t hciStatusCode)
+{
     std::stringstream retval;
 
     switch (hciStatusCode)
@@ -330,7 +341,8 @@ static std::string hciStatusCodeToString(const uint8_t hciStatusCode) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_passkey_display_t &passkeyDisplay) {
+static std::string asText(const ble_gap_evt_passkey_display_t &passkeyDisplay)
+{
     std::stringstream retval;
     std::stringstream passkey;
 
@@ -344,7 +356,8 @@ static std::string asText(const ble_gap_evt_passkey_display_t &passkeyDisplay) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_enc_info_t &encryptionInfo) {
+static std::string asText(const ble_gap_enc_info_t &encryptionInfo)
+{
     std::stringstream retval;
     std::vector<uint8_t> key(encryptionInfo.ltk, encryptionInfo.ltk + encryptionInfo.ltk_len);
 
@@ -355,7 +368,8 @@ static std::string asText(const ble_gap_enc_info_t &encryptionInfo) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_conn_params_t &connectionParams) {
+static std::string asText(const ble_gap_conn_params_t &connectionParams)
+{
     std::stringstream retval;
 
     retval << "conn_sup_timeout:" << static_cast<uint32_t>(connectionParams.conn_sup_timeout)
@@ -369,7 +383,8 @@ static std::string asText(const ble_gap_conn_params_t &connectionParams) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_connected_t &connected) {
+static std::string asText(const ble_gap_evt_connected_t &connected)
+{
     std::stringstream retval;
 
     retval << "peer_addr:[" << asText(connected.peer_addr) << "] ";
@@ -385,22 +400,25 @@ static std::string asText(const ble_gap_evt_connected_t &connected) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_disconnected_t &disconnected) {
+static std::string asText(const ble_gap_evt_disconnected_t &disconnected)
+{
     std::stringstream retval;
 
     retval << "reason:" << hciStatusCodeToString(disconnected.reason);
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_scan_req_report_t &scanReqReport) {
+static std::string asText(const ble_gap_evt_scan_req_report_t &scanReqReport)
+{
     std::stringstream retval;
 
     retval << "peer_addr:[" << asText(scanReqReport.peer_addr) << "]";
-    retval << " rssi:" << static_cast<uint32_t>(scanReqReport.rssi);
+    retval << " rssi:" << static_cast<int32_t>(scanReqReport.rssi);
     return retval.str();
 }
 
-static std::string asText(const ble_gap_sec_kdist_t &keyDist) {
+static std::string asText(const ble_gap_sec_kdist_t &keyDist)
+{
     std::stringstream retval;
     retval << "enc:" << (keyDist.enc ? "yes" : "no") << " ";
     retval << "id:" << (keyDist.id ? "yes" : "no") << " ";
@@ -409,7 +427,8 @@ static std::string asText(const ble_gap_sec_kdist_t &keyDist) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_sec_request_t &securityRequest) {
+static std::string asText(const ble_gap_evt_sec_request_t &securityRequest)
+{
     std::stringstream retval;
     retval << "bond:" << (securityRequest.bond ? "yes" : "no") << " ";
     retval << "mitm:" << (securityRequest.mitm ? "yes" : "no") << " ";
@@ -418,7 +437,8 @@ static std::string asText(const ble_gap_evt_sec_request_t &securityRequest) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_sec_params_request_t &securityParamsRequest) {
+static std::string asText(const ble_gap_evt_sec_params_request_t &securityParamsRequest)
+{
     std::stringstream retval;
     retval << "peer_params:[";
     retval << "bond:" << (securityParamsRequest.peer_params.bond ? "yes" : "no") << " ";
@@ -438,7 +458,8 @@ static std::string asText(const ble_gap_evt_sec_params_request_t &securityParams
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_auth_key_request_t &authKeyRequest) {
+static std::string asText(const ble_gap_evt_auth_key_request_t &authKeyRequest)
+{
     std::stringstream retval;
     retval << "key_type: ";
 
@@ -460,7 +481,8 @@ static std::string asText(const ble_gap_evt_auth_key_request_t &authKeyRequest) 
     return retval.str();
 }
 
-static std::string asText(const ble_gap_conn_sec_mode_t &connSecMode) {
+static std::string asText(const ble_gap_conn_sec_mode_t &connSecMode)
+{
     std::stringstream retval;
 
     retval << "sm:" << static_cast<uint32_t>(connSecMode.sm)
@@ -471,71 +493,210 @@ static std::string asText(const ble_gap_conn_sec_mode_t &connSecMode) {
         retval << "Security Mode 0 Level 0: No access permissions at all";
     }
     else if (connSecMode.sm == 1 && connSecMode.lv == 1)
-    { retval << "No security is needed (aka open link)"; }
+    {
+        retval << "No security is needed (aka open link)";
+    }
     else if (connSecMode.sm == 1 && connSecMode.lv == 2)
-    { retval << "Encrypted link required, MITM protection not necessary"; }
+    {
+        retval << "Encrypted link required, MITM protection not necessary";
+    }
     else if (connSecMode.sm == 1 && connSecMode.lv == 3)
-    { retval << "MITM protected encrypted link required"; }
+    {
+        retval << "MITM protected encrypted link required";
+    }
     else if (connSecMode.sm == 1 && connSecMode.lv == 4)
-    { retval << "LESC MITM protected encrypted link required"; }
+    {
+        retval << "LESC MITM protected encrypted link required";
+    }
     else if (connSecMode.sm == 2 && connSecMode.lv == 1)
-    { retval << "Signing or encryption required, MITM protection not necessary"; }
+    {
+        retval << "Signing or encryption required, MITM protection not necessary";
+    }
     else if (connSecMode.sm == 2 && connSecMode.lv == 2)
-    { retval << "MITM protected signing required, unless link is MITM protected encrypted"; }
+    {
+        retval << "MITM protected signing required, unless link is MITM protected encrypted";
+    }
 
     retval << "'";
     return retval.str();
 }
 
-static std::string asText(const ble_gap_conn_sec_t &connSec) {
+static std::string asText(const ble_gap_conn_sec_t &connSec)
+{
     std::stringstream retval;
     retval << "sec_mode:[" << asText(connSec.sec_mode) << "] ";
     retval << "encr_key_size:" << static_cast<uint32_t>(connSec.encr_key_size);
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_rssi_changed_t &rssiChanged) {
+static std::string asText(const ble_gap_evt_rssi_changed_t &rssiChanged)
+{
     std::stringstream retval;
     retval << "rssi:" << static_cast<uint32_t>(rssiChanged.rssi) << "dBm";
     return retval.str();
 }
 
-static std::string asText(const ble_gap_lesc_p256_pk_t &lsecP256Pk) {
+static std::string asText(const ble_gap_lesc_p256_pk_t &lsecP256Pk)
+{
     std::stringstream retval;
     std::vector<uint8_t> key(lsecP256Pk.pk, lsecP256Pk.pk + 64);
     retval << "key:" << asHex(key);
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_key_pressed_t &keyPressed) {
+static std::string asText(const ble_gap_evt_key_pressed_t &keyPressed)
+{
     std::stringstream retval;
     retval << "pk_not:" << keyPressed.kp_not; // TODO: convert to string
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_timeout_t &timeout) {
+static std::string asText(const std::vector<uint8_t> &data)
+{
+    std::stringstream retval;
+
+    for (auto v : data)
+    {
+        if (std::isprint(v))
+        {
+            retval << v;
+        }
+    }
+
+    return retval.str();
+}
+
+static std::string asText(const ble_gap_evt_timeout_t &timeout)
+{
     std::stringstream retval;
     retval << "src:" << timeout.src; // TODO: convert to string
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_adv_report_t &advReport) {
-#if NRF_SD_BLE_API < 6
+#if NRF_SD_BLE_API == 6
+static std::string asText(const ble_gap_adv_report_type_t &reportType)
+{
     std::stringstream retval;
-    std::vector<uint8_t> data(advReport.data, advReport.data + advReport.dlen);
 
-    retval << "peer_addr:[" << asText(advReport.peer_addr) << "]";
-    retval << " data:" << asHex(data);
-    retval << " rssi:" << static_cast<uint32_t>(advReport.rssi) << "dBm";
-    retval << " scan_rsp:" << (advReport.scan_rsp ? "yes" : "no");
-    retval << " type:0x" << asHex(advReport.type); // TODO: convert to string
+    if (reportType.connectable)
+    {
+        retval << " connectable:" << (reportType.connectable ? "yes" : "no");
+    }
+
+    if (reportType.scannable)
+    {
+        retval << " scannable:" << (reportType.scannable ? "yes" : "no");
+    }
+
+    if (reportType.directed)
+    {
+        retval << " directed:" << (reportType.directed ? "yes" : "no");
+    }
+
+    if (reportType.scan_response)
+    {
+        retval << " scan_response:" << (reportType.scan_response ? "yes" : "no");
+    }
+
+    if (reportType.extended_pdu)
+    {
+        retval << " extended_pdu:" << (reportType.extended_pdu ? "yes" : "no");
+    }
+
+    retval << " status:";
+
+    switch (reportType.status)
+    {
+        case BLE_GAP_ADV_DATA_STATUS_COMPLETE:
+            retval << "COMPLETE";
+            break;
+        case BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA:
+            retval << "INCOMPLETE_MORE_DATA";
+            break;
+        case BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_TRUNCATED:
+            retval << "INCOMPLETE_TRUNCATED";
+            break;
+        case BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MISSED:
+            retval << "INCOMPLETE_MISSED";
+            break;
+        default:
+            retval << "UNKNOWN(" << std::hex << static_cast<uint32_t>(reportType.status) << ")";
+            break;
+    }
+
     return retval.str();
-#else
-    return "asText for ble_gap_evt_adv_report_t not supported on SD API v6";
+}
 #endif
+
+#if NRF_SD_BLE_API == 6
+static std::string asText(const ble_gap_aux_pointer_t &auxPointer)
+{
+    std::stringstream retval;
+    retval << "aux_offset:" << static_cast<uint32_t>(auxPointer.aux_offset);
+    retval << " aux_phy:" << static_cast<uint32_t>(auxPointer.aux_phy);
+    return retval.str();
+}
+#endif
+
+static std::string asText(const ble_gap_evt_adv_report_t &advReport)
+{
+    std::stringstream retval;
+#if NRF_SD_BLE_API == 6
+    std::vector<uint8_t> data(advReport.data.p_data, advReport.data.p_data + advReport.data.len);
+    retval << "type:" << asText(advReport.type);
+
+#else
+    std::vector<uint8_t> data(advReport.data, advReport.data + advReport.dlen);
+    retval << "type:" << asHex(advReport.type);
+#endif
+
+#if NRF_SD_BLE_API == 6
+    if (advReport.type.directed)
+    {
+        retval << " direct_addr:[" << asText(advReport.direct_addr) << "]";
+    }
+
+    retval << " primary_phy:" << static_cast<uint32_t>(advReport.primary_phy);
+    retval << " secondary_phy:" << static_cast<uint32_t>(advReport.secondary_phy);
+
+    if (advReport.tx_power != BLE_GAP_POWER_LEVEL_INVALID)
+    {
+        retval << " tx_power:" << static_cast<uint32_t>(advReport.tx_power);
+    }
+#endif
+
+    retval << " rssi:" << static_cast<int32_t>(advReport.rssi) << "dBm";
+
+#if NRF_SD_BLE_API == 6
+    retval << " ch_index:" << std::hex << static_cast<uint32_t>(advReport.ch_index);
+
+    if (advReport.set_id != BLE_GAP_ADV_REPORT_SET_ID_NOT_AVAILABLE)
+    {
+        retval << " set_id:" << std::hex << static_cast<uint32_t>(advReport.set_id);
+    }
+
+    if (advReport.data_id != BLE_GAP_ADV_REPORT_SET_ID_NOT_AVAILABLE)
+    {
+        retval << " data_id:" << std::hex << static_cast<uint32_t>(advReport.data_id);
+    }
+
+    if (advReport.type.status == BLE_GAP_ADV_DATA_STATUS_INCOMPLETE_MORE_DATA)
+    {
+        retval << " aux_pointer:[" << asText(advReport.aux_pointer) << "]";
+    }
+#endif
+
+#if NRF_SD_BLE_API < 6
+    retval << " scan_rsp:" << (advReport.scan_rsp ? "yes" : "no");
+#endif
+
+    retval << " data:" << asHex(data) << "/" << asText(data);
+
+    return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_lesc_dhkey_request_t &dhkeyRequest) {
+static std::string asText(const ble_gap_evt_lesc_dhkey_request_t &dhkeyRequest)
+{
     std::stringstream retval;
     retval << "p_pk_peer:["
            << ((dhkeyRequest.p_pk_peer != nullptr) ? asText(*dhkeyRequest.p_pk_peer) : "NULL")
@@ -544,7 +705,8 @@ static std::string asText(const ble_gap_evt_lesc_dhkey_request_t &dhkeyRequest) 
     return retval.str();
 }
 
-static std::string asText(const ble_gap_master_id_t &masterId) {
+static std::string asText(const ble_gap_master_id_t &masterId)
+{
     std::stringstream retval;
     std::vector<uint8_t> rand(masterId.rand, masterId.rand + sizeof(masterId.rand));
     retval << "ediv:0x" << asHex(masterId.ediv);
@@ -552,7 +714,8 @@ static std::string asText(const ble_gap_master_id_t &masterId) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_sec_info_request_t &secInfoRequest) {
+static std::string asText(const ble_gap_evt_sec_info_request_t &secInfoRequest)
+{
     std::stringstream retval;
     retval << "peer_addr:[" << asText(secInfoRequest.peer_addr) << "]";
     retval << " enc_info:" << (secInfoRequest.enc_info ? "required" : "not_required");
@@ -566,7 +729,8 @@ static std::string asText(const ble_gap_evt_sec_info_request_t &secInfoRequest) 
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_conn_sec_update_t &connSecUpdate) {
+static std::string asText(const ble_gap_evt_conn_sec_update_t &connSecUpdate)
+{
     std::stringstream retval;
     retval << "conn_sec:[";
     retval << asText(connSecUpdate.conn_sec);
@@ -574,7 +738,8 @@ static std::string asText(const ble_gap_evt_conn_sec_update_t &connSecUpdate) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_sec_levels_t &secLevels) {
+static std::string asText(const ble_gap_sec_levels_t &secLevels)
+{
     std::stringstream retval;
     retval << "lv1:" << (secLevels.lv1 ? "yes" : "no");
     retval << " lv2:" << (secLevels.lv2 ? "yes" : "no");
@@ -583,7 +748,8 @@ static std::string asText(const ble_gap_sec_levels_t &secLevels) {
     return retval.str();
 }
 
-static std::string asText(const ble_gap_evt_auth_status_t &authStatus) {
+static std::string asText(const ble_gap_evt_auth_status_t &authStatus)
+{
     std::stringstream retval;
     retval << "auth_status:" << gattAuthStatusToString(authStatus.auth_status) << " ";
     retval << "error_src:" << gattAuthErrorSrcToString(authStatus.error_src) << " ";
@@ -602,7 +768,8 @@ static std::string asText(const ble_gap_evt_auth_status_t &authStatus) {
  *
  * @return textual representation of the code
  */
-static std::string gattStatusToString(const uint16_t code) {
+static std::string gattStatusToString(const uint16_t code)
+{
     std::stringstream retval;
     retval << "GATT status code: 0x" << std::setfill('0') << std::setw(4) << std::hex
            << (uint32_t)code << ".";
@@ -610,7 +777,8 @@ static std::string gattStatusToString(const uint16_t code) {
 }
 
 // Operator overloading for common types used
-std::string asText(const sd_rpc_app_status_t &status) {
+std::string asText(const sd_rpc_app_status_t &status)
+{
     switch (status)
     {
         case PKT_SEND_MAX_RETRIES_REACHED:
@@ -634,25 +802,29 @@ std::string asText(const sd_rpc_app_status_t &status) {
     }
 }
 
-static std::string asText(const uint16_t &value) {
+static std::string asText(const uint16_t &value)
+{
     std::stringstream retval;
     retval << "0x" << std::setfill('0') << std::setw(4) << std::hex << (uint32_t)value;
     return retval.str();
 }
 
-static std::string asText(const uint8_t &value) {
+static std::string asText(const uint8_t &value)
+{
     std::stringstream retval;
     retval << "0x" << std::setfill('0') << std::setw(2) << std::hex << (uint32_t)value;
     return retval.str();
 }
 
-static std::string asText(const ble_uuid_t &uuid) {
+static std::string asText(const ble_uuid_t &uuid)
+{
     std::stringstream retval;
     retval << "uuid:[type: " << asText(uuid.type) << ", uuid: " << asText(uuid.uuid) << "]";
     return retval.str();
 }
 
-static std::string asText(const ble_gattc_char_t &gattc_char) {
+static std::string asText(const ble_gattc_char_t &gattc_char)
+{
     std::stringstream retval;
     retval << "characteristic:["
            << "handle_decl: " << asText(gattc_char.handle_decl)
@@ -662,7 +834,8 @@ static std::string asText(const ble_gattc_char_t &gattc_char) {
     return retval.str();
 }
 
-static std::string asText(const ble_gattc_handle_range_t &gattc_handle_range) {
+static std::string asText(const ble_gattc_handle_range_t &gattc_handle_range)
+{
     std::stringstream retval;
     retval << "handle range:["
            << "start: " << asText(gattc_handle_range.start_handle)
@@ -670,14 +843,16 @@ static std::string asText(const ble_gattc_handle_range_t &gattc_handle_range) {
     return retval.str();
 }
 
-static std::string asText(const ble_gattc_desc_t &gattc_desc) {
+static std::string asText(const ble_gattc_desc_t &gattc_desc)
+{
     std::stringstream retval;
     retval << "descriptor:["
            << "handle: " << asText(gattc_desc.handle) << " " << asText(gattc_desc.uuid) << "]";
     return retval.str();
 }
 
-static std::string asText(const sd_rpc_log_severity_t &severity) {
+static std::string asText(const sd_rpc_log_severity_t &severity)
+{
     switch (severity)
     {
         case SD_RPC_LOG_TRACE:

--- a/test/include/test_util_conversion.h
+++ b/test/include/test_util_conversion.h
@@ -641,13 +641,14 @@ static std::string asText(const ble_gap_aux_pointer_t &auxPointer)
 static std::string asText(const ble_gap_evt_adv_report_t &advReport)
 {
     std::stringstream retval;
+
+    retval << "peer_addr:[" << asText(advReport.peer_addr) << "]";
 #if NRF_SD_BLE_API == 6
     std::vector<uint8_t> data(advReport.data.p_data, advReport.data.p_data + advReport.data.len);
-    retval << "type:" << asText(advReport.type);
-
+    retval << " type:[" << asText(advReport.type) << "]";
 #else
     std::vector<uint8_t> data(advReport.data, advReport.data + advReport.dlen);
-    retval << "type:" << asHex(advReport.type);
+    retval << " type:" << asHex(advReport.type);
 #endif
 
 #if NRF_SD_BLE_API == 6

--- a/test/softdevice_api/test_advertising_api.cpp
+++ b/test/softdevice_api/test_advertising_api.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ *   4. This software must only be used in or with a processor manufactured by Nordic
+ *   Semiconductor ASA, or in or with a processor manufactured by a third party that
+ *   is used in combination with a processor manufactured by Nordic Semiconductor.
+ *
+ *   5. Any software provided in binary or object form under this license must not be
+ *   reverse engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Test framework
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"
+
+#if NRF_SD_BLE_API >= 6
+
+// Logging support
+#include <internal/log.h>
+
+// Test support
+#include <test_setup.h>
+#include <test_util.h>
+
+#include <ble.h>
+#include <sd_rpc.h>
+
+#include <memory>
+#include <sstream>
+#include <thread>
+
+// Indicates if an error has occurred in a callback.
+// The test framework is not thread safe so this variable is used to communicate that an issues has
+// occurred in a callback.
+bool error = false;
+
+enum TestState {
+    P_ADVERTISING_FAST_EXTENDED,
+    P_ADVERTISING_FAST_EXTENDED_NOTIFICATION, // BLE_ADV_EVT_FAST
+    C_ADVERTISING_EXTENDED_RECEIVED,
+    P_RECEIVED_SCAN_REQ_NOTIFICATION, // BLE_GAP_EVT_SCAN_REQ_REPORT
+};
+
+TestState testState;
+
+TEST_CASE("test_advertising_api")
+{
+    auto env = ::test::getEnvironment();
+    REQUIRE(env.serialPorts.size() >= 2);
+    const auto central    = env.serialPorts.at(0);
+    const auto peripheral = env.serialPorts.at(1);
+
+#if NRF_SD_BLE_API == 6
+    SECTION("test_extended")
+    {
+        const auto baudRate = central.baudRate;
+
+        INFO("Central serial port used: " << central.port);
+        INFO("Peripheral serial port used: " << peripheral.port);
+        INFO("Baud rate used: " << baudRate);
+
+        std::vector<uint8_t> peripheralAdvNameBase;
+        testutil::appendRandomAlphaNumeric(peripheralAdvNameBase, testutil::ADV_DATA_BUFFER_SIZE -
+                                                                      2 /* length and AD type */);
+
+        const std::string peripheralAdvName(peripheralAdvNameBase.begin(),
+                                            peripheralAdvNameBase.end());
+
+        // Instantiate an adapter to use as BLE Central in the test
+        auto c = std::make_shared<testutil::AdapterWrapper>(testutil::Central, central.port,
+                                                            baudRate, 150);
+
+        // Instantiated an adapter to use as BLE Peripheral in the test
+        auto p = std::make_shared<testutil::AdapterWrapper>(testutil::Peripheral, peripheral.port,
+                                                            baudRate, 150);
+
+        REQUIRE(sd_rpc_log_handler_severity_filter_set(c->unwrap(), env.driverLogLevel) ==
+                NRF_SUCCESS);
+        REQUIRE(sd_rpc_log_handler_severity_filter_set(p->unwrap(), env.driverLogLevel) ==
+                NRF_SUCCESS);
+
+        c->setGapEventCallback([&c, peripheralAdvName](const uint16_t eventId,
+                                                       const ble_gap_evt_t *gapEvent) -> bool {
+            switch (eventId)
+            {
+                case BLE_GAP_EVT_ADV_REPORT:
+                    if (testutil::findAdvName(&(gapEvent->params.adv_report), peripheralAdvName))
+                    {
+                        // TODO: do additional checks on the received advertisement report
+                    }
+#if NRF_SD_BLE_API == 6
+                    else
+                    {
+                        c->startScan(true);
+                    }
+#endif
+                    return true;
+                case BLE_GAP_EVT_TIMEOUT:
+                    if (gapEvent->params.timeout.src == BLE_GAP_TIMEOUT_SRC_SCAN)
+                    {
+                        const auto err_code = c->startScan();
+
+                        if (err_code != NRF_SUCCESS)
+                        {
+                            NRF_LOG(c->role()
+                                    << " Scan start error, err_code " << std::hex << err_code);
+                            error = true;
+                        }
+                    }
+                    return true;
+                default:
+                    return false;
+            }
+        });
+
+        c->setEventCallback([&c](const ble_evt_t *p_ble_evt) -> bool {
+            const auto eventId = p_ble_evt->header.evt_id;
+            NRF_LOG(c->role() << " Received an un-handled event with ID: " << std::hex << eventId);
+            return true;
+        });
+
+        p->setGapEventCallback([](const uint16_t eventId, const ble_gap_evt_t *gapEvent) {
+            switch (eventId)
+            {
+                case BLE_GAP_EVT_TIMEOUT:
+                    return true;
+                case BLE_GAP_EVT_SCAN_REQ_REPORT:
+                case BLE_GAP_EVT_ADV_SET_TERMINATED:
+                    return true;
+                default:
+                    return false;
+            }
+        });
+
+        p->setEventCallback([&p](const ble_evt_t *p_ble_evt) -> bool {
+            const auto eventId = p_ble_evt->header.evt_id;
+            NRF_LOG(p->role() << " Received an un-handled event with ID: " << std::hex << eventId);
+            return true;
+        });
+
+        // Open the adapters
+        REQUIRE(c->open() == NRF_SUCCESS);
+        REQUIRE(p->open() == NRF_SUCCESS);
+
+        REQUIRE(c->configure() == NRF_SUCCESS);
+        REQUIRE(p->configure() == NRF_SUCCESS);
+
+        // Create advertising data and scan response data
+        std::vector<uint8_t> advertising;
+#if 1
+        testutil::appendAdvertisingName(advertising, peripheralAdvName);
+
+        std::vector<uint8_t> scanResponse;
+        std::vector<uint8_t> scanResponseData;
+        testutil::appendRandomData(scanResponseData,
+                                   testutil::ADV_DATA_BUFFER_SIZE - 2 /* length and AD type */);
+
+        scanResponse.reserve(scanResponseData.size() + 2);
+        scanResponse.push_back(
+            static_cast<uint8_t>(scanResponseData.size() + 1)); // Data + advertisement type
+        scanResponse.push_back(BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA);
+        std::copy(scanResponseData.begin(), scanResponseData.end(),
+                  std::back_inserter(scanResponse));
+#else
+        testutil::appendAdvertisingName(advertising, "12345");
+        const std::vector<uint8_t> scanResponse = {};
+#endif
+
+        REQUIRE(p->setupAdvertising(advertising,              // advertising data
+                                    scanResponse,             // scan response data
+                                    40, //BLE_GAP_ADV_INTERVAL_MIN, // interval
+                                    0,                        // duration
+                                    false,                    // connectable
+                                    true,                     // extended
+                                    false, // true,                     // scan_req_notification
+                                    0,     // set_id
+                                    BLE_GAP_PHY_1MBPS, // primary phy
+                                    BLE_GAP_PHY_2MBPS, // secondary phy
+                                    0,                 // filter policy
+                                    0                  // max_adv_events
+                                    ) == NRF_SUCCESS);
+        REQUIRE(p->startAdvertising() == NRF_SUCCESS);
+
+        REQUIRE(c->startScan() == NRF_SUCCESS);
+
+        // Wait for the test to complete
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+
+        REQUIRE(error == false);
+
+        REQUIRE(c->close() == NRF_SUCCESS);
+        sd_rpc_adapter_delete(c->unwrap());
+
+        REQUIRE(p->close() == NRF_SUCCESS);
+        sd_rpc_adapter_delete(p->unwrap());
+    }
+#endif // NRF_SD_BLE_API == 6
+}
+
+#else
+TEST_CASE("test_advertising_api")
+{
+    INFO("Not relevant for SoftDevice API version < 3")
+}
+
+#endif // NRF_SD_BLE_API >= 6

--- a/test/softdevice_api/test_advertising_api.cpp
+++ b/test/softdevice_api/test_advertising_api.cpp
@@ -55,19 +55,12 @@
 #include <sstream>
 #include <thread>
 
+using namespace testutil;
+
 // Indicates if an error has occurred in a callback.
 // The test framework is not thread safe so this variable is used to communicate that an issues has
 // occurred in a callback.
 bool error = false;
-
-enum TestState {
-    P_ADVERTISING_FAST_EXTENDED,
-    P_ADVERTISING_FAST_EXTENDED_NOTIFICATION, // BLE_ADV_EVT_FAST
-    C_ADVERTISING_EXTENDED_RECEIVED,
-    P_RECEIVED_SCAN_REQ_NOTIFICATION, // BLE_GAP_EVT_SCAN_REQ_REPORT
-};
-
-TestState testState;
 
 TEST_CASE("test_advertising_api")
 {
@@ -85,14 +78,35 @@ TEST_CASE("test_advertising_api")
         INFO("Peripheral serial port used: " << peripheral.port);
         INFO("Baud rate used: " << baudRate);
 
-        const auto maxLengthOfAdvData = testutil::ADV_DATA_BUFFER_SIZE;
+        const auto maxLengthOfAdvData        = testutil::ADV_DATA_BUFFER_SIZE;
+        const auto maxNumberOfAdvertisements = 20;
+        const auto advertisementNameLength   = 40;
+        const auto advertisementSetId        = 5;
 
-        std::vector<uint8_t> peripheralAdvNameBase;
-        testutil::appendRandomAlphaNumeric(peripheralAdvNameBase,
-                                           maxLengthOfAdvData - 2 /* length and AD type */);
+        auto scanRequestCountOtherCentral = 0;
+        auto scanRequestCountThisCentral  = 0;
 
-        const std::string peripheralAdvName(peripheralAdvNameBase.begin(),
-                                            peripheralAdvNameBase.end());
+        std::vector<uint8_t> peripheralAdvNameBuffer(advertisementNameLength);
+        testutil::appendRandomAlphaNumeric(peripheralAdvNameBuffer, advertisementNameLength);
+        const std::string peripheralAdvName(peripheralAdvNameBuffer.begin(),
+                                            peripheralAdvNameBuffer.end());
+
+        // Create advertising data and scan response data
+        std::vector<uint8_t> advertising;
+        std::vector<uint8_t> scanResponse;
+
+        testutil::appendAdvertisingName(scanResponse, peripheralAdvName);
+
+        // Append max number of bytes in advertisement packet with manufacturer specific random data
+        // after the peripheral name
+        const auto remainingSpace =
+            maxLengthOfAdvData - scanResponse.size() - 2 /* length and AD type */;
+        std::vector<uint8_t> randomData;
+
+        testutil::appendRandomData(randomData, remainingSpace);
+
+        scanResponse.reserve(maxLengthOfAdvData);
+        testutil::appendManufacturerSpecificData(scanResponse, randomData, true);
 
         // Instantiate an adapter to use as BLE Central in the test
         auto c = std::make_shared<testutil::AdapterWrapper>(testutil::Central, central.port,
@@ -107,21 +121,51 @@ TEST_CASE("test_advertising_api")
         REQUIRE(sd_rpc_log_handler_severity_filter_set(p->unwrap(), env.driverLogLevel) ==
                 NRF_SUCCESS);
 
-        c->setGapEventCallback([&c, peripheralAdvName](const uint16_t eventId,
-                                                       const ble_gap_evt_t *gapEvent) -> bool {
+        c->setGapEventCallback([&](const uint16_t eventId, const ble_gap_evt_t *gapEvent) -> bool {
             switch (eventId)
             {
                 case BLE_GAP_EVT_ADV_REPORT:
-                    if (testutil::findAdvName(&(gapEvent->params.adv_report), peripheralAdvName))
+                {
+                    const auto advReport = gapEvent->params.adv_report;
+
+                    if (testutil::findAdvName(advReport, peripheralAdvName))
                     {
-                        // TODO: do additional checks on the received advertisement report
+                        std::vector<uint8_t> manufacturerSpecificData;
+
+                        if (testutil::findManufacturerSpecificData(advReport,
+                                                                   manufacturerSpecificData))
+                        {
+                            // Check that the received data is according to setupAdvertisement
+                            if (manufacturerSpecificData != randomData)
+                            {
+                                NRF_LOG(c->role() << " Data configured in peripheral does not "
+                                                     "match data received on central");
+                                error = true;
+                            }
+                            else
+                            {
+                                // TODO: check previous state
+                                if (!(advReport.primary_phy == BLE_GAP_PHY_1MBPS &&
+                                      advReport.secondary_phy == BLE_GAP_PHY_2MBPS &&
+                                      advReport.type.extended_pdu == 1 &&
+                                      advReport.type.scan_response == 1 &&
+                                      advReport.type.connectable == 0 &&
+                                      advReport.set_id == advertisementSetId))
+                                {
+                                    NRF_LOG(c->role()
+                                            << " Configured advertisement on peripheral does not "
+                                               "match event received on central");
+                                    error = true;
+                                }
+                            }
+                        }
                     }
-#if NRF_SD_BLE_API == 6
-                    else
+
+                    if (!error)
                     {
                         c->startScan(true);
                     }
-#endif
+                }
                     return true;
                 case BLE_GAP_EVT_TIMEOUT:
                     if (gapEvent->params.timeout.src == BLE_GAP_TIMEOUT_SRC_SCAN)
@@ -147,13 +191,91 @@ TEST_CASE("test_advertising_api")
             return true;
         });
 
-        p->setGapEventCallback([](const uint16_t eventId, const ble_gap_evt_t *gapEvent) {
+        p->setGapEventCallback([&](const uint16_t eventId, const ble_gap_evt_t *gapEvent) {
             switch (eventId)
             {
                 case BLE_GAP_EVT_TIMEOUT:
-                    return true;
+                    return false;
                 case BLE_GAP_EVT_SCAN_REQ_REPORT:
+                {
+                    const auto scanRequestReport = gapEvent->params.scan_req_report;
+                    if (scanRequestReport.adv_handle != p->scratchpad.adv_handle)
+                    {
+                        NRF_LOG(p->role() << " BLE_GAP_EVT_SCAN_REQ_REPORT:  Received "
+                                             "advertisement handle does not match the "
+                                             "one setup with sd_ble_gap_adv_set_configure.");
+                        error = true;
+                    }
+                    else
+                    {
+                        if (scanRequestReport.peer_addr == c->address)
+                        {
+                            scanRequestCountThisCentral += 1;
+                        }
+                        else
+                        {
+                            scanRequestCountOtherCentral += 1;
+                        }
+
+                        NRF_LOG(p->role()
+                                << " SCAN_REQ_REPORT count, this: " << scanRequestCountThisCentral
+                                << ", other: " << scanRequestCountOtherCentral);
+                    }
+                }
+                    return true;
                 case BLE_GAP_EVT_ADV_SET_TERMINATED:
+                {
+                    const auto setTerminated = gapEvent->params.adv_set_terminated;
+                    if (setTerminated.adv_handle != p->scratchpad.adv_handle)
+                    {
+                        NRF_LOG(p->role() << " BLE_GAP_EVT_ADV_SET_TERMINATED: Received "
+                                             "advertisement handle does not match the "
+                                             "one setup with sd_ble_gap_adv_set_configure.");
+                        error = true;
+                    }
+                    else
+                    {
+                        if (setTerminated.num_completed_adv_events != maxLengthOfAdvData)
+                        {
+                            NRF_LOG(p->role()
+                                    << " BLE_GAP_EVT_ADV_SET_TERMINATED: Number of completed "
+                                       "advertisement events does not match max_adv_evts set in "
+                                       "sd_ble_gap_adv_set_configure.");
+                            error = true;
+                        }
+                        else
+                        {
+                            if (setTerminated.reason !=
+                                BLE_GAP_EVT_ADV_SET_TERMINATED_REASON_LIMIT_REACHED)
+                            {
+                                NRF_LOG(p->role()
+                                        << " BLE_GAP_EVT_ADV_SET_TERMINATED: Limit reason was not "
+                                           "LIMIT_REACHED which it should be.");
+                                error = true;
+                            }
+                            else
+                            {
+                                std::vector<uint8_t> manufacturerSpecificData;
+                                const auto advReport = setTerminated.adv_data;
+
+                                std::vector<uint8_t> advData;
+                                const auto data       = advReport.adv_data.p_data;
+                                const auto dataLength = advReport.adv_data.len;
+                                advData.assign(data, data + dataLength);
+
+                                if (scanResponse != advData)
+                                {
+                                    NRF_LOG(p->role()
+                                            << " BLE_GAP_EVT_ADV_SET_TERMINATED: Advertisement "
+                                               "buffers set in sd_ble_gap_adv_set_configure does "
+                                               "not match.");
+                                    error = true;
+                                }
+                            }
+                        }
+                    }
+                }
+
                     return true;
                 default:
                     return false;
@@ -166,6 +288,22 @@ TEST_CASE("test_advertising_api")
             return true;
         });
 
+        c->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+            if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+                code == PKT_UNEXPECTED)
+            {
+                error = true;
+            }
+        });
+
+        p->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+            if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+                code == PKT_UNEXPECTED)
+            {
+                error = true;
+            }
+        });
+
         // Open the adapters
         REQUIRE(c->open() == NRF_SUCCESS);
         REQUIRE(p->open() == NRF_SUCCESS);
@@ -173,36 +311,25 @@ TEST_CASE("test_advertising_api")
         REQUIRE(c->configure() == NRF_SUCCESS);
         REQUIRE(p->configure() == NRF_SUCCESS);
 
-        // Create advertising data and scan response data
-        std::vector<uint8_t> advertising;
-
-        std::vector<uint8_t> scanResponse;
-        std::vector<uint8_t> randomData;
-        testutil::appendRandomData(randomData,
-                                   maxLengthOfAdvData - 2 /* length and AD type */);
-
-        scanResponse.reserve(maxLengthOfAdvData);
-        testutil::appendManufacturerSpecificData(scanResponse, randomData, true);
-
-        REQUIRE(p->setupAdvertising({},    // advertising data
-                                    scanResponse,      // scan response data
-                                    40,                // interval
-                                    0,                 // duration
-                                    false,             // connectable
-                                    true,              // extended
-                                    true,             // scan_req_notification
-                                    0,                 // set_id
-                                    BLE_GAP_PHY_1MBPS, // primary phy
-                                    BLE_GAP_PHY_2MBPS, // secondary phy
-                                    0,                 // filter policy
-                                    0                  // max_adv_events
+        REQUIRE(p->setupAdvertising({},                       // advertising data
+                                    scanResponse,             // scan response data
+                                    40,                       // interval
+                                    0,                        // duration
+                                    false,                    // connectable
+                                    true,                     // extended
+                                    true,                     // scan_req_notification
+                                    advertisementSetId,       // set_id
+                                    BLE_GAP_PHY_1MBPS,        // primary phy
+                                    BLE_GAP_PHY_2MBPS,        // secondary phy
+                                    0,                        // filter policy
+                                    maxNumberOfAdvertisements // max_adv_events
                                     ) == NRF_SUCCESS);
         REQUIRE(p->startAdvertising() == NRF_SUCCESS);
 
         REQUIRE(c->startScan(false, true, false) == NRF_SUCCESS);
 
         // Wait for the test to complete
-        std::this_thread::sleep_for(std::chrono::seconds(5));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
 
         REQUIRE(error == false);
 

--- a/test/softdevice_api/test_advertising_api.cpp
+++ b/test/softdevice_api/test_advertising_api.cpp
@@ -176,27 +176,13 @@ TEST_CASE("test_advertising_api")
         // Create advertising data and scan response data
         std::vector<uint8_t> advertising;
 
-#if 1
-        testutil::appendAdvertisementFlags(advertising, BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
-        testutil::appendAdvertisingName(advertising, peripheralAdvName);
-
         std::vector<uint8_t> scanResponse;
-        std::vector<uint8_t> scanResponseData;
-        testutil::appendRandomData(scanResponseData,
+        std::vector<uint8_t> randomData;
+        testutil::appendRandomData(randomData,
                                    maxLengthOfAdvData - 2 /* length and AD type */);
 
-        scanResponse.reserve(scanResponseData.size() + 2);
-        scanResponse.push_back(
-            static_cast<uint8_t>(scanResponseData.size() + 1)); // Data + advertisement type
-        scanResponse.push_back(BLE_GAP_AD_TYPE_MANUFACTURER_SPECIFIC_DATA);
-        std::copy(scanResponseData.begin(), scanResponseData.end(),
-                  std::back_inserter(scanResponse));
-#else
-        testutil::appendAdvertisementFlags(advertising, BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
-        testutil::appendAdvertisingName(advertising, "12345");
-        std::vector<uint8_t> scanResponse;
-        testutil::appendManufacturerSpecificData(scanResponse, {1,2,3,4});
-#endif
+        scanResponse.reserve(maxLengthOfAdvData);
+        testutil::appendManufacturerSpecificData(scanResponse, randomData, true);
 
         REQUIRE(p->setupAdvertising({},    // advertising data
                                     scanResponse,      // scan response data
@@ -213,7 +199,7 @@ TEST_CASE("test_advertising_api")
                                     ) == NRF_SUCCESS);
         REQUIRE(p->startAdvertising() == NRF_SUCCESS);
 
-        REQUIRE(c->startScan() == NRF_SUCCESS);
+        REQUIRE(c->startScan(false, true, false) == NRF_SUCCESS);
 
         // Wait for the test to complete
         std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/test/softdevice_api/test_issue_gh_112.cpp
+++ b/test/softdevice_api/test_issue_gh_112.cpp
@@ -206,7 +206,7 @@ TEST_CASE("test_issue_gh_112")
                 case BLE_GAP_EVT_DISCONNECTED:
                     return true;
                 case BLE_GAP_EVT_ADV_REPORT:
-                    if (testutil::findAdvName(&(gapEvent->params.adv_report), peripheralAdvName))
+                    if (testutil::findAdvName(gapEvent->params.adv_report, peripheralAdvName))
                     {
                         if (!c->scratchpad.connection_in_progress)
                         {

--- a/test/softdevice_api/test_security.cpp
+++ b/test/softdevice_api/test_security.cpp
@@ -229,7 +229,7 @@ TEST_CASE("test_security")
                 case BLE_GAP_EVT_DISCONNECTED:
                     return true;
                 case BLE_GAP_EVT_ADV_REPORT:
-                    if (testutil::findAdvName(&(gapEvent->params.adv_report), peripheralAdvName))
+                    if (testutil::findAdvName(gapEvent->params.adv_report, peripheralAdvName))
                     {
                         if (!c->scratchpad.connection_in_progress)
                         {


### PR DESCRIPTION
Add extended advertising API tests

* Add tests for extended advertising. Test fails because of a bug in the connectivity firmware or SDK code when decoding BLE_GAP_EVT_ADV_SET_TERMINATED.  Issue has been filed with the SDK team.
* Add status callback for packet decode errors to enable detection of this in tests
