### PR TITLE
Add sleep after open

### DIFF
--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -129,7 +129,7 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
         // The 200ms wait time is based on testing with PCA10028, PCA10031 and PCA10040.
         // All of these devices use the Segger OB which at the time of testing has firmware version
         // "J-Link OB-SAM3U128-V2-NordicSemi compiled Jan 12 2018 16:05:20"
-        // std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
         const auto baudRate      = uartSettingsBoost.getBoostBaudRate();
         const auto flowControl   = uartSettingsBoost.getBoostFlowControl();


### PR DESCRIPTION
We have received reports that removing the sleep
after open creates issues on older Linux kernels.

This commit reintroduce a sleep of 200ms before
starting to communicate with the SEGGER OB.