### PR TITLE
Fix nRF52840 open close reset issue

### DIFF
--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_81c7e01/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_fdc124d/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_fdc124d/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -11,10 +11,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -41,10 +41,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..b43a740 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -59,6 +59,15 @@ static ble_data_t m_scan_data = {0};
  #endif
  ser_ble_gap_app_keyset_t m_app_keys_table[SER_MAX_CONNECTIONS];
@@ -61,10 +61,10 @@ index cb0bd94..b43a740 100644
  uint32_t app_ble_gap_sec_context_create(uint16_t conn_handle, uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..bce737d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -69,6 +69,8 @@ typedef struct
    ble_gap_sec_keyset_t   keyset;         /**< Keyset structure, see @ref ble_gap_sec_keyset_t.*/
  } ser_ble_gap_app_keyset_t;
@@ -74,10 +74,10 @@ index 58a0870..bce737d 100644
  /**@brief Allocates the instance in m_app_keys_table[] for storage of encryption keys.
   *
   * @param[in]     conn_handle         conn_handle
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -90,10 +90,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_81c7e01/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_fdc124d/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -116,10 +116,21 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_81c7e01/components/serialization/common/ser_config.h
-index 2e6d502..83d3ee9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_fdc124d/components/serialization/common/ser_config.h
+index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/ser_config.h
+@@ -66,8 +66,8 @@ extern "C" {
+ 
+ /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
+  *  packet length). */
+-#define SER_HAL_TRANSPORT_APP_TO_CONN_MAX_PKT_SIZE    (512UL)
+-#define SER_HAL_TRANSPORT_CONN_TO_APP_MAX_PKT_SIZE    (512UL)
++#define SER_HAL_TRANSPORT_APP_TO_CONN_MAX_PKT_SIZE    (768UL)
++#define SER_HAL_TRANSPORT_CONN_TO_APP_MAX_PKT_SIZE    (768UL)
+ 
+ #define SER_HAL_TRANSPORT_MAX_PKT_SIZE ((SER_HAL_TRANSPORT_APP_TO_CONN_MAX_PKT_SIZE) >= \
+                                         (SER_HAL_TRANSPORT_CONN_TO_APP_MAX_PKT_SIZE)    \
 @@ -99,7 +99,7 @@ extern "C" {
  
  /** UART transmission parameters */
@@ -139,10 +150,10 @@ index 2e6d502..83d3ee9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_81c7e01/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_fdc124d/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -186,11 +197,28 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_hal_transport.c
-index 9bcc818..8ed82a7 100644
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_hal_transport.c
+index 9bcc818..bcbfb44 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_hal_transport.c
-@@ -297,6 +297,12 @@ static void phy_events_handler(ser_phy_evt_t phy_event)
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_hal_transport.c
+@@ -44,7 +44,7 @@
+ #include "ser_config.h"
+ #include "ser_phy.h"
+ #include "ser_hal_transport.h"
+-
++#include "app_scheduler.h"
+ #define NRF_LOG_MODULE_NAME ser_hal_transport
+ #if SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED
+     #define NRF_LOG_LEVEL       SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL
+@@ -276,6 +276,7 @@ static void phy_events_handler(ser_phy_evt_t phy_event)
+                 m_tx_state = HAL_TRANSP_TX_STATE_TRANSMITTED;
+                 err_code   = ser_hal_transport_tx_pkt_free(phy_event.evt_params.hw_error.p_buffer);
+                 APP_ERROR_CHECK(err_code);
++                app_sched_resume();
+                 /* An event to an upper layer that a packet has been transmitted. */
+             }
+             else if (HAL_TRANSP_RX_STATE_RECEIVING == m_rx_state)
+@@ -297,6 +298,12 @@ static void phy_events_handler(ser_phy_evt_t phy_event)
      }
  }
  
@@ -203,10 +231,10 @@ index 9bcc818..8ed82a7 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -216,10 +244,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -235,10 +263,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-index 20e1eef..18ed469 100644
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -257,7 +285,18 @@ index 20e1eef..18ed469 100644
  #define NRF_LOG_MODULE_NAME sphy_hci
  #include "nrf_log.h"
  NRF_LOG_MODULE_REGISTER();
-@@ -191,6 +202,7 @@ _static uint8_t m_tx_ack_packet[PKT_HDR_SIZE];
+@@ -93,6 +104,10 @@ NRF_LOG_MODULE_REGISTER();
+ #define HCI_LINK_CONTROL_TIMEOUT     1u                                                /**< Default link control timeout. */
+ #endif  /* HCI_LINK_CONTROL */
+ 
++#define PACKET_TYPE_STR(type)\
++    ((type == PKT_TYPE_ACK) ? "ACK" :\
++    ((type ==PKT_TYPE_LINK_CONTROL) ? "Link Control" : \
++    ((type ==PKT_TYPE_VENDOR_SPECIFIC) ? "Vendor Specific" : "Reset")))
+ 
+ #define RETRANSMISSION_TIMEOUT_IN_TICKS (APP_TIMER_TICKS(RETRANSMISSION_TIMEOUT_IN_ms)) /**< Retransmission timeout for application packet in units of timer ticks. */
+ #define MAX_RETRY_COUNT                 5                                      /**< Max retransmission retry count for application packets. */
+@@ -191,6 +206,7 @@ _static uint8_t m_tx_ack_packet[PKT_HDR_SIZE];
  #ifdef HCI_LINK_CONTROL
  _static uint8_t m_tx_link_control_header[PKT_HDR_SIZE];
  _static uint8_t m_tx_link_control_payload[HCI_PKT_CONFIG_SIZE - PKT_HDR_SIZE];
@@ -265,7 +304,21 @@ index 20e1eef..18ed469 100644
  #endif /* HCI_LINK_CONTROL */
  
  _static uint32_t m_packet_ack_number; // Sequence number counter of the packet expected to be received
-@@ -739,7 +751,6 @@ static void error_callback(void)
+@@ -664,6 +680,7 @@ static void ack_transmit(void)
+     pkt_header.num_of_bytes = PKT_HDR_SIZE;
+     DEBUG_EVT_SLIP_ACK_TX(0);
+     err_code = ser_phy_hci_slip_tx_pkt_send(&pkt_header, NULL, NULL);
++    NRF_LOG_DEBUG("Start sending ACK.");
+     ser_phy_hci_assert(err_code == NRF_SUCCESS);
+ 
+     return;
+@@ -734,12 +751,12 @@ static void error_callback(void)
+ 
+     DEBUG_EVT_HCI_PHY_EVT_TX_ERROR(0);
+ 
++    NRF_LOG_DEBUG("no ack");
+     event.evt_type = SER_PHY_EVT_HW_ERROR;
+     event.evt_params.hw_error.p_buffer = m_p_tx_payload;
      ser_phy_event_callback(event);
  }
  
@@ -273,11 +326,34 @@ index 20e1eef..18ed469 100644
  static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
  {
      hci_evt_t event;
-@@ -798,7 +809,12 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
+@@ -748,7 +765,7 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
+ 
+     if ( p_event->evt_type == SER_PHY_HCI_SLIP_EVT_PKT_SENT )
+     {
+-        NRF_LOG_DEBUG("EVT_PKT_SENT");
++        NRF_LOG_DEBUG("EVT:Tx packet sent.");
+ 
+         DEBUG_EVT_SLIP_PACKET_TXED(0);
+         event.evt_source                    = HCI_SLIP_EVT;
+@@ -764,7 +781,7 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
+     }
+     else if ( p_event->evt_type == SER_PHY_HCI_SLIP_EVT_ACK_SENT )
+     {
+-        NRF_LOG_DEBUG("EVT_ACK_SENT");
++        NRF_LOG_DEBUG("EVT:ACK sent.");
+ 
+         DEBUG_EVT_SLIP_ACK_TXED(0);
+         event.evt_source                    = HCI_SLIP_EVT;
+@@ -793,12 +810,16 @@ static void hci_slip_event_handler(ser_phy_hci_slip_evt_t * p_event)
+             event.evt.ser_phy_slip_evt.evt_params.received_pkt.p_buffer,
+             event.evt.ser_phy_slip_evt.evt_params.received_pkt.num_of_bytes);
+ 
+-        NRF_LOG_DEBUG("EVT_PKT_RECEIVED 0x%X/%u", packet_type,
++        NRF_LOG_DEBUG("EVT:RX %s packet (length:%u)", PACKET_TYPE_STR(packet_type),
+             p_event->evt_params.received_pkt.num_of_bytes);
  
          if (packet_type == PKT_TYPE_RESET)
          {
-+            NRF_LOG_DEBUG("PKT_TYPE_RESET");
 +#if defined(SER_CONNECTIVITY) && defined(SER_PHY_HCI_USB_CDC)
 +            (void)soft_reset_trigger();
 +#else
@@ -286,12 +362,45 @@ index 20e1eef..18ed469 100644
          }
          else if (packet_type == PKT_TYPE_ACK )
          {
-@@ -1422,14 +1438,23 @@ static void hci_link_control_event_handler(hci_evt_t * p_event)
+@@ -892,6 +913,7 @@ static void hci_pkt_send(void)
+     pkt_crc.num_of_bytes     = PKT_CRC_SIZE;
+     DEBUG_EVT_SLIP_PACKET_TX(0);
+     err_code = ser_phy_hci_slip_tx_pkt_send(&pkt_header, &pkt_payload, &pkt_crc);
++    NRF_LOG_DEBUG("Started TX packet (payload %d).", m_tx_payload_length);
+     ser_phy_hci_assert(err_code == NRF_SUCCESS);
+ 
+     return;
+@@ -1055,6 +1077,7 @@ static void hci_tx_fsm_event_process(hci_evt_t * p_event)
+                 // m_tx_retx_counter++; // global retransmissions counter
+                 if (m_tx_retry_count)
+                 {
++                    NRF_LOG_DEBUG("Timeout, no ACK. Retrying tx packet.");
+                     hci_pkt_send();
+                     DEBUG_HCI_RETX(0);
+                     m_hci_tx_fsm_state = HCI_TX_STATE_WAIT_FOR_ACK_OR_TX_END;
+@@ -1063,6 +1086,7 @@ static void hci_tx_fsm_event_process(hci_evt_t * p_event)
+                 {
+                     error_callback();
+                     m_hci_tx_fsm_state = HCI_TX_STATE_SEND;
++                    NRF_LOG_WARNING("Timeout, no ACK. Dropping.");
+                 }
+             }
+             break;
+@@ -1414,6 +1438,7 @@ static void hci_link_control_event_handler(hci_evt_t * p_event)
+                         m_hci_rx_fsm_state  = HCI_RX_STATE_DISABLE;
+                         m_hci_other_side_active = false;
+                     }
++                    NRF_LOG_DEBUG("Link control. Sync received, sending Sync Response.");
+                     hci_link_control_pkt_send();
+                     hci_timeout_setup(HCI_LINK_CONTROL_TIMEOUT); // Need to trigger transmitting SYNC messages
+                     break;
+@@ -1422,14 +1447,24 @@ static void hci_link_control_event_handler(hci_evt_t * p_event)
                      {
                          m_hci_mode                  = HCI_MODE_INITIALIZED;
                          m_hci_link_control_next_pkt = HCI_PKT_CONFIG;
 +                        m_cfg_sent = false;
                      }
++                    NRF_LOG_DEBUG("Link control. Sync Resposnse recieved.");
                      break;
                  case HCI_PKT_CONFIG:
                      if (m_hci_mode != HCI_MODE_UNINITIALIZED)
@@ -312,15 +421,7 @@ index 20e1eef..18ed469 100644
                      }
                      break;
                  case HCI_PKT_CONFIG_RSP:
-@@ -1453,6 +1478,7 @@ static void hci_link_control_event_handler(hci_evt_t * p_event)
-             break;
- 
-         case HCI_TIMER_EVT:
-+            NRF_LOG_DEBUG("Timer evt");
-             /* Send one of the Link Control packets if in Unintialized or Initialized state */
-             CRITICAL_REGION_ENTER();
-             switch (m_hci_mode)
-@@ -1466,6 +1492,7 @@ static void hci_link_control_event_handler(hci_evt_t * p_event)
+@@ -1466,6 +1501,7 @@ static void hci_link_control_event_handler(hci_evt_t * p_event)
                  case HCI_MODE_INITIALIZED:
                      m_hci_link_control_next_pkt = HCI_PKT_CONFIG;
                      hci_link_control_pkt_send();
@@ -328,7 +429,15 @@ index 20e1eef..18ed469 100644
                      hci_timeout_setup(HCI_LINK_CONTROL_TIMEOUT);
                      break;
                  case HCI_MODE_ACTIVE:
-@@ -1573,14 +1600,10 @@ uint32_t ser_phy_tx_pkt_send(const uint8_t * p_buffer, uint16_t num_of_bytes)
+@@ -1548,6 +1584,7 @@ uint32_t ser_phy_rx_buf_set(uint8_t * p_buffer)
+ /* ser_phy API function */
+ uint32_t ser_phy_tx_pkt_send(const uint8_t * p_buffer, uint16_t num_of_bytes)
+ {
++    NRF_LOG_DEBUG("TX request (%d bytes)", num_of_bytes);
+     uint32_t  status = NRF_SUCCESS;
+     hci_evt_t event;
+ 
+@@ -1573,14 +1610,10 @@ uint32_t ser_phy_tx_pkt_send(const uint8_t * p_buffer, uint16_t num_of_bytes)
      return status;
  }
  
@@ -345,7 +454,7 @@ index 20e1eef..18ed469 100644
  
      if (err_code != NRF_SUCCESS)
      {
-@@ -1593,7 +1616,6 @@ static uint32_t  hci_timer_init(void)
+@@ -1593,7 +1626,6 @@ static uint32_t  hci_timer_init(void)
      {
          return NRF_ERROR_INTERNAL;
      }
@@ -353,7 +462,7 @@ index 20e1eef..18ed469 100644
  #else
  
      // Configure TIMER for compare[1] event
-@@ -1603,6 +1625,7 @@ static uint32_t  hci_timer_init(void)
+@@ -1603,6 +1635,7 @@ static uint32_t  hci_timer_init(void)
  
      // Clear TIMER
      HCI_TIMER->TASKS_CLEAR = 1;
@@ -361,7 +470,7 @@ index 20e1eef..18ed469 100644
  
      // Enable interrupt
      HCI_TIMER->INTENCLR = 0xFFFFFFFF;
-@@ -1613,11 +1636,51 @@ static uint32_t  hci_timer_init(void)
+@@ -1613,11 +1646,51 @@ static uint32_t  hci_timer_init(void)
      NVIC_EnableIRQ(HCI_TIMER_IRQn);
  
  #endif
@@ -414,7 +523,7 @@ index 20e1eef..18ed469 100644
  
  /* ser_phy API function */
  uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
-@@ -1634,6 +1697,8 @@ uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
+@@ -1634,6 +1707,8 @@ uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
          return NRF_ERROR_NULL;
      }
  
@@ -423,7 +532,7 @@ index 20e1eef..18ed469 100644
      err_code = hci_timer_init();
  
      if (err_code != NRF_SUCCESS)
-@@ -1641,9 +1706,6 @@ uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
+@@ -1641,9 +1716,6 @@ uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
          return NRF_ERROR_INTERNAL;
      }
  
@@ -433,7 +542,7 @@ index 20e1eef..18ed469 100644
      err_code = ser_phy_hci_slip_open(hci_slip_event_handler);
  
      if (err_code != NRF_SUCCESS)
-@@ -1653,18 +1715,7 @@ uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
+@@ -1653,18 +1725,7 @@ uint32_t ser_phy_open(ser_phy_events_handler_t events_handler)
  
      if (err_code == NRF_SUCCESS)
      {
@@ -453,10 +562,10 @@ index 20e1eef..18ed469 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -466,10 +575,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -554,10 +663,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -669,10 +778,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -691,10 +800,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -712,10 +821,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..a925373 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -55,6 +55,22 @@ typedef struct
  ble_data_item_t m_ble_data_pool[8];
  
@@ -739,10 +848,10 @@ index 3f8c122..a925373 100644
  uint32_t conn_ble_gap_sec_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..9863b84 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -79,6 +79,9 @@ typedef struct
    ble_gap_lesc_p256_pk_t  pk_peer;         /**< Peer Public key, see @ref ble_gap_lesc_p256_pk_t. */
  } ser_ble_gap_conn_keyset_t;
@@ -753,10 +862,10 @@ index 875de9a..9863b84 100644
  /**@brief Allocates instance in m_conn_keys_table[] for storage of encryption keys.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -774,10 +883,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -788,10 +897,50 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_handlers.c
-index f656ee2..ae3a5f2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_event_encoder.c
+index d784754..7d8e424 100644
+--- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_event_encoder.c
+@@ -46,6 +46,7 @@
+ #include "ser_hal_transport.h"
+ #include "ser_conn_event_encoder.h"
+ #include "ser_conn_handlers.h"
++#include "nrf_log.h"
+ #ifdef BLE_STACK_SUPPORT_REQD
+ #include "ble_conn.h"
+ #endif // BLE_STACK_SUPPORT_REQD
+@@ -55,8 +56,15 @@
+ #endif // ANT_STACK_SUPPORT_REQD
+ 
+ #ifdef BLE_STACK_SUPPORT_REQD
++extern bool m_reset_ongoing;
+ void ser_conn_ble_event_encoder(void * p_event_data, uint16_t event_size)
+ {
++    if (m_reset_ongoing)
++    {
++        NRF_LOG_INFO("Dropping BLE event (during reset).");
++        return;
++    }
++
+     if (NULL == p_event_data)
+     {
+         APP_ERROR_CHECK(NRF_ERROR_NULL);
+@@ -100,7 +108,10 @@ void ser_conn_ble_event_encoder(void * p_event_data, uint16_t event_size)
+          * scheduler queue. In result the next event reserves the TX buffer before the current
+          * packet is sent. If in meantime a command arrives a command response cannot be sent in
+          * result. Pausing the scheduler temporary prevents processing a next event. */
+-        app_sched_pause();
++        if (!m_reset_ongoing) 
++        {
++            app_sched_pause();
++        }
+     }
+     else
+     {
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_handlers.c
+index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -815,16 +964,25 @@ index f656ee2..ae3a5f2 100644
  
  NRF_SDH_BLE_OBSERVER(m_ble_observer, 0, ser_conn_ble_event_handle, NULL);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_handlers.h
-index cc5777a..06585b5 100644
+@@ -171,7 +180,7 @@ void ser_conn_ble_event_handle(ble_evt_t const * p_ble_evt, void * p_context)
+                                    ser_conn_ble_event_encoder);
+     APP_ERROR_CHECK(err_code);
+     uint16_t free_space = app_sched_queue_space_get();
+-    if (!free_space)
++    if (free_space < (SER_CONN_SCHED_QUEUE_SIZE/4))
+     {
+         // Queue is full. Do not pull new events.
+         nrf_sdh_suspend();
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_handlers.h
+index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
  /** Maximum number of events in the application scheduler queue. */
 -#define SER_CONN_SCHED_QUEUE_SIZE             4u
-+#define SER_CONN_SCHED_QUEUE_SIZE             10u
++#define SER_CONN_SCHED_QUEUE_SIZE             16u
  
  /** Maximum size of events data in the application scheduler queue aligned to 32 bits - this is
   *  size of the buffers of the SoftDevice handler, which stores events pulled from the SoftDevice.
@@ -838,10 +996,10 @@ index cc5777a..06585b5 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -854,11 +1012,11 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-index fcf4235..69de580 100644
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-@@ -39,9 +39,82 @@
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+@@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
  #include "ser_conn_reset_cmd_decoder.h"
@@ -875,14 +1033,19 @@ index fcf4235..69de580 100644
 -void ser_conn_reset_command_process()
 +APP_TIMER_DEF(reset_timer);
 +
-+static bool m_reset_ongoing;
++bool m_reset_ongoing;
 +static bool m_timer_created;
++
++bool rst_req;
 +
 +extern void ser_phy_hci_reset(void);
 +
 +static void sd_start_from_app_sched(void * p_event_data, uint16_t event_size)
 +{
++
++    NRF_LOG_DEBUG("sdh enable request.");
 +    nrf_sdh_enable_request();
++    rst_req = false;
 +    m_reset_ongoing = false;
 +}
 +
@@ -890,9 +1053,12 @@ index fcf4235..69de580 100644
 +{
 +    if (state == NRF_SDH_EVT_STATE_DISABLED)
 +    {
-+        NRF_LOG_DEBUG("sd disabled scheduling request");
-+        app_sched_resume();
++        rst_req = true;
 +        APP_ERROR_CHECK(app_sched_event_put(NULL, 0, sd_start_from_app_sched));
++        app_sched_resume();
++    } else if (state == NRF_SDH_EVT_STATE_ENABLED)
++    {
++	   NRF_LOG_DEBUG("sdh enabled.");
 +    }
 +}
 +
@@ -902,6 +1068,7 @@ index fcf4235..69de580 100644
 +
 +void timer_handler(void * p_ctx)
 +{
++     NRF_LOG_DEBUG("transport reset");
 +    ser_hal_transport_reset();
 +    ser_phy_hci_reset();
 +    ser_phy_hci_slip_reset();
@@ -916,6 +1083,7 @@ index fcf4235..69de580 100644
 +
 +    m_reset_ongoing = true;
 +
++    NRF_LOG_INFO("reset ongoing");
 +    if (!m_timer_created)
 +    {
 +	    (void)app_timer_create(&reset_timer, APP_TIMER_MODE_SINGLE_SHOT, timer_handler);
@@ -944,10 +1112,10 @@ index fcf4235..69de580 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_fdc124d/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -968,10 +1136,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_81c7e01/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_fdc124d/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -998,10 +1166,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_81c7e01/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_fdc124d/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -1078,10 +1246,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -1108,11 +1276,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -1795,11 +1963,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -1891,11 +2059,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -3814,11 +3982,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4040,11 +4208,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4706,11 +4874,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5490,11 +5658,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5627,11 +5795,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5835,11 +6003,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5979,11 +6147,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6198,11 +6366,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6421,11 +6589,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6514,11 +6682,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6587,11 +6755,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6675,11 +6843,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7166,11 +7334,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -7200,11 +7368,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7537,11 +7705,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8449,11 +8617,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8543,11 +8711,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -10468,11 +10636,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11148,11 +11316,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11700,20 +11868,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -19409,11 +19577,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -19448,11 +19616,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -19490,11 +19658,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -20124,11 +20292,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -20221,11 +20389,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -22416,11 +22584,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -22650,11 +22818,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23363,11 +23531,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24210,11 +24378,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -24351,11 +24519,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24864,11 +25032,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25026,11 +25194,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25247,11 +25415,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -25494,11 +25662,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -25590,11 +25758,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25666,11 +25834,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25757,11 +25925,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -26249,11 +26417,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -26283,11 +26451,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -26646,11 +26814,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27586,11 +27754,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -27682,20 +27850,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -35540,11 +35708,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -35579,11 +35747,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_fdc124d/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -35621,10 +35789,10 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/main.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/main.c
 index fc7996c..a56e94c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/main.c
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/main.c
 @@ -57,13 +57,13 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
@@ -35797,14 +35965,16 @@ index fc7996c..a56e94c 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index 611a3b6..0831dda 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index 611a3b6..0a1645f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-@@ -7,10 +7,17 @@ MEMORY
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
+ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0x5a000
-   RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
+-  RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
++  RAM (rwx) :  ORIGIN = 0x2000a8a8, LENGTH = 0x5758
 +  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
  }
  
@@ -35819,36 +35989,10 @@ index 611a3b6..0831dda 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..dfd12e6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -4133,132 +4133,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -35982,34 +36126,25 @@ index c5caa64..dfd12e6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-index 7eccb28..19f0bbb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-@@ -28,7 +28,7 @@
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+@@ -27,8 +27,8 @@
+       linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
-       linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
+-      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
 -      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000a8a8;RAM_SIZE=0x5758"
 +      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000;connectivity_version_info RX 0x50000 0x18"
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36018,14 +36153,16 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..13d8c11 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-@@ -7,10 +7,17 @@ MEMORY
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
+ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0x5a000
-   RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
+-  RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
++  RAM (rwx) :  ORIGIN = 0x2000a8a8, LENGTH = 0x5758
 +  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
  }
  
@@ -36040,36 +36177,10 @@ index f67446c..13d8c11 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..ada8ae6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -4339,132 +4339,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -36203,34 +36314,25 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-index 918459a..c33b4a8 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-@@ -28,7 +28,7 @@
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+@@ -27,8 +27,8 @@
+       linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
-       linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
+-      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
 -      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000a8a8;RAM_SIZE=0x5758"
 +      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000;connectivity_version_info RX 0x50000 0x18"
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36239,14 +36341,16 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..13d8c11 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-@@ -7,10 +7,17 @@ MEMORY
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
+ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0x5a000
-   RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
+-  RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
++  RAM (rwx) :  ORIGIN = 0x2000a8a8, LENGTH = 0x5758
 +  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
  }
  
@@ -36261,36 +36365,10 @@ index f67446c..13d8c11 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..ada8ae6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -4339,132 +4339,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -36424,34 +36502,25 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-index 4f3e9db..8505751 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-@@ -28,7 +28,7 @@
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+@@ -27,8 +27,8 @@
+       linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
-       linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
+-      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
 -      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000a8a8;RAM_SIZE=0x5758"
 +      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000;connectivity_version_info RX 0x50000 0x18"
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36460,14 +36529,16 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..13d8c11 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-@@ -7,10 +7,17 @@ MEMORY
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
+ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0x5a000
-   RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
+-  RAM (rwx) :  ORIGIN = 0x2000b8a8, LENGTH = 0x4758
++  RAM (rwx) :  ORIGIN = 0x2000a8a8, LENGTH = 0x5758
 +  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
  }
  
@@ -36482,36 +36553,10 @@ index f67446c..13d8c11 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..dcef5bd 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -4017,132 +4017,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -36645,34 +36690,25 @@ index 17cad13..dcef5bd 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-index 400fec8..d9ccddf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-@@ -28,7 +28,7 @@
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+@@ -27,8 +27,8 @@
+       linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
-       linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
+-      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000b8a8;RAM_SIZE=0x4758"
 -      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x26000;FLASH_SIZE=0x5a000;RAM_START=0x2000a8a8;RAM_SIZE=0x5758"
 +      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000;connectivity_version_info RX 0x50000 0x18"
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36681,11 +36717,11 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -36949,11 +36985,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..6c6f018
+index 0000000..7110f07
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36963,7 +36999,7 @@ index 0000000..6c6f018
 +MEMORY
 +{
 +  FLASH (rx) : ORIGIN = 0x1f000, LENGTH = 0x61000
-+  RAM (rwx) :  ORIGIN = 0x2000b9c0, LENGTH = 0x4640
++  RAM (rwx) :  ORIGIN = 0x2000a9c0, LENGTH = 0x5640
 +  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
 +}
 +
@@ -37033,6 +37069,12 @@ index 0000000..6c6f018
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -37045,12 +37087,6 @@ index 0000000..6c6f018
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -37061,11 +37097,11 @@ index 0000000..6c6f018
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..dfd12e6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4428 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -41495,11 +41531,11 @@ index 0000000..dfd12e6
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
-index 0000000..e4df930
+index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -41530,7 +41566,7 @@ index 0000000..e4df930
 +      linker_printf_width_precision_supported="Yes"
 +      linker_printf_fmt_level="long"
 +      linker_section_placement_file="flash_placement.xml"
-+      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x1f000;FLASH_SIZE=0x61000;RAM_START=0x2000b9c0;RAM_SIZE=0x4640"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x1f000;FLASH_SIZE=0x61000;RAM_START=0x2000a9c0;RAM_SIZE=0x5640"
 +      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000;connectivity_version_info RX 0x50000 0x18"
 +      project_directory=""
 +      project_type="Executable" />
@@ -41655,11 +41691,11 @@ index 0000000..e4df930
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -41669,11 +41705,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -41688,9 +41724,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -41724,11 +41760,11 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
-index 0000000..7e7f3f8
+index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -41982,8 +42018,8 @@ index 0000000..7e7f3f8
 +
 +# Flash softdevice
 +flash_softdevice:
-+	@echo Flashing: s132_nrf52_5.0.0_softdevice.hex
-+	nrfjprog -f nrf52 --program $(SDK_ROOT)/components/softdevice/s132v5/hex/s132_nrf52_5.0.0_softdevice.hex --sectorerase
++	@echo Flashing: s132_nrf52_5.1.0_softdevice.hex
++	nrfjprog -f nrf52 --program $(SDK_ROOT)/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex --sectorerase
 +	nrfjprog -f nrf52 --reset
 +
 +erase:
@@ -41993,11 +42029,11 @@ index 0000000..7e7f3f8
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..f9ac665
+index 0000000..9e0c093
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -42007,7 +42043,7 @@ index 0000000..f9ac665
 +MEMORY
 +{
 +  FLASH (rx) : ORIGIN = 0x23000, LENGTH = 0x5d000
-+  RAM (rwx) :  ORIGIN = 0x2000b380, LENGTH = 0x4c80
++  RAM (rwx) :  ORIGIN = 0x2000a380, LENGTH = 0x5c80
 +  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
 +}
 +
@@ -42077,6 +42113,12 @@ index 0000000..f9ac665
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -42089,12 +42131,6 @@ index 0000000..f9ac665
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -42105,11 +42141,11 @@ index 0000000..f9ac665
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..d464764
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4449 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -46560,11 +46596,11 @@ index 0000000..d464764
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
-index 0000000..5931364
+index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -46589,13 +46625,13 @@ index 0000000..5931364
 +      gcc_entry_point="Reset_Handler"
 +      macros="CMSIS_CONFIG_TOOL=../../../../../../external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar"
 +      debug_register_definition_file="../../../../../../modules/nrfx/mdk/nrf52.svd"
-+      debug_additional_load_file="../../../../../../components/softdevice/s132v5/hex/s132_nrf52_5.0.0_softdevice.hex"
++      debug_additional_load_file="../../../../../../components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex"
 +      debug_start_from_entry_point_symbol="No"
 +      gcc_debugging_level="Level 3"      linker_output_format="hex"
 +      linker_printf_width_precision_supported="Yes"
 +      linker_printf_fmt_level="long"
 +      linker_section_placement_file="flash_placement.xml"
-+      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x23000;FLASH_SIZE=0x5d000;RAM_START=0x2000b380;RAM_SIZE=0x4c80"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x80000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x10000;FLASH_START=0x23000;FLASH_SIZE=0x5d000;RAM_START=0x2000a380;RAM_SIZE=0x5c80"
 +      linker_section_placements_segments="FLASH RX 0x0 0x80000;RAM RWX 0x20000000 0x10000;connectivity_version_info RX 0x50000 0x18"
 +      project_directory=""
 +      project_type="Executable" />
@@ -46721,11 +46757,11 @@ index 0000000..5931364
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -46735,11 +46771,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -46754,9 +46790,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -46790,10 +46826,10 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index e8a3735..9a410b0 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index e8a3735..7b95e77 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -46812,36 +46848,10 @@ index e8a3735..9a410b0 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..b33d1e8 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -3998,132 +3998,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -46975,10 +46985,10 @@ index 6539e77..b33d1e8 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -46988,21 +46998,10 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47011,10 +47010,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..9ce3ba9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47033,36 +47032,10 @@ index 40d23f1..9ce3ba9 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..24057c5 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -4148,132 +4148,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47196,10 +47169,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47209,21 +47182,10 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47232,10 +47194,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..9ce3ba9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47254,36 +47216,10 @@ index 40d23f1..9ce3ba9 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..24057c5 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -4148,132 +4148,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47417,10 +47353,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47430,21 +47366,10 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47453,10 +47378,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..9ce3ba9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47475,36 +47400,10 @@ index 40d23f1..9ce3ba9 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..fce649b 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -3882,132 +3882,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47638,10 +47537,10 @@ index 7b74df4..fce649b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47651,21 +47550,10 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47674,10 +47562,11039 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..6816cb2 100644
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+new file mode 100644
+index 0000000..70d9b8b
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+@@ -0,0 +1,276 @@
++PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
++TARGETS          := nrf52840_xxaa
++OUTPUT_DIRECTORY := _build
++
++SDK_ROOT := ../../../../../..
++PROJ_DIR := ../../..
++
++$(OUTPUT_DIRECTORY)/nrf52840_xxaa.out: \
++  LINKER_SCRIPT  := ble_connectivity_gcc_nrf52.ld
++
++# Source files common to all targets
++SRC_FILES += \
++  $(SDK_ROOT)/modules/nrfx/mdk/gcc_startup_nrf52840.S \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_rtt.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_serial.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_uart.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_default_backends.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_frontend.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_str_formatter.c \
++  $(SDK_ROOT)/components/libraries/util/app_error.c \
++  $(SDK_ROOT)/components/libraries/util/app_error_handler_gcc.c \
++  $(SDK_ROOT)/components/libraries/util/app_error_weak.c \
++  $(SDK_ROOT)/components/libraries/scheduler/app_scheduler.c \
++  $(SDK_ROOT)/components/libraries/timer/app_timer.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
++  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd_core.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd_serial_num.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd_string_desc.c \
++  $(SDK_ROOT)/components/libraries/util/app_util_platform.c \
++  $(SDK_ROOT)/components/libraries/crc16/crc16.c \
++  $(SDK_ROOT)/components/libraries/util/nrf_assert.c \
++  $(SDK_ROOT)/components/libraries/atomic_fifo/nrf_atfifo.c \
++  $(SDK_ROOT)/components/libraries/atomic/nrf_atomic.c \
++  $(SDK_ROOT)/components/libraries/balloc/nrf_balloc.c \
++  $(SDK_ROOT)/external/fprintf/nrf_fprintf.c \
++  $(SDK_ROOT)/external/fprintf/nrf_fprintf_format.c \
++  $(SDK_ROOT)/components/libraries/memobj/nrf_memobj.c \
++  $(SDK_ROOT)/components/libraries/queue/nrf_queue.c \
++  $(SDK_ROOT)/components/libraries/ringbuf/nrf_ringbuf.c \
++  $(SDK_ROOT)/components/libraries/experimental_section_vars/nrf_section_iter.c \
++  $(SDK_ROOT)/components/libraries/strerror/nrf_strerror.c \
++  $(SDK_ROOT)/modules/nrfx/mdk/system_nrf52840.c \
++  $(SDK_ROOT)/components/boards/boards.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/ble_dtm_init.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gatt_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gattc_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gattc_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gattc_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gatts_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gatts_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gatts_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_l2cap_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/ble_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/cond_field_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/conn_ble_l2cap_sdu_pool.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/conn_mw.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gattc.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gatts.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_l2cap.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/conn_mw_nrf_soc.c \
++  $(SDK_ROOT)/components/serialization/connectivity/hal/dtm_uart.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/nrf_soc_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/nrf_soc_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_cmd_decoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_dtm_cmd_decoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_error_handling.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_event_encoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_handlers.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_pkt_decoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c \
++  $(SDK_ROOT)/components/serialization/common/ser_dbg_sd_str.c \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_hal_transport.c \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/ser_phy_hci.c \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c \
++  $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_clock.c \
++  $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_power.c \
++  $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_uart.c \
++  $(SDK_ROOT)/components/drivers_nrf/usbd/nrf_drv_usbd.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
++  $(PROJ_DIR)/main.c \
++  $(SDK_ROOT)/external/segger_rtt/SEGGER_RTT.c \
++  $(SDK_ROOT)/external/segger_rtt/SEGGER_RTT_Syscalls_GCC.c \
++  $(SDK_ROOT)/external/segger_rtt/SEGGER_RTT_printf.c \
++  $(SDK_ROOT)/components/ble/common/ble_advdata.c \
++  $(SDK_ROOT)/components/ble/ble_dtm/ble_dtm.c \
++  $(SDK_ROOT)/components/ble/ble_dtm/ble_dtm_hw_nrf52.c \
++  $(SDK_ROOT)/components/ble/common/ble_srv_common.c \
++  $(SDK_ROOT)/external/utf_converter/utf.c \
++  $(SDK_ROOT)/components/softdevice/common/nrf_sdh.c \
++  $(SDK_ROOT)/components/softdevice/common/nrf_sdh_ble.c \
++  $(SDK_ROOT)/components/softdevice/common/nrf_sdh_soc.c \
++
++# Include folders common to all targets
++INC_FOLDERS += \
++  $(SDK_ROOT)/components \
++  $(SDK_ROOT)/components/serialization/connectivity/hal \
++  $(SDK_ROOT)/modules/nrfx/mdk \
++  $(SDK_ROOT)/components/libraries/scheduler \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers \
++  $(SDK_ROOT)/components/toolchain/cmsis/include \
++  $(SDK_ROOT)/components/libraries/queue \
++  $(SDK_ROOT)/components/libraries/timer \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common \
++  $(SDK_ROOT)/components/serialization/connectivity \
++  $(SDK_ROOT)/components/libraries/strerror \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware \
++  $(SDK_ROOT)/components/libraries/crc16 \
++  $(SDK_ROOT)/components/ble/ble_dtm \
++  $(SDK_ROOT)/components/serialization/common \
++  $(SDK_ROOT)/components/libraries/util \
++  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm \
++  ../config \
++  $(SDK_ROOT)/components/libraries/usbd/class/cdc \
++  $(SDK_ROOT)/components/ble/common \
++  $(SDK_ROOT)/integration/nrfx \
++  $(SDK_ROOT)/components/libraries/balloc \
++  $(SDK_ROOT)/components/drivers_nrf/usbd \
++  $(SDK_ROOT)/components/libraries/ringbuf \
++  $(SDK_ROOT)/modules/nrfx/hal \
++  $(SDK_ROOT)/components/libraries/bsp \
++  $(SDK_ROOT)/components/softdevice/s132v3/headers/nrf52 \
++  $(SDK_ROOT)/components/libraries/log \
++  $(SDK_ROOT)/external/utf_converter \
++  $(SDK_ROOT)/modules/nrfx \
++  $(SDK_ROOT)/components/libraries/experimental_section_vars \
++  $(SDK_ROOT)/integration/nrfx/legacy \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy \
++  $(SDK_ROOT)/components/libraries/usbd \
++  $(SDK_ROOT)/components/libraries/delay \
++  $(SDK_ROOT)/external/segger_rtt \
++  $(SDK_ROOT)/components/libraries/atomic_fifo \
++  $(SDK_ROOT)/components/libraries/atomic \
++  $(SDK_ROOT)/components/boards \
++  $(SDK_ROOT)/components/libraries/memobj \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble \
++  $(SDK_ROOT)/components/softdevice/s132v3/headers \
++  $(SDK_ROOT)/components/serialization/common/transport \
++  $(SDK_ROOT)/components/softdevice/common \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/config \
++  $(SDK_ROOT)/modules/nrfx/drivers/include \
++  $(SDK_ROOT)/external/fprintf \
++  $(SDK_ROOT)/components/libraries/log/src \
++
++# Libraries common to all targets
++LIB_FILES += \
++
++# Optimization flags
++OPT = -Os -g3
++# Uncomment the line below to enable link time optimization
++#OPT += -flto
++
++# C flags common to all targets
++CFLAGS += $(OPT)
++CFLAGS += -DBLE_STACK_SUPPORT_REQD
++CFLAGS += -DBOARD_PCA10056
++CFLAGS += -DBSP_DEFINES_ONLY
++CFLAGS += -DCONFIG_GPIO_AS_PINRESET
++CFLAGS += -DFLOAT_ABI_HARD
++CFLAGS += -DHCI_TIMER2
++CFLAGS += -DNRF52840_XXAA
++CFLAGS += -DNRF_SD_BLE_API_VERSION=3
++CFLAGS += -DS132
++CFLAGS += -DSER_CONNECTIVITY
++CFLAGS += -DSER_PHY_HCI_USB_CDC
++CFLAGS += -DSOFTDEVICE_PRESENT
++CFLAGS += -DSWI_DISABLE0
++CFLAGS += -mcpu=cortex-m4
++CFLAGS += -mthumb -mabi=aapcs
++CFLAGS += -Wall -Werror
++CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
++# keep every function in a separate section, this allows linker to discard unused ones
++CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
++CFLAGS += -fno-builtin -fshort-enums
++
++# C++ flags common to all targets
++CXXFLAGS += $(OPT)
++
++# Assembler flags common to all targets
++ASMFLAGS += -g3
++ASMFLAGS += -mcpu=cortex-m4
++ASMFLAGS += -mthumb -mabi=aapcs
++ASMFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
++ASMFLAGS += -DBLE_STACK_SUPPORT_REQD
++ASMFLAGS += -DBOARD_PCA10056
++ASMFLAGS += -DBSP_DEFINES_ONLY
++ASMFLAGS += -DCONFIG_GPIO_AS_PINRESET
++ASMFLAGS += -DFLOAT_ABI_HARD
++ASMFLAGS += -DHCI_TIMER2
++ASMFLAGS += -DNRF52840_XXAA
++ASMFLAGS += -DNRF_SD_BLE_API_VERSION=3
++ASMFLAGS += -DS132
++ASMFLAGS += -DSER_CONNECTIVITY
++ASMFLAGS += -DSER_PHY_HCI_USB_CDC
++ASMFLAGS += -DSOFTDEVICE_PRESENT
++ASMFLAGS += -DSWI_DISABLE0
++
++# Linker flags
++LDFLAGS += $(OPT)
++LDFLAGS += -mthumb -mabi=aapcs -L$(SDK_ROOT)/modules/nrfx/mdk -T$(LINKER_SCRIPT)
++LDFLAGS += -mcpu=cortex-m4
++LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
++# let linker dump unused sections
++LDFLAGS += -Wl,--gc-sections
++# use newlib in nano version
++LDFLAGS += --specs=nano.specs
++
++nrf52840_xxaa: CFLAGS += -D__HEAP_SIZE=512
++nrf52840_xxaa: CFLAGS += -D__STACK_SIZE=2048
++nrf52840_xxaa: ASMFLAGS += -D__HEAP_SIZE=512
++nrf52840_xxaa: ASMFLAGS += -D__STACK_SIZE=2048
++
++# Add standard libraries at the very end of the linker input, after all objects
++# that may need symbols provided by these libraries.
++LIB_FILES += -lc -lnosys -lm
++
++
++.PHONY: default help
++
++# Default target - first one defined
++default: nrf52840_xxaa
++
++# Print all targets that can be built
++help:
++	@echo following targets are available:
++	@echo		nrf52840_xxaa
++	@echo		flash_softdevice
++	@echo		sdk_config - starting external tool for editing sdk_config.h
++	@echo		flash      - flashing binary
++
++TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
++
++
++include $(TEMPLATE_PATH)/Makefile.common
++
++$(foreach target, $(TARGETS), $(call define_target, $(target)))
++
++.PHONY: flash flash_softdevice erase
++
++# Flash the program
++flash: default
++	@echo Flashing: $(OUTPUT_DIRECTORY)/nrf52840_xxaa.hex
++	nrfjprog -f nrf52 --program $(OUTPUT_DIRECTORY)/nrf52840_xxaa.hex --sectorerase
++	nrfjprog -f nrf52 --reset
++
++# Flash softdevice
++flash_softdevice:
++	@echo Flashing: s132_nrf52_3.0.0_softdevice.hex
++	nrfjprog -f nrf52 --program $(SDK_ROOT)/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex --sectorerase
++	nrfjprog -f nrf52 --reset
++
++erase:
++	nrfjprog -f nrf52 --eraseall
++
++SDK_CONFIG_FILE := ../config/sdk_config.h
++CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
++sdk_config:
++	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+new file mode 100644
+index 0000000..a7a64cd
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -0,0 +1,106 @@
++/* Linker script to configure memory regions. */
++
++SEARCH_DIR(.)
++GROUP(-lgcc -lc -lnosys)
++
++MEMORY
++{
++  FLASH (rx) : ORIGIN = 0x1f000, LENGTH = 0xe1000
++  RAM (rwx) :  ORIGIN = 0x200199c0, LENGTH = 0x26640
++  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
++}
++
++SECTIONS
++{
++  .connectivity_version_info :
++  {
++    PROVIDE(__start_connectivity_version_info = .);
++    KEEP(*(SORT(.connectivity_version_info*)))
++    PROVIDE(__stop_connectivity_version_info = .);
++  } > connectivity_version_info
++}
++
++SECTIONS
++{
++  . = ALIGN(4);
++  .mem_section_dummy_ram :
++  {
++  }
++  .log_dynamic_data :
++  {
++    PROVIDE(__start_log_dynamic_data = .);
++    KEEP(*(SORT(.log_dynamic_data*)))
++    PROVIDE(__stop_log_dynamic_data = .);
++  } > RAM
++  .log_filter_data :
++  {
++    PROVIDE(__start_log_filter_data = .);
++    KEEP(*(SORT(.log_filter_data*)))
++    PROVIDE(__stop_log_filter_data = .);
++  } > RAM
++
++} INSERT AFTER .data;
++
++SECTIONS
++{
++  .mem_section_dummy_rom :
++  {
++  }
++  .sdh_ble_observers :
++  {
++    PROVIDE(__start_sdh_ble_observers = .);
++    KEEP(*(SORT(.sdh_ble_observers*)))
++    PROVIDE(__stop_sdh_ble_observers = .);
++  } > FLASH
++  .sdh_soc_observers :
++  {
++    PROVIDE(__start_sdh_soc_observers = .);
++    KEEP(*(SORT(.sdh_soc_observers*)))
++    PROVIDE(__stop_sdh_soc_observers = .);
++  } > FLASH
++    .nrf_queue :
++  {
++    PROVIDE(__start_nrf_queue = .);
++    KEEP(*(.nrf_queue))
++    PROVIDE(__stop_nrf_queue = .);
++  } > FLASH
++  .log_const_data :
++  {
++    PROVIDE(__start_log_const_data = .);
++    KEEP(*(SORT(.log_const_data*)))
++    PROVIDE(__stop_log_const_data = .);
++  } > FLASH
++    .nrf_balloc :
++  {
++    PROVIDE(__start_nrf_balloc = .);
++    KEEP(*(.nrf_balloc))
++    PROVIDE(__stop_nrf_balloc = .);
++  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
++  .sdh_req_observers :
++  {
++    PROVIDE(__start_sdh_req_observers = .);
++    KEEP(*(SORT(.sdh_req_observers*)))
++    PROVIDE(__stop_sdh_req_observers = .);
++  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
++  .log_backends :
++  {
++    PROVIDE(__start_log_backends = .);
++    KEEP(*(SORT(.log_backends*)))
++    PROVIDE(__stop_log_backends = .);
++  } > FLASH
++
++} INSERT AFTER .text
++
++INCLUDE "nrf_common.ld"
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+new file mode 100644
+index 0000000..0bcfe3e
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+@@ -0,0 +1,4862 @@
++/**
++ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
++ *
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without modification,
++ * are permitted provided that the following conditions are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright notice, this
++ *    list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form, except as embedded into a Nordic
++ *    Semiconductor ASA integrated circuit in a product or a software update for
++ *    such product, must reproduce the above copyright notice, this list of
++ *    conditions and the following disclaimer in the documentation and/or other
++ *    materials provided with the distribution.
++ *
++ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
++ *    contributors may be used to endorse or promote products derived from this
++ *    software without specific prior written permission.
++ *
++ * 4. This software, with or without modification, must only be used with a
++ *    Nordic Semiconductor ASA integrated circuit.
++ *
++ * 5. Any software provided in binary form under this license must not be reverse
++ *    engineered, decompiled, modified and/or disassembled.
++ *
++ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
++ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
++ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
++ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
++ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ *
++ */
++
++
++
++#ifndef SDK_CONFIG_H
++#define SDK_CONFIG_H
++// <<< Use Configuration Wizard in Context Menu >>>\n
++#ifdef USE_APP_CONFIG
++#include "app_config.h"
++#endif
++// <h> nRF_BLE 
++
++//==========================================================
++// <q> BLE_DTM_ENABLED  - ble_dtm - Module for testing RF/PHY using DTM commands
++ 
++
++#ifndef BLE_DTM_ENABLED
++#define BLE_DTM_ENABLED 1
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Drivers 
++
++//==========================================================
++// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
++//==========================================================
++#ifndef NRFX_CLOCK_ENABLED
++#define NRFX_CLOCK_ENABLED 1
++#endif
++// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
++ 
++// <0=> RC 
++// <1=> XTAL 
++// <2=> Synth 
++// <131073=> External Low Swing 
++// <196609=> External Full Swing 
++
++#ifndef NRFX_CLOCK_CONFIG_LF_SRC
++#define NRFX_CLOCK_CONFIG_LF_SRC 1
++#endif
++
++// <o> NRFX_CLOCK_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_CLOCK_CONFIG_IRQ_PRIORITY
++#define NRFX_CLOCK_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
++#define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
++#define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
++#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
++#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
++//==========================================================
++#ifndef NRFX_POWER_ENABLED
++#define NRFX_POWER_ENABLED 1
++#endif
++// <o> NRFX_POWER_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_POWER_CONFIG_IRQ_PRIORITY
++#define NRFX_POWER_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <q> NRFX_POWER_CONFIG_DEFAULT_DCDCEN  - The default configuration of main DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef NRFX_POWER_CONFIG_DEFAULT_DCDCEN
++#define NRFX_POWER_CONFIG_DEFAULT_DCDCEN 0
++#endif
++
++// <q> NRFX_POWER_CONFIG_DEFAULT_DCDCENHV  - The default configuration of High Voltage DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef NRFX_POWER_CONFIG_DEFAULT_DCDCENHV
++#define NRFX_POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
++//==========================================================
++#ifndef NRFX_PRS_ENABLED
++#define NRFX_PRS_ENABLED 1
++#endif
++// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_0_ENABLED
++#define NRFX_PRS_BOX_0_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_1_ENABLED
++#define NRFX_PRS_BOX_1_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_2_ENABLED
++#define NRFX_PRS_BOX_2_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_3_ENABLED
++#define NRFX_PRS_BOX_3_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_4_ENABLED
++#define NRFX_PRS_BOX_4_ENABLED 1
++#endif
++
++// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_PRS_CONFIG_LOG_ENABLED
++#define NRFX_PRS_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_PRS_CONFIG_LOG_LEVEL
++#define NRFX_PRS_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_PRS_CONFIG_INFO_COLOR
++#define NRFX_PRS_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
++#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
++//==========================================================
++#ifndef NRFX_UARTE_ENABLED
++#define NRFX_UARTE_ENABLED 1
++#endif
++// <o> NRFX_UARTE0_ENABLED - Enable UARTE0 instance 
++#ifndef NRFX_UARTE0_ENABLED
++#define NRFX_UARTE0_ENABLED 0
++#endif
++
++// <o> NRFX_UARTE1_ENABLED - Enable UARTE1 instance 
++#ifndef NRFX_UARTE1_ENABLED
++#define NRFX_UARTE1_ENABLED 0
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_HWFC  - Hardware Flow Control
++ 
++// <0=> Disabled 
++// <1=> Enabled 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_HWFC
++#define NRFX_UARTE_DEFAULT_CONFIG_HWFC 0
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_PARITY  - Parity
++ 
++// <0=> Excluded 
++// <14=> Included 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_PARITY
++#define NRFX_UARTE_DEFAULT_CONFIG_PARITY 0
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3862528=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7716864=> 28800 baud 
++// <8388608=> 31250 baud 
++// <10289152=> 38400 baud 
++// <15007744=> 56000 baud 
++// <15400960=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30801920=> 115200 baud 
++// <61865984=> 230400 baud 
++// <67108864=> 250000 baud 
++// <121634816=> 460800 baud 
++// <251658240=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_BAUDRATE
++#define NRFX_UARTE_DEFAULT_CONFIG_BAUDRATE 30801920
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
++#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
++#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
++#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
++#define NRFX_UARTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
++#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
++//==========================================================
++#ifndef NRFX_UART_ENABLED
++#define NRFX_UART_ENABLED 1
++#endif
++// <o> NRFX_UART0_ENABLED - Enable UART0 instance 
++#ifndef NRFX_UART0_ENABLED
++#define NRFX_UART0_ENABLED 0
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_HWFC  - Hardware Flow Control
++ 
++// <0=> Disabled 
++// <1=> Enabled 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_HWFC
++#define NRFX_UART_DEFAULT_CONFIG_HWFC 0
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_PARITY  - Parity
++ 
++// <0=> Excluded 
++// <14=> Included 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_PARITY
++#define NRFX_UART_DEFAULT_CONFIG_PARITY 0
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3866624=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7729152=> 28800 baud 
++// <8388608=> 31250 baud 
++// <10309632=> 38400 baud 
++// <15007744=> 56000 baud 
++// <15462400=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30924800=> 115200 baud 
++// <61845504=> 230400 baud 
++// <67108864=> 250000 baud 
++// <123695104=> 460800 baud 
++// <247386112=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_BAUDRATE
++#define NRFX_UART_DEFAULT_CONFIG_BAUDRATE 30924800
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
++#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_UART_CONFIG_LOG_ENABLED
++#define NRFX_UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_UART_CONFIG_LOG_LEVEL
++#define NRFX_UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UART_CONFIG_INFO_COLOR
++#define NRFX_UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
++#define NRFX_UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRF_CLOCK_ENABLED - nrf_drv_clock - CLOCK peripheral driver - legacy layer
++//==========================================================
++#ifndef NRF_CLOCK_ENABLED
++#define NRF_CLOCK_ENABLED 1
++#endif
++// <o> CLOCK_CONFIG_LF_SRC  - LF Clock Source
++ 
++// <0=> RC 
++// <1=> XTAL 
++// <2=> Synth 
++// <131073=> External Low Swing 
++// <196609=> External Full Swing 
++
++#ifndef CLOCK_CONFIG_LF_SRC
++#define CLOCK_CONFIG_LF_SRC 1
++#endif
++
++// <o> CLOCK_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef CLOCK_CONFIG_IRQ_PRIORITY
++#define CLOCK_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
++// <e> POWER_ENABLED - nrf_drv_power - POWER peripheral driver - legacy layer
++//==========================================================
++#ifndef POWER_ENABLED
++#define POWER_ENABLED 1
++#endif
++// <o> POWER_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef POWER_CONFIG_IRQ_PRIORITY
++#define POWER_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <q> POWER_CONFIG_DEFAULT_DCDCEN  - The default configuration of main DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef POWER_CONFIG_DEFAULT_DCDCEN
++#define POWER_CONFIG_DEFAULT_DCDCEN 0
++#endif
++
++// <q> POWER_CONFIG_DEFAULT_DCDCENHV  - The default configuration of High Voltage DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef POWER_CONFIG_DEFAULT_DCDCENHV
++#define POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
++//==========================================================
++#ifndef UART_ENABLED
++#define UART_ENABLED 1
++#endif
++// <o> UART_DEFAULT_CONFIG_HWFC  - Hardware Flow Control
++ 
++// <0=> Disabled 
++// <1=> Enabled 
++
++#ifndef UART_DEFAULT_CONFIG_HWFC
++#define UART_DEFAULT_CONFIG_HWFC 0
++#endif
++
++// <o> UART_DEFAULT_CONFIG_PARITY  - Parity
++ 
++// <0=> Excluded 
++// <14=> Included 
++
++#ifndef UART_DEFAULT_CONFIG_PARITY
++#define UART_DEFAULT_CONFIG_PARITY 0
++#endif
++
++// <o> UART_DEFAULT_CONFIG_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3862528=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7716864=> 28800 baud 
++// <10289152=> 38400 baud 
++// <15400960=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30801920=> 115200 baud 
++// <61865984=> 230400 baud 
++// <67108864=> 250000 baud 
++// <121634816=> 460800 baud 
++// <251658240=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef UART_DEFAULT_CONFIG_BAUDRATE
++#define UART_DEFAULT_CONFIG_BAUDRATE 30801920
++#endif
++
++// <o> UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef UART_DEFAULT_CONFIG_IRQ_PRIORITY
++#define UART_DEFAULT_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <q> UART_EASY_DMA_SUPPORT  - Driver supporting EasyDMA
++ 
++
++#ifndef UART_EASY_DMA_SUPPORT
++#define UART_EASY_DMA_SUPPORT 1
++#endif
++
++// <q> UART_LEGACY_SUPPORT  - Driver supporting Legacy mode
++ 
++
++#ifndef UART_LEGACY_SUPPORT
++#define UART_LEGACY_SUPPORT 1
++#endif
++
++// <e> UART0_ENABLED - Enable UART0 instance
++//==========================================================
++#ifndef UART0_ENABLED
++#define UART0_ENABLED 1
++#endif
++// <q> UART0_CONFIG_USE_EASY_DMA  - Default setting for using EasyDMA
++ 
++
++#ifndef UART0_CONFIG_USE_EASY_DMA
++#define UART0_CONFIG_USE_EASY_DMA 1
++#endif
++
++// </e>
++
++// <e> UART1_ENABLED - Enable UART1 instance
++//==========================================================
++#ifndef UART1_ENABLED
++#define UART1_ENABLED 0
++#endif
++// </e>
++
++// </e>
++
++// <e> USBD_ENABLED - nrf_drv_usbd - USB driver
++//==========================================================
++#ifndef USBD_ENABLED
++#define USBD_ENABLED 1
++#endif
++// <o> USBD_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef USBD_CONFIG_IRQ_PRIORITY
++#define USBD_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <o> USBD_CONFIG_DMASCHEDULER_MODE  - USBD SMA scheduler working scheme
++ 
++// <0=> Prioritized access 
++// <1=> Round Robin 
++
++#ifndef USBD_CONFIG_DMASCHEDULER_MODE
++#define USBD_CONFIG_DMASCHEDULER_MODE 0
++#endif
++
++// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
++ 
++
++// <i> This option gives priority to isochronous transfers.
++// <i> Enabling it assures that isochronous transfers are always processed,
++// <i> even if multiple other transfers are pending.
++// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
++// <i> function is called, so the option is independent of the algorithm chosen.
++
++#ifndef USBD_CONFIG_DMASCHEDULER_ISO_BOOST
++#define USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
++#endif
++
++// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
++ 
++
++// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
++// <i> Else, there will be no response.
++
++#ifndef USBD_CONFIG_ISO_IN_ZLP
++#define USBD_CONFIG_ISO_IN_ZLP 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Libraries 
++
++//==========================================================
++// <e> APP_SCHEDULER_ENABLED - app_scheduler - Events scheduler
++//==========================================================
++#ifndef APP_SCHEDULER_ENABLED
++#define APP_SCHEDULER_ENABLED 1
++#endif
++// <q> APP_SCHEDULER_WITH_PAUSE  - Enabling pause feature
++ 
++
++#ifndef APP_SCHEDULER_WITH_PAUSE
++#define APP_SCHEDULER_WITH_PAUSE 1
++#endif
++
++// <q> APP_SCHEDULER_WITH_PROFILER  - Enabling scheduler profiling
++ 
++
++#ifndef APP_SCHEDULER_WITH_PROFILER
++#define APP_SCHEDULER_WITH_PROFILER 1
++#endif
++
++// </e>
++
++// <e> APP_TIMER_ENABLED - app_timer - Application timer functionality
++//==========================================================
++#ifndef APP_TIMER_ENABLED
++#define APP_TIMER_ENABLED 1
++#endif
++// <o> APP_TIMER_CONFIG_RTC_FREQUENCY  - Configure RTC prescaler.
++ 
++// <0=> 32768 Hz 
++// <1=> 16384 Hz 
++// <3=> 8192 Hz 
++// <7=> 4096 Hz 
++// <15=> 2048 Hz 
++// <31=> 1024 Hz 
++
++#ifndef APP_TIMER_CONFIG_RTC_FREQUENCY
++#define APP_TIMER_CONFIG_RTC_FREQUENCY 0
++#endif
++
++// <o> APP_TIMER_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef APP_TIMER_CONFIG_IRQ_PRIORITY
++#define APP_TIMER_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <o> APP_TIMER_CONFIG_OP_QUEUE_SIZE - Capacity of timer requests queue. 
++// <i> Size of the queue depends on how many timers are used
++// <i> in the system, how often timers are started and overall
++// <i> system latency. If queue size is too small app_timer calls
++// <i> will fail.
++
++#ifndef APP_TIMER_CONFIG_OP_QUEUE_SIZE
++#define APP_TIMER_CONFIG_OP_QUEUE_SIZE 10
++#endif
++
++// <q> APP_TIMER_CONFIG_USE_SCHEDULER  - Enable scheduling app_timer events to app_scheduler
++ 
++
++#ifndef APP_TIMER_CONFIG_USE_SCHEDULER
++#define APP_TIMER_CONFIG_USE_SCHEDULER 0
++#endif
++
++// <q> APP_TIMER_KEEPS_RTC_ACTIVE  - Enable RTC always on
++ 
++
++// <i> If option is enabled RTC is kept running even if there is no active timers.
++// <i> This option can be used when app_timer is used for timestamping.
++
++#ifndef APP_TIMER_KEEPS_RTC_ACTIVE
++#define APP_TIMER_KEEPS_RTC_ACTIVE 0
++#endif
++
++// <o> APP_TIMER_SAFE_WINDOW_MS - Maximum possible latency (in milliseconds) of handling app_timer event. 
++// <i> Maximum possible timeout that can be set is reduced by safe window.
++// <i> Example: RTC frequency 16384 Hz, maximum possible timeout 1024 seconds - APP_TIMER_SAFE_WINDOW_MS.
++// <i> Since RTC is not stopped when processor is halted in debugging session, this value
++// <i> must cover it if debugging is needed. It is possible to halt processor for APP_TIMER_SAFE_WINDOW_MS
++// <i> without corrupting app_timer behavior.
++
++#ifndef APP_TIMER_SAFE_WINDOW_MS
++#define APP_TIMER_SAFE_WINDOW_MS 300000
++#endif
++
++// <h> App Timer Legacy configuration - Legacy configuration.
++
++//==========================================================
++// <q> APP_TIMER_WITH_PROFILER  - Enable app_timer profiling
++ 
++
++#ifndef APP_TIMER_WITH_PROFILER
++#define APP_TIMER_WITH_PROFILER 0
++#endif
++
++// <q> APP_TIMER_CONFIG_SWI_NUMBER  - Configure SWI instance used.
++ 
++
++#ifndef APP_TIMER_CONFIG_SWI_NUMBER
++#define APP_TIMER_CONFIG_SWI_NUMBER 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </e>
++
++// <e> APP_USBD_ENABLED - app_usbd - USB Device library
++//==========================================================
++#ifndef APP_USBD_ENABLED
++#define APP_USBD_ENABLED 1
++#endif
++// <s> APP_USBD_VID - Vendor ID.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Vendor ID ordered from USB IF: http://www.usb.org/developers/vendor/
++#ifndef APP_USBD_VID
++#define APP_USBD_VID 0x1915
++#endif
++
++// <s> APP_USBD_PID - Product ID.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Selected Product ID
++#ifndef APP_USBD_PID
++#define APP_USBD_PID 0xC00A
++#endif
++
++// <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
++
++
++// <i> Device version, will be converted automatically to BCD notation. Use just decimal values.
++
++#ifndef APP_USBD_DEVICE_VER_MAJOR
++#define APP_USBD_DEVICE_VER_MAJOR 1
++#endif
++
++// <o> APP_USBD_DEVICE_VER_MINOR - Device version, minor part.  <0-99> 
++
++
++// <i> Device version, will be converted automatically to BCD notation. Use just decimal values.
++
++#ifndef APP_USBD_DEVICE_VER_MINOR
++#define APP_USBD_DEVICE_VER_MINOR 0
++#endif
++
++// <q> APP_USBD_CONFIG_SELF_POWERED  - Self-powered device, as opposed to bus-powered.
++ 
++
++#ifndef APP_USBD_CONFIG_SELF_POWERED
++#define APP_USBD_CONFIG_SELF_POWERED 1
++#endif
++
++// <o> APP_USBD_CONFIG_MAX_POWER - MaxPower field in configuration descriptor in milliamps.  <0-500> 
++
++
++#ifndef APP_USBD_CONFIG_MAX_POWER
++#define APP_USBD_CONFIG_MAX_POWER 500
++#endif
++
++// <q> APP_USBD_CONFIG_POWER_EVENTS_PROCESS  - Process power events.
++ 
++
++// <i> Enable processing power events in USB event handler.
++
++#ifndef APP_USBD_CONFIG_POWER_EVENTS_PROCESS
++#define APP_USBD_CONFIG_POWER_EVENTS_PROCESS 1
++#endif
++
++// <e> APP_USBD_CONFIG_EVENT_QUEUE_ENABLE - Enable event queue.
++
++// <i> This is the default configuration when all the events are placed into internal queue.
++// <i> Disable it when an external queue is used like app_scheduler or if you wish to process all events inside interrupts.
++// <i> Processing all events from the interrupt level adds requirement not to call any functions that modifies the USBD library state from the context higher than USB interrupt context.
++// <i> Functions that modify USBD state are functions for sleep, wakeup, start, stop, enable, and disable.
++//==========================================================
++#ifndef APP_USBD_CONFIG_EVENT_QUEUE_ENABLE
++#define APP_USBD_CONFIG_EVENT_QUEUE_ENABLE 1
++#endif
++// <o> APP_USBD_CONFIG_EVENT_QUEUE_SIZE - The size of the event queue.  <16-64> 
++
++
++// <i> The size of the queue for the events that would be processed in the main loop.
++
++#ifndef APP_USBD_CONFIG_EVENT_QUEUE_SIZE
++#define APP_USBD_CONFIG_EVENT_QUEUE_SIZE 32
++#endif
++
++// <o> APP_USBD_CONFIG_SOF_HANDLING_MODE  - Change SOF events handling mode.
++ 
++
++// <i> Normal queue   - SOF events are pushed normally into the event queue.
++// <i> Compress queue - SOF events are counted and binded with other events or executed when the queue is empty.
++// <i>                  This prevents the queue from filling up with SOF events.
++// <i> Interrupt      - SOF events are processed in interrupt.
++// <0=> Normal queue 
++// <1=> Compress queue 
++// <2=> Interrupt 
++
++#ifndef APP_USBD_CONFIG_SOF_HANDLING_MODE
++#define APP_USBD_CONFIG_SOF_HANDLING_MODE 1
++#endif
++
++// </e>
++
++// <q> APP_USBD_CONFIG_SOF_TIMESTAMP_PROVIDE  - Provide a function that generates timestamps for logs based on the current SOF.
++ 
++
++// <i> The function app_usbd_sof_timestamp_get is implemented if the logger is enabled. 
++// <i> Use it when initializing the logger. 
++// <i> SOF processing is always enabled when this configuration parameter is active. 
++// <i> Note: This option is configured outside of APP_USBD_CONFIG_LOG_ENABLED. 
++// <i> This means that it works even if the logging in this very module is disabled. 
++
++#ifndef APP_USBD_CONFIG_SOF_TIMESTAMP_PROVIDE
++#define APP_USBD_CONFIG_SOF_TIMESTAMP_PROVIDE 0
++#endif
++
++// <o> APP_USBD_CONFIG_DESC_STRING_SIZE - Maximum size of the NULL-terminated string of the string descriptor.  <31-254> 
++
++
++// <i> 31 characters can be stored in the internal USB buffer used for transfers.
++// <i> Any value higher than 31 creates an additional buffer just for descriptor strings.
++
++#ifndef APP_USBD_CONFIG_DESC_STRING_SIZE
++#define APP_USBD_CONFIG_DESC_STRING_SIZE 31
++#endif
++
++// <q> APP_USBD_CONFIG_DESC_STRING_UTF_ENABLED  - Enable UTF8 conversion.
++ 
++
++// <i> Enable UTF8-encoded characters. In normal processing, only ASCII characters are available.
++
++#ifndef APP_USBD_CONFIG_DESC_STRING_UTF_ENABLED
++#define APP_USBD_CONFIG_DESC_STRING_UTF_ENABLED 0
++#endif
++
++// <s> APP_USBD_STRINGS_LANGIDS - Supported languages identifiers.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Comma-separated list of supported languages.
++#ifndef APP_USBD_STRINGS_LANGIDS
++#define APP_USBD_STRINGS_LANGIDS APP_USBD_LANG_AND_SUBLANG(APP_USBD_LANG_ENGLISH, APP_USBD_SUBLANG_ENGLISH_US)
++#endif
++
++// <e> APP_USBD_STRING_ID_MANUFACTURER - Define manufacturer string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_MANUFACTURER
++#define APP_USBD_STRING_ID_MANUFACTURER 1
++#endif
++// <q> APP_USBD_STRINGS_MANUFACTURER_EXTERN  - Define whether @ref APP_USBD_STRINGS_MANUFACTURER is created by macro or declared as a global variable.
++ 
++
++#ifndef APP_USBD_STRINGS_MANUFACTURER_EXTERN
++#define APP_USBD_STRINGS_MANUFACTURER_EXTERN 0
++#endif
++
++// <s> APP_USBD_STRINGS_MANUFACTURER - String descriptor for the manufacturer name.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Comma-separated list of manufacturer names for each defined language.
++// <i> Use @ref APP_USBD_STRING_DESC macro to create string descriptor from a NULL-terminated string.
++// <i> Use @ref APP_USBD_STRING_RAW8_DESC macro to create string descriptor from comma-separated uint8_t values.
++// <i> Use @ref APP_USBD_STRING_RAW16_DESC macro to create string descriptor from comma-separated uint16_t values.
++// <i> Alternatively, configure the macro to point to any internal variable pointer that already contains the descriptor.
++// <i> Setting string to NULL disables that string.
++// <i> The order of manufacturer names must be the same like in @ref APP_USBD_STRINGS_LANGIDS.
++#ifndef APP_USBD_STRINGS_MANUFACTURER
++#define APP_USBD_STRINGS_MANUFACTURER APP_USBD_STRING_DESC("Nordic Semiconductor")
++#endif
++
++// </e>
++
++// <e> APP_USBD_STRING_ID_PRODUCT - Define product string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_PRODUCT
++#define APP_USBD_STRING_ID_PRODUCT 2
++#endif
++// <q> APP_USBD_STRINGS_PRODUCT_EXTERN  - Define whether @ref APP_USBD_STRINGS_PRODUCT is created by macro or declared as a global variable.
++ 
++
++#ifndef APP_USBD_STRINGS_PRODUCT_EXTERN
++#define APP_USBD_STRINGS_PRODUCT_EXTERN 0
++#endif
++
++// <s> APP_USBD_STRINGS_PRODUCT - String descriptor for the product name.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> List of product names that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
++#ifndef APP_USBD_STRINGS_PRODUCT
++#define APP_USBD_STRINGS_PRODUCT APP_USBD_STRING_DESC("nRF52 Connectivity")
++#endif
++
++// </e>
++
++// <e> APP_USBD_STRING_ID_SERIAL - Define serial number string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_SERIAL
++#define APP_USBD_STRING_ID_SERIAL 3
++#endif
++// <q> APP_USBD_STRING_SERIAL_EXTERN  - Define whether @ref APP_USBD_STRING_SERIAL is created by macro or declared as a global variable.
++ 
++
++#ifndef APP_USBD_STRING_SERIAL_EXTERN
++#define APP_USBD_STRING_SERIAL_EXTERN 1
++#endif
++
++// <s> APP_USBD_STRING_SERIAL - String descriptor for the serial number.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Serial number that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
++#ifndef APP_USBD_STRING_SERIAL
++#define APP_USBD_STRING_SERIAL g_extern_serial_number
++#endif
++
++// </e>
++
++// <e> APP_USBD_STRING_ID_CONFIGURATION - Define configuration string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_CONFIGURATION
++#define APP_USBD_STRING_ID_CONFIGURATION 4
++#endif
++// <q> APP_USBD_STRING_CONFIGURATION_EXTERN  - Define whether @ref APP_USBD_STRINGS_CONFIGURATION is created by macro or declared as global variable.
++ 
++
++#ifndef APP_USBD_STRING_CONFIGURATION_EXTERN
++#define APP_USBD_STRING_CONFIGURATION_EXTERN 0
++#endif
++
++// <s> APP_USBD_STRINGS_CONFIGURATION - String descriptor for the device configuration.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Configuration string that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
++#ifndef APP_USBD_STRINGS_CONFIGURATION
++#define APP_USBD_STRINGS_CONFIGURATION APP_USBD_STRING_DESC("Default configuration")
++#endif
++
++// </e>
++
++// <s> APP_USBD_STRINGS_USER - Default values for user strings.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> This value stores all application specific user strings with the default initialization.
++// <i> The setup is done by X-macros.
++// <i> Expected macro parameters:
++// <i> @code
++// <i> X(mnemonic, [=str_idx], ...)
++// <i> @endcode
++// <i> - @c mnemonic: Mnemonic of the string descriptor that would be added to
++// <i>                @ref app_usbd_string_desc_idx_t enumerator.
++// <i> - @c str_idx : String index value, can be set or left empty.
++// <i>                For example, WinUSB driver requires descriptor to be present on 0xEE index.
++// <i>                Then use X(USBD_STRING_WINUSB, =0xEE, (APP_USBD_STRING_DESC(...)))
++// <i> - @c ...     : List of string descriptors for each defined language.
++#ifndef APP_USBD_STRINGS_USER
++#define APP_USBD_STRINGS_USER X(APP_USER_1, , APP_USBD_STRING_DESC("User 1"))
++#endif
++
++// </e>
++
++// <q> CRC16_ENABLED  - crc16 - CRC16 calculation routines
++ 
++
++#ifndef CRC16_ENABLED
++#define CRC16_ENABLED 1
++#endif
++
++// <e> NRF_BALLOC_ENABLED - nrf_balloc - Block allocator module
++//==========================================================
++#ifndef NRF_BALLOC_ENABLED
++#define NRF_BALLOC_ENABLED 1
++#endif
++// <e> NRF_BALLOC_CONFIG_DEBUG_ENABLED - Enables debug mode in the module.
++//==========================================================
++#ifndef NRF_BALLOC_CONFIG_DEBUG_ENABLED
++#define NRF_BALLOC_CONFIG_DEBUG_ENABLED 0
++#endif
++// <o> NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS - Number of words used as head guard.  <0-255> 
++
++
++#ifndef NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS
++#define NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS 1
++#endif
++
++// <o> NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS - Number of words used as tail guard.  <0-255> 
++
++
++#ifndef NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS
++#define NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS 1
++#endif
++
++// <q> NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED  - Enables basic checks in this module.
++ 
++
++#ifndef NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED
++#define NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED 0
++#endif
++
++// <q> NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED  - Enables double memory free check in this module.
++ 
++
++#ifndef NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED
++#define NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED 0
++#endif
++
++// <q> NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED  - Enables free memory corruption check in this module.
++ 
++
++#ifndef NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED
++#define NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED 0
++#endif
++
++// <q> NRF_BALLOC_CLI_CMDS  - Enable CLI commands specific to the module
++ 
++
++#ifndef NRF_BALLOC_CLI_CMDS
++#define NRF_BALLOC_CLI_CMDS 0
++#endif
++
++// </e>
++
++// </e>
++
++// <q> NRF_FPRINTF_ENABLED  - nrf_fprintf - fprintf function.
++ 
++
++#ifndef NRF_FPRINTF_ENABLED
++#define NRF_FPRINTF_ENABLED 1
++#endif
++
++// <q> NRF_MEMOBJ_ENABLED  - nrf_memobj - Linked memory allocator module
++ 
++
++#ifndef NRF_MEMOBJ_ENABLED
++#define NRF_MEMOBJ_ENABLED 1
++#endif
++
++// <e> NRF_QUEUE_ENABLED - nrf_queue - Queue module
++//==========================================================
++#ifndef NRF_QUEUE_ENABLED
++#define NRF_QUEUE_ENABLED 1
++#endif
++// <q> NRF_QUEUE_CLI_CMDS  - Enable CLI commands specific to the module
++ 
++
++#ifndef NRF_QUEUE_CLI_CMDS
++#define NRF_QUEUE_CLI_CMDS 0
++#endif
++
++// </e>
++
++// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
++ 
++
++#ifndef NRF_SECTION_ITER_ENABLED
++#define NRF_SECTION_ITER_ENABLED 1
++#endif
++
++// <q> NRF_STRERROR_ENABLED  - nrf_strerror - Library for converting error code to string.
++ 
++
++#ifndef NRF_STRERROR_ENABLED
++#define NRF_STRERROR_ENABLED 1
++#endif
++
++// <h> app_usbd_cdc_acm - USB CDC ACM class
++
++//==========================================================
++// <q> APP_USBD_CDC_ACM_ENABLED  - Enabling USBD CDC ACM Class library
++ 
++
++#ifndef APP_USBD_CDC_ACM_ENABLED
++#define APP_USBD_CDC_ACM_ENABLED 1
++#endif
++
++// <q> APP_USBD_CDC_ACM_ZLP_ON_EPSIZE_WRITE  - Send ZLP on write with same size as endpoint
++ 
++
++// <i> If enabled, CDC ACM class will automatically send a zero length packet after transfer which has the same size as endpoint.
++// <i> This may limit throughput if a lot of binary data is sent, but in terminal mode operation it makes sure that the data is always displayed right after it is sent.
++
++#ifndef APP_USBD_CDC_ACM_ZLP_ON_EPSIZE_WRITE
++#define APP_USBD_CDC_ACM_ZLP_ON_EPSIZE_WRITE 1
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Log 
++
++//==========================================================
++// <e> NRF_LOG_BACKEND_RTT_ENABLED - nrf_log_backend_rtt - Log RTT backend
++//==========================================================
++#ifndef NRF_LOG_BACKEND_RTT_ENABLED
++#define NRF_LOG_BACKEND_RTT_ENABLED 0
++#endif
++// <o> NRF_LOG_BACKEND_RTT_TEMP_BUFFER_SIZE - Size of buffer for partially processed strings. 
++// <i> Size of the buffer is a trade-off between RAM usage and processing.
++// <i> if buffer is smaller then strings will often be fragmented.
++// <i> It is recommended to use size which will fit typical log and only the
++// <i> longer one will be fragmented.
++
++#ifndef NRF_LOG_BACKEND_RTT_TEMP_BUFFER_SIZE
++#define NRF_LOG_BACKEND_RTT_TEMP_BUFFER_SIZE 64
++#endif
++
++// <o> NRF_LOG_BACKEND_RTT_TX_RETRY_DELAY_MS - Period before retrying writing to RTT 
++#ifndef NRF_LOG_BACKEND_RTT_TX_RETRY_DELAY_MS
++#define NRF_LOG_BACKEND_RTT_TX_RETRY_DELAY_MS 1
++#endif
++
++// <o> NRF_LOG_BACKEND_RTT_TX_RETRY_CNT - Writing to RTT retries. 
++// <i> If RTT fails to accept any new data after retries
++// <i> module assumes that host is not active and on next
++// <i> request it will perform only one write attempt.
++// <i> On successful writing, module assumes that host is active
++// <i> and scheme with retry is applied again.
++
++#ifndef NRF_LOG_BACKEND_RTT_TX_RETRY_CNT
++#define NRF_LOG_BACKEND_RTT_TX_RETRY_CNT 3
++#endif
++
++// </e>
++
++// <e> NRF_LOG_BACKEND_UART_ENABLED - nrf_log_backend_uart - Log UART backend
++//==========================================================
++#ifndef NRF_LOG_BACKEND_UART_ENABLED
++#define NRF_LOG_BACKEND_UART_ENABLED 0
++#endif
++// <o> NRF_LOG_BACKEND_UART_TX_PIN - UART TX pin 
++#ifndef NRF_LOG_BACKEND_UART_TX_PIN
++#define NRF_LOG_BACKEND_UART_TX_PIN 6
++#endif
++
++// <o> NRF_LOG_BACKEND_UART_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3862528=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7716864=> 28800 baud 
++// <10289152=> 38400 baud 
++// <15400960=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30801920=> 115200 baud 
++// <61865984=> 230400 baud 
++// <67108864=> 250000 baud 
++// <121634816=> 460800 baud 
++// <251658240=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef NRF_LOG_BACKEND_UART_BAUDRATE
++#define NRF_LOG_BACKEND_UART_BAUDRATE 30801920
++#endif
++
++// <o> NRF_LOG_BACKEND_UART_TEMP_BUFFER_SIZE - Size of buffer for partially processed strings. 
++// <i> Size of the buffer is a trade-off between RAM usage and processing.
++// <i> if buffer is smaller then strings will often be fragmented.
++// <i> It is recommended to use size which will fit typical log and only the
++// <i> longer one will be fragmented.
++
++#ifndef NRF_LOG_BACKEND_UART_TEMP_BUFFER_SIZE
++#define NRF_LOG_BACKEND_UART_TEMP_BUFFER_SIZE 64
++#endif
++
++// </e>
++
++// <e> NRF_LOG_ENABLED - nrf_log - Logger
++//==========================================================
++#ifndef NRF_LOG_ENABLED
++#define NRF_LOG_ENABLED 0
++#endif
++// <h> Log message pool - Configuration of log message pool
++
++//==========================================================
++// <o> NRF_LOG_MSGPOOL_ELEMENT_SIZE - Size of a single element in the pool of memory objects. 
++// <i> If a small value is set, then performance of logs processing
++// <i> is degraded because data is fragmented. Bigger value impacts
++// <i> RAM memory utilization. The size is set to fit a message with
++// <i> a timestamp and up to 2 arguments in a single memory object.
++
++#ifndef NRF_LOG_MSGPOOL_ELEMENT_SIZE
++#define NRF_LOG_MSGPOOL_ELEMENT_SIZE 20
++#endif
++
++// <o> NRF_LOG_MSGPOOL_ELEMENT_COUNT - Number of elements in the pool of memory objects 
++// <i> If a small value is set, then it may lead to a deadlock
++// <i> in certain cases if backend has high latency and holds
++// <i> multiple messages for long time. Bigger value impacts
++// <i> RAM memory usage.
++
++#ifndef NRF_LOG_MSGPOOL_ELEMENT_COUNT
++#define NRF_LOG_MSGPOOL_ELEMENT_COUNT 8
++#endif
++
++// </h> 
++//==========================================================
++
++// <q> NRF_LOG_ALLOW_OVERFLOW  - Configures behavior when circular buffer is full.
++ 
++
++// <i> If set then oldest logs are overwritten. Otherwise a 
++// <i> marker is injected informing about overflow.
++
++#ifndef NRF_LOG_ALLOW_OVERFLOW
++#define NRF_LOG_ALLOW_OVERFLOW 1
++#endif
++
++// <o> NRF_LOG_BUFSIZE  - Size of the buffer for storing logs (in bytes).
++ 
++
++// <i> Must be power of 2 and multiple of 4.
++// <i> If NRF_LOG_DEFERRED = 0 then buffer size can be reduced to minimum.
++// <128=> 128 
++// <256=> 256 
++// <512=> 512 
++// <1024=> 1024 
++// <2048=> 2048 
++// <4096=> 4096 
++// <8192=> 8192 
++// <16384=> 16384 
++
++#ifndef NRF_LOG_BUFSIZE
++#define NRF_LOG_BUFSIZE 1024
++#endif
++
++// <q> NRF_LOG_CLI_CMDS  - Enable CLI commands for the module.
++ 
++
++#ifndef NRF_LOG_CLI_CMDS
++#define NRF_LOG_CLI_CMDS 0
++#endif
++
++// <o> NRF_LOG_DEFAULT_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_LOG_DEFAULT_LEVEL
++#define NRF_LOG_DEFAULT_LEVEL 3
++#endif
++
++// <q> NRF_LOG_DEFERRED  - Enable deffered logger.
++ 
++
++// <i> Log data is buffered and can be processed in idle.
++
++#ifndef NRF_LOG_DEFERRED
++#define NRF_LOG_DEFERRED 1
++#endif
++
++// <q> NRF_LOG_FILTERS_ENABLED  - Enable dynamic filtering of logs.
++ 
++
++#ifndef NRF_LOG_FILTERS_ENABLED
++#define NRF_LOG_FILTERS_ENABLED 0
++#endif
++
++// <o> NRF_LOG_STR_PUSH_BUFFER_SIZE  - Size of the buffer dedicated for strings stored using @ref NRF_LOG_PUSH.
++ 
++// <16=> 16 
++// <32=> 32 
++// <64=> 64 
++// <128=> 128 
++// <256=> 256 
++// <512=> 512 
++// <1024=> 1024 
++
++#ifndef NRF_LOG_STR_PUSH_BUFFER_SIZE
++#define NRF_LOG_STR_PUSH_BUFFER_SIZE 128
++#endif
++
++// <o> NRF_LOG_STR_PUSH_BUFFER_SIZE  - Size of the buffer dedicated for strings stored using @ref NRF_LOG_PUSH.
++ 
++// <16=> 16 
++// <32=> 32 
++// <64=> 64 
++// <128=> 128 
++// <256=> 256 
++// <512=> 512 
++// <1024=> 1024 
++
++#ifndef NRF_LOG_STR_PUSH_BUFFER_SIZE
++#define NRF_LOG_STR_PUSH_BUFFER_SIZE 128
++#endif
++
++// <e> NRF_LOG_USES_COLORS - If enabled then ANSI escape code for colors is prefixed to every string
++//==========================================================
++#ifndef NRF_LOG_USES_COLORS
++#define NRF_LOG_USES_COLORS 0
++#endif
++// <o> NRF_LOG_COLOR_DEFAULT  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LOG_COLOR_DEFAULT
++#define NRF_LOG_COLOR_DEFAULT 0
++#endif
++
++// <o> NRF_LOG_ERROR_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LOG_ERROR_COLOR
++#define NRF_LOG_ERROR_COLOR 2
++#endif
++
++// <o> NRF_LOG_WARNING_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LOG_WARNING_COLOR
++#define NRF_LOG_WARNING_COLOR 4
++#endif
++
++// </e>
++
++// <e> NRF_LOG_USES_TIMESTAMP - Enable timestamping
++
++// <i> Function for getting the timestamp is provided by the user
++//==========================================================
++#ifndef NRF_LOG_USES_TIMESTAMP
++#define NRF_LOG_USES_TIMESTAMP 0
++#endif
++// <o> NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY - Default frequency of the timestamp (in Hz) or 0 to use app_timer frequency. 
++#ifndef NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY
++#define NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY 0
++#endif
++
++// </e>
++
++// <h> nrf_log module configuration 
++
++//==========================================================
++// <h> nrf_log in nRF_Core 
++
++//==========================================================
++// <e> NRF_MPU_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_MPU_CONFIG_LOG_ENABLED
++#define NRF_MPU_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_MPU_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_MPU_CONFIG_LOG_LEVEL
++#define NRF_MPU_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_MPU_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MPU_CONFIG_INFO_COLOR
++#define NRF_MPU_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_MPU_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MPU_CONFIG_DEBUG_COLOR
++#define NRF_MPU_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_STACK_GUARD_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_STACK_GUARD_CONFIG_LOG_ENABLED
++#define NRF_STACK_GUARD_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_STACK_GUARD_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_STACK_GUARD_CONFIG_LOG_LEVEL
++#define NRF_STACK_GUARD_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_STACK_GUARD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_STACK_GUARD_CONFIG_INFO_COLOR
++#define NRF_STACK_GUARD_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_STACK_GUARD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_STACK_GUARD_CONFIG_DEBUG_COLOR
++#define NRF_STACK_GUARD_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TASK_MANAGER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TASK_MANAGER_CONFIG_LOG_ENABLED
++#define TASK_MANAGER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TASK_MANAGER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TASK_MANAGER_CONFIG_LOG_LEVEL
++#define TASK_MANAGER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TASK_MANAGER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TASK_MANAGER_CONFIG_INFO_COLOR
++#define TASK_MANAGER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TASK_MANAGER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TASK_MANAGER_CONFIG_DEBUG_COLOR
++#define TASK_MANAGER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nrf_log in nRF_Drivers 
++
++//==========================================================
++// <e> CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef CLOCK_CONFIG_LOG_ENABLED
++#define CLOCK_CONFIG_LOG_ENABLED 0
++#endif
++// <o> CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef CLOCK_CONFIG_LOG_LEVEL
++#define CLOCK_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef CLOCK_CONFIG_INFO_COLOR
++#define CLOCK_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef CLOCK_CONFIG_DEBUG_COLOR
++#define CLOCK_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef COMP_CONFIG_LOG_ENABLED
++#define COMP_CONFIG_LOG_ENABLED 0
++#endif
++// <o> COMP_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef COMP_CONFIG_LOG_LEVEL
++#define COMP_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef COMP_CONFIG_INFO_COLOR
++#define COMP_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef COMP_CONFIG_DEBUG_COLOR
++#define COMP_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef GPIOTE_CONFIG_LOG_ENABLED
++#define GPIOTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef GPIOTE_CONFIG_LOG_LEVEL
++#define GPIOTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef GPIOTE_CONFIG_INFO_COLOR
++#define GPIOTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef GPIOTE_CONFIG_DEBUG_COLOR
++#define GPIOTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef LPCOMP_CONFIG_LOG_ENABLED
++#define LPCOMP_CONFIG_LOG_ENABLED 0
++#endif
++// <o> LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef LPCOMP_CONFIG_LOG_LEVEL
++#define LPCOMP_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef LPCOMP_CONFIG_INFO_COLOR
++#define LPCOMP_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef LPCOMP_CONFIG_DEBUG_COLOR
++#define LPCOMP_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> MAX3421E_HOST_CONFIG_LOG_ENABLED - Enable logging in the module
++//==========================================================
++#ifndef MAX3421E_HOST_CONFIG_LOG_ENABLED
++#define MAX3421E_HOST_CONFIG_LOG_ENABLED 0
++#endif
++// <o> MAX3421E_HOST_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef MAX3421E_HOST_CONFIG_LOG_LEVEL
++#define MAX3421E_HOST_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> MAX3421E_HOST_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef MAX3421E_HOST_CONFIG_INFO_COLOR
++#define MAX3421E_HOST_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> MAX3421E_HOST_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef MAX3421E_HOST_CONFIG_DEBUG_COLOR
++#define MAX3421E_HOST_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef PDM_CONFIG_LOG_ENABLED
++#define PDM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> PDM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PDM_CONFIG_LOG_LEVEL
++#define PDM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PDM_CONFIG_INFO_COLOR
++#define PDM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PDM_CONFIG_DEBUG_COLOR
++#define PDM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef PPI_CONFIG_LOG_ENABLED
++#define PPI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> PPI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PPI_CONFIG_LOG_LEVEL
++#define PPI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PPI_CONFIG_INFO_COLOR
++#define PPI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PPI_CONFIG_DEBUG_COLOR
++#define PPI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef PWM_CONFIG_LOG_ENABLED
++#define PWM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> PWM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PWM_CONFIG_LOG_LEVEL
++#define PWM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PWM_CONFIG_INFO_COLOR
++#define PWM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PWM_CONFIG_DEBUG_COLOR
++#define PWM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef QDEC_CONFIG_LOG_ENABLED
++#define QDEC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> QDEC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef QDEC_CONFIG_LOG_LEVEL
++#define QDEC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef QDEC_CONFIG_INFO_COLOR
++#define QDEC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef QDEC_CONFIG_DEBUG_COLOR
++#define QDEC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef RNG_CONFIG_LOG_ENABLED
++#define RNG_CONFIG_LOG_ENABLED 0
++#endif
++// <o> RNG_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef RNG_CONFIG_LOG_LEVEL
++#define RNG_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RNG_CONFIG_INFO_COLOR
++#define RNG_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RNG_CONFIG_DEBUG_COLOR
++#define RNG_CONFIG_DEBUG_COLOR 0
++#endif
++
++// <q> RNG_CONFIG_RANDOM_NUMBER_LOG_ENABLED  - Enables logging of random numbers.
++ 
++
++#ifndef RNG_CONFIG_RANDOM_NUMBER_LOG_ENABLED
++#define RNG_CONFIG_RANDOM_NUMBER_LOG_ENABLED 0
++#endif
++
++// </e>
++
++// <e> RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef RTC_CONFIG_LOG_ENABLED
++#define RTC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> RTC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef RTC_CONFIG_LOG_LEVEL
++#define RTC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RTC_CONFIG_INFO_COLOR
++#define RTC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RTC_CONFIG_DEBUG_COLOR
++#define RTC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SAADC_CONFIG_LOG_ENABLED
++#define SAADC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SAADC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SAADC_CONFIG_LOG_LEVEL
++#define SAADC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SAADC_CONFIG_INFO_COLOR
++#define SAADC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SAADC_CONFIG_DEBUG_COLOR
++#define SAADC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SPIS_CONFIG_LOG_ENABLED
++#define SPIS_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SPIS_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SPIS_CONFIG_LOG_LEVEL
++#define SPIS_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPIS_CONFIG_INFO_COLOR
++#define SPIS_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPIS_CONFIG_DEBUG_COLOR
++#define SPIS_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SPI_CONFIG_LOG_ENABLED
++#define SPI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SPI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SPI_CONFIG_LOG_LEVEL
++#define SPI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPI_CONFIG_INFO_COLOR
++#define SPI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPI_CONFIG_DEBUG_COLOR
++#define SPI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TIMER_CONFIG_LOG_ENABLED
++#define TIMER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TIMER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TIMER_CONFIG_LOG_LEVEL
++#define TIMER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TIMER_CONFIG_INFO_COLOR
++#define TIMER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TIMER_CONFIG_DEBUG_COLOR
++#define TIMER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TWIS_CONFIG_LOG_ENABLED
++#define TWIS_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TWIS_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TWIS_CONFIG_LOG_LEVEL
++#define TWIS_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWIS_CONFIG_INFO_COLOR
++#define TWIS_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWIS_CONFIG_DEBUG_COLOR
++#define TWIS_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TWI_CONFIG_LOG_ENABLED
++#define TWI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TWI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TWI_CONFIG_LOG_LEVEL
++#define TWI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWI_CONFIG_INFO_COLOR
++#define TWI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWI_CONFIG_DEBUG_COLOR
++#define TWI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef UART_CONFIG_LOG_ENABLED
++#define UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef UART_CONFIG_LOG_LEVEL
++#define UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef UART_CONFIG_INFO_COLOR
++#define UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef UART_CONFIG_DEBUG_COLOR
++#define UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> USBD_CONFIG_LOG_ENABLED - Enable logging in the module
++//==========================================================
++#ifndef USBD_CONFIG_LOG_ENABLED
++#define USBD_CONFIG_LOG_ENABLED 0
++#endif
++// <o> USBD_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef USBD_CONFIG_LOG_LEVEL
++#define USBD_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef USBD_CONFIG_INFO_COLOR
++#define USBD_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef USBD_CONFIG_DEBUG_COLOR
++#define USBD_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef WDT_CONFIG_LOG_ENABLED
++#define WDT_CONFIG_LOG_ENABLED 0
++#endif
++// <o> WDT_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef WDT_CONFIG_LOG_LEVEL
++#define WDT_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef WDT_CONFIG_INFO_COLOR
++#define WDT_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef WDT_CONFIG_DEBUG_COLOR
++#define WDT_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nrf_log in nRF_Libraries 
++
++//==========================================================
++// <e> APP_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_TIMER_CONFIG_LOG_ENABLED
++#define APP_TIMER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_TIMER_CONFIG_LOG_LEVEL
++#define APP_TIMER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_TIMER_CONFIG_INITIAL_LOG_LEVEL  - Initial severity level if dynamic filtering is enabled.
++ 
++
++// <i> If module generates a lot of logs, initial log level can
++// <i> be decreased to prevent flooding. Severity level can be
++// <i> increased on instance basis.
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_TIMER_CONFIG_INITIAL_LOG_LEVEL
++#define APP_TIMER_CONFIG_INITIAL_LOG_LEVEL 3
++#endif
++
++// <o> APP_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_TIMER_CONFIG_INFO_COLOR
++#define APP_TIMER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_TIMER_CONFIG_DEBUG_COLOR
++#define APP_TIMER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_CDC_ACM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_CDC_ACM_CONFIG_LOG_ENABLED
++#define APP_USBD_CDC_ACM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_CDC_ACM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_CDC_ACM_CONFIG_LOG_LEVEL
++#define APP_USBD_CDC_ACM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_CDC_ACM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CDC_ACM_CONFIG_INFO_COLOR
++#define APP_USBD_CDC_ACM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_CDC_ACM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CDC_ACM_CONFIG_DEBUG_COLOR
++#define APP_USBD_CDC_ACM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_CONFIG_LOG_ENABLED - Enable logging in the module.
++//==========================================================
++#ifndef APP_USBD_CONFIG_LOG_ENABLED
++#define APP_USBD_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_CONFIG_LOG_LEVEL
++#define APP_USBD_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CONFIG_INFO_COLOR
++#define APP_USBD_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CONFIG_DEBUG_COLOR
++#define APP_USBD_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_DUMMY_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_DUMMY_CONFIG_LOG_ENABLED
++#define APP_USBD_DUMMY_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_DUMMY_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_DUMMY_CONFIG_LOG_LEVEL
++#define APP_USBD_DUMMY_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_DUMMY_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_DUMMY_CONFIG_INFO_COLOR
++#define APP_USBD_DUMMY_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_DUMMY_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_DUMMY_CONFIG_DEBUG_COLOR
++#define APP_USBD_DUMMY_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_MSC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_MSC_CONFIG_LOG_ENABLED
++#define APP_USBD_MSC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_MSC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_MSC_CONFIG_LOG_LEVEL
++#define APP_USBD_MSC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_MSC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_MSC_CONFIG_INFO_COLOR
++#define APP_USBD_MSC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_MSC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_MSC_CONFIG_DEBUG_COLOR
++#define APP_USBD_MSC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_ATFIFO_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_ATFIFO_CONFIG_LOG_ENABLED
++#define NRF_ATFIFO_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_ATFIFO_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_ATFIFO_CONFIG_LOG_LEVEL
++#define NRF_ATFIFO_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_ATFIFO_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_ATFIFO_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_ATFIFO_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_ATFIFO_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_ATFIFO_CONFIG_INFO_COLOR
++#define NRF_ATFIFO_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_ATFIFO_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_ATFIFO_CONFIG_DEBUG_COLOR
++#define NRF_ATFIFO_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BALLOC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BALLOC_CONFIG_LOG_ENABLED
++#define NRF_BALLOC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BALLOC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BALLOC_CONFIG_LOG_LEVEL
++#define NRF_BALLOC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BALLOC_CONFIG_INITIAL_LOG_LEVEL  - Initial severity level if dynamic filtering is enabled.
++ 
++
++// <i> If module generates a lot of logs, initial log level can
++// <i> be decreased to prevent flooding. Severity level can be
++// <i> increased on instance basis.
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BALLOC_CONFIG_INITIAL_LOG_LEVEL
++#define NRF_BALLOC_CONFIG_INITIAL_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BALLOC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BALLOC_CONFIG_INFO_COLOR
++#define NRF_BALLOC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BALLOC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BALLOC_CONFIG_DEBUG_COLOR
++#define NRF_BALLOC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_ENABLED
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_LEVEL
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_INFO_COLOR
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_DEBUG_COLOR
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BLOCK_DEV_QSPI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_LOG_ENABLED
++#define NRF_BLOCK_DEV_QSPI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_LOG_LEVEL
++#define NRF_BLOCK_DEV_QSPI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_BLOCK_DEV_QSPI_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_INFO_COLOR
++#define NRF_BLOCK_DEV_QSPI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_DEBUG_COLOR
++#define NRF_BLOCK_DEV_QSPI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BLOCK_DEV_RAM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_LOG_ENABLED
++#define NRF_BLOCK_DEV_RAM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_LOG_LEVEL
++#define NRF_BLOCK_DEV_RAM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_BLOCK_DEV_RAM_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_INFO_COLOR
++#define NRF_BLOCK_DEV_RAM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_DEBUG_COLOR
++#define NRF_BLOCK_DEV_RAM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_CLI_BLE_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_CLI_BLE_UART_CONFIG_LOG_ENABLED
++#define NRF_CLI_BLE_UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_CLI_BLE_UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_CLI_BLE_UART_CONFIG_LOG_LEVEL
++#define NRF_CLI_BLE_UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_CLI_BLE_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_BLE_UART_CONFIG_INFO_COLOR
++#define NRF_CLI_BLE_UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_CLI_BLE_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_BLE_UART_CONFIG_DEBUG_COLOR
++#define NRF_CLI_BLE_UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_CLI_LIBUARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_CLI_LIBUARTE_CONFIG_LOG_ENABLED
++#define NRF_CLI_LIBUARTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_CLI_LIBUARTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_CLI_LIBUARTE_CONFIG_LOG_LEVEL
++#define NRF_CLI_LIBUARTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_CLI_LIBUARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_LIBUARTE_CONFIG_INFO_COLOR
++#define NRF_CLI_LIBUARTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_CLI_LIBUARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_LIBUARTE_CONFIG_DEBUG_COLOR
++#define NRF_CLI_LIBUARTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_CLI_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_CLI_UART_CONFIG_LOG_ENABLED
++#define NRF_CLI_UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_CLI_UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_CLI_UART_CONFIG_LOG_LEVEL
++#define NRF_CLI_UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_CLI_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_UART_CONFIG_INFO_COLOR
++#define NRF_CLI_UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_CLI_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_UART_CONFIG_DEBUG_COLOR
++#define NRF_CLI_UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_LIBUARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_LIBUARTE_CONFIG_LOG_ENABLED
++#define NRF_LIBUARTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_LIBUARTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_LIBUARTE_CONFIG_LOG_LEVEL
++#define NRF_LIBUARTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_LIBUARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LIBUARTE_CONFIG_INFO_COLOR
++#define NRF_LIBUARTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_LIBUARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LIBUARTE_CONFIG_DEBUG_COLOR
++#define NRF_LIBUARTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_MEMOBJ_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_MEMOBJ_CONFIG_LOG_ENABLED
++#define NRF_MEMOBJ_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_MEMOBJ_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_MEMOBJ_CONFIG_LOG_LEVEL
++#define NRF_MEMOBJ_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_MEMOBJ_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MEMOBJ_CONFIG_INFO_COLOR
++#define NRF_MEMOBJ_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_MEMOBJ_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MEMOBJ_CONFIG_DEBUG_COLOR
++#define NRF_MEMOBJ_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_PWR_MGMT_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_PWR_MGMT_CONFIG_LOG_ENABLED
++#define NRF_PWR_MGMT_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_PWR_MGMT_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_PWR_MGMT_CONFIG_LOG_LEVEL
++#define NRF_PWR_MGMT_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_PWR_MGMT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_PWR_MGMT_CONFIG_INFO_COLOR
++#define NRF_PWR_MGMT_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_PWR_MGMT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_PWR_MGMT_CONFIG_DEBUG_COLOR
++#define NRF_PWR_MGMT_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_QUEUE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_QUEUE_CONFIG_LOG_ENABLED
++#define NRF_QUEUE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_QUEUE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_QUEUE_CONFIG_LOG_LEVEL
++#define NRF_QUEUE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_QUEUE_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_QUEUE_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_QUEUE_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_QUEUE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_QUEUE_CONFIG_INFO_COLOR
++#define NRF_QUEUE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_QUEUE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_QUEUE_CONFIG_DEBUG_COLOR
++#define NRF_QUEUE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_ANT_LOG_ENABLED - Enable logging in SoftDevice handler (ANT) module.
++//==========================================================
++#ifndef NRF_SDH_ANT_LOG_ENABLED
++#define NRF_SDH_ANT_LOG_ENABLED 0
++#endif
++// <o> NRF_SDH_ANT_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_ANT_LOG_LEVEL
++#define NRF_SDH_ANT_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_ANT_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_ANT_INFO_COLOR
++#define NRF_SDH_ANT_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_ANT_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_ANT_DEBUG_COLOR
++#define NRF_SDH_ANT_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_BLE_LOG_ENABLED - Enable logging in SoftDevice handler (BLE) module.
++//==========================================================
++#ifndef NRF_SDH_BLE_LOG_ENABLED
++#define NRF_SDH_BLE_LOG_ENABLED 1
++#endif
++// <o> NRF_SDH_BLE_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_BLE_LOG_LEVEL
++#define NRF_SDH_BLE_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_BLE_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_BLE_INFO_COLOR
++#define NRF_SDH_BLE_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_BLE_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_BLE_DEBUG_COLOR
++#define NRF_SDH_BLE_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_LOG_ENABLED - Enable logging in SoftDevice handler module.
++//==========================================================
++#ifndef NRF_SDH_LOG_ENABLED
++#define NRF_SDH_LOG_ENABLED 1
++#endif
++// <o> NRF_SDH_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_LOG_LEVEL
++#define NRF_SDH_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_INFO_COLOR
++#define NRF_SDH_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_DEBUG_COLOR
++#define NRF_SDH_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_SOC_LOG_ENABLED - Enable logging in SoftDevice handler (SoC) module.
++//==========================================================
++#ifndef NRF_SDH_SOC_LOG_ENABLED
++#define NRF_SDH_SOC_LOG_ENABLED 1
++#endif
++// <o> NRF_SDH_SOC_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_SOC_LOG_LEVEL
++#define NRF_SDH_SOC_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_SOC_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_SOC_INFO_COLOR
++#define NRF_SDH_SOC_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_SOC_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_SOC_DEBUG_COLOR
++#define NRF_SDH_SOC_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SORTLIST_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_SORTLIST_CONFIG_LOG_ENABLED
++#define NRF_SORTLIST_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_SORTLIST_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SORTLIST_CONFIG_LOG_LEVEL
++#define NRF_SORTLIST_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SORTLIST_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SORTLIST_CONFIG_INFO_COLOR
++#define NRF_SORTLIST_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_SORTLIST_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SORTLIST_CONFIG_DEBUG_COLOR
++#define NRF_SORTLIST_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_TWI_SENSOR_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_TWI_SENSOR_CONFIG_LOG_ENABLED
++#define NRF_TWI_SENSOR_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_TWI_SENSOR_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_TWI_SENSOR_CONFIG_LOG_LEVEL
++#define NRF_TWI_SENSOR_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_TWI_SENSOR_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_TWI_SENSOR_CONFIG_INFO_COLOR
++#define NRF_TWI_SENSOR_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_TWI_SENSOR_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_TWI_SENSOR_CONFIG_DEBUG_COLOR
++#define NRF_TWI_SENSOR_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PM_LOG_ENABLED - Enable logging in Peer Manager and its submodules.
++//==========================================================
++#ifndef PM_LOG_ENABLED
++#define PM_LOG_ENABLED 1
++#endif
++// <o> PM_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PM_LOG_LEVEL
++#define PM_LOG_LEVEL 3
++#endif
++
++// <o> PM_LOG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PM_LOG_INFO_COLOR
++#define PM_LOG_INFO_COLOR 0
++#endif
++
++// <o> PM_LOG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PM_LOG_DEBUG_COLOR
++#define PM_LOG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nrf_log in nRF_Serialization 
++
++//==========================================================
++// <e> SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED
++#define SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL
++#define SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SER_HAL_TRANSPORT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SER_HAL_TRANSPORT_CONFIG_INFO_COLOR
++#define SER_HAL_TRANSPORT_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SER_HAL_TRANSPORT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SER_HAL_TRANSPORT_CONFIG_DEBUG_COLOR
++#define SER_HAL_TRANSPORT_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// </e>
++
++// <q> NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED  - nrf_log_str_formatter - Log string formatter
++ 
++
++#ifndef NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED
++#define NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED 1
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Segger_RTT 
++
++//==========================================================
++// <h> segger_rtt - SEGGER RTT
++
++//==========================================================
++// <o> SEGGER_RTT_CONFIG_BUFFER_SIZE_UP - Size of upstream buffer. 
++// <i> Note that either @ref NRF_LOG_BACKEND_RTT_OUTPUT_BUFFER_SIZE
++// <i> or this value is actually used. It depends on which one is bigger.
++
++#ifndef SEGGER_RTT_CONFIG_BUFFER_SIZE_UP
++#define SEGGER_RTT_CONFIG_BUFFER_SIZE_UP 512
++#endif
++
++// <o> SEGGER_RTT_CONFIG_MAX_NUM_UP_BUFFERS - Size of upstream buffer. 
++#ifndef SEGGER_RTT_CONFIG_MAX_NUM_UP_BUFFERS
++#define SEGGER_RTT_CONFIG_MAX_NUM_UP_BUFFERS 2
++#endif
++
++// <o> SEGGER_RTT_CONFIG_BUFFER_SIZE_DOWN - Size of upstream buffer. 
++#ifndef SEGGER_RTT_CONFIG_BUFFER_SIZE_DOWN
++#define SEGGER_RTT_CONFIG_BUFFER_SIZE_DOWN 16
++#endif
++
++// <o> SEGGER_RTT_CONFIG_MAX_NUM_DOWN_BUFFERS - Size of upstream buffer. 
++#ifndef SEGGER_RTT_CONFIG_MAX_NUM_DOWN_BUFFERS
++#define SEGGER_RTT_CONFIG_MAX_NUM_DOWN_BUFFERS 2
++#endif
++
++// <o> SEGGER_RTT_CONFIG_DEFAULT_MODE  - RTT behavior if the buffer is full.
++ 
++
++// <i> The following modes are supported:
++// <i> - SKIP  - Do not block, output nothing.
++// <i> - TRIM  - Do not block, output as much as fits.
++// <i> - BLOCK - Wait until there is space in the buffer.
++// <0=> SKIP 
++// <1=> TRIM 
++// <2=> BLOCK_IF_FIFO_FULL 
++
++#ifndef SEGGER_RTT_CONFIG_DEFAULT_MODE
++#define SEGGER_RTT_CONFIG_DEFAULT_MODE 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> nRF_SoftDevice 
++
++//==========================================================
++// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
++//==========================================================
++#ifndef NRF_SDH_BLE_ENABLED
++#define NRF_SDH_BLE_ENABLED 1
++#endif
++// <h> BLE Stack configuration - Stack configuration parameters
++
++// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
++// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
++//==========================================================
++// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251> 
++
++
++// <i> Requested BLE GAP data length to be negotiated.
++
++#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
++#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
++#endif
++
++// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
++#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
++#endif
++
++// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
++#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
++#endif
++
++// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
++// <i> Maximum number of total concurrent connections using the default configuration.
++
++#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
++#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
++#endif
++
++// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length. 
++// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
++
++#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
++#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
++#endif
++
++// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size. 
++#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
++#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 250
++#endif
++
++// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4. 
++#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
++#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
++#endif
++
++// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs. 
++#ifndef NRF_SDH_BLE_VS_UUID_COUNT
++#define NRF_SDH_BLE_VS_UUID_COUNT 0
++#endif
++
++// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
++ 
++
++#ifndef NRF_SDH_BLE_SERVICE_CHANGED
++#define NRF_SDH_BLE_SERVICE_CHANGED 0
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> BLE Observers - Observers and priority levels
++
++//==========================================================
++// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers. 
++// <i> This setting configures the number of priority levels available for BLE event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
++#endif
++
++// <h> BLE Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> BLE_ADV_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Advertising module.
++
++#ifndef BLE_ADV_BLE_OBSERVER_PRIO
++#define BLE_ADV_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_ANCS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Apple Notification Service Client.
++
++#ifndef BLE_ANCS_C_BLE_OBSERVER_PRIO
++#define BLE_ANCS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_ANS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Alert Notification Service Client.
++
++#ifndef BLE_ANS_C_BLE_OBSERVER_PRIO
++#define BLE_ANS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_BAS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Battery Service.
++
++#ifndef BLE_BAS_BLE_OBSERVER_PRIO
++#define BLE_BAS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_BAS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Battery Service Client.
++
++#ifndef BLE_BAS_C_BLE_OBSERVER_PRIO
++#define BLE_BAS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_BPS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Blood Pressure Service.
++
++#ifndef BLE_BPS_BLE_OBSERVER_PRIO
++#define BLE_BPS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_CONN_PARAMS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Connection parameters module.
++
++#ifndef BLE_CONN_PARAMS_BLE_OBSERVER_PRIO
++#define BLE_CONN_PARAMS_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Connection State module.
++
++#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
++#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
++#endif
++
++// <o> BLE_CSCS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Cycling Speed and Cadence Service.
++
++#ifndef BLE_CSCS_BLE_OBSERVER_PRIO
++#define BLE_CSCS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_CTS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Current Time Service Client.
++
++#ifndef BLE_CTS_C_BLE_OBSERVER_PRIO
++#define BLE_CTS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_DB_DISC_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Database Discovery module.
++
++#ifndef BLE_DB_DISC_BLE_OBSERVER_PRIO
++#define BLE_DB_DISC_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_DFU_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the DFU Service.
++
++#ifndef BLE_DFU_BLE_OBSERVER_PRIO
++#define BLE_DFU_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_DIS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Device Information Client.
++
++#ifndef BLE_DIS_C_BLE_OBSERVER_PRIO
++#define BLE_DIS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_GLS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Glucose Service.
++
++#ifndef BLE_GLS_BLE_OBSERVER_PRIO
++#define BLE_GLS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HIDS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Human Interface Device Service.
++
++#ifndef BLE_HIDS_BLE_OBSERVER_PRIO
++#define BLE_HIDS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HRS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Heart Rate Service.
++
++#ifndef BLE_HRS_BLE_OBSERVER_PRIO
++#define BLE_HRS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HRS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Heart Rate Service Client.
++
++#ifndef BLE_HRS_C_BLE_OBSERVER_PRIO
++#define BLE_HRS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HTS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Health Thermometer Service.
++
++#ifndef BLE_HTS_BLE_OBSERVER_PRIO
++#define BLE_HTS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_IAS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Immediate Alert Service.
++
++#ifndef BLE_IAS_BLE_OBSERVER_PRIO
++#define BLE_IAS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_IAS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Immediate Alert Service Client.
++
++#ifndef BLE_IAS_C_BLE_OBSERVER_PRIO
++#define BLE_IAS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LBS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the LED Button Service.
++
++#ifndef BLE_LBS_BLE_OBSERVER_PRIO
++#define BLE_LBS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LBS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the LED Button Service Client.
++
++#ifndef BLE_LBS_C_BLE_OBSERVER_PRIO
++#define BLE_LBS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LLS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Link Loss Service.
++
++#ifndef BLE_LLS_BLE_OBSERVER_PRIO
++#define BLE_LLS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LNS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Location Navigation Service.
++
++#ifndef BLE_LNS_BLE_OBSERVER_PRIO
++#define BLE_LNS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_NUS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the UART Service.
++
++#ifndef BLE_NUS_BLE_OBSERVER_PRIO
++#define BLE_NUS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_NUS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the UART Central Service.
++
++#ifndef BLE_NUS_C_BLE_OBSERVER_PRIO
++#define BLE_NUS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_OTS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Object transfer service.
++
++#ifndef BLE_OTS_BLE_OBSERVER_PRIO
++#define BLE_OTS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_OTS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Object transfer service client.
++
++#ifndef BLE_OTS_C_BLE_OBSERVER_PRIO
++#define BLE_OTS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_RSCS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Running Speed and Cadence Service.
++
++#ifndef BLE_RSCS_BLE_OBSERVER_PRIO
++#define BLE_RSCS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_RSCS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Running Speed and Cadence Client.
++
++#ifndef BLE_RSCS_C_BLE_OBSERVER_PRIO
++#define BLE_RSCS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_TPS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the TX Power Service.
++
++#ifndef BLE_TPS_BLE_OBSERVER_PRIO
++#define BLE_TPS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BSP_BTN_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Button Control module.
++
++#ifndef BSP_BTN_BLE_OBSERVER_PRIO
++#define BSP_BTN_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the NFC pairing library.
++
++#ifndef NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO
++#define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the NFC pairing library.
++
++#ifndef NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO
++#define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the NFC pairing library.
++
++#ifndef NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO
++#define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Bond Management Service.
++
++#ifndef NRF_BLE_BMS_BLE_OBSERVER_PRIO
++#define NRF_BLE_BMS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_CGMS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Contiuon Glucose Monitoring Service.
++
++#ifndef NRF_BLE_CGMS_BLE_OBSERVER_PRIO
++#define NRF_BLE_CGMS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_ES_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Eddystone module.
++
++#ifndef NRF_BLE_ES_BLE_OBSERVER_PRIO
++#define NRF_BLE_ES_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_GATTS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the GATT Service Client.
++
++#ifndef NRF_BLE_GATTS_C_BLE_OBSERVER_PRIO
++#define NRF_BLE_GATTS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_GATT_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the GATT module.
++
++#ifndef NRF_BLE_GATT_BLE_OBSERVER_PRIO
++#define NRF_BLE_GATT_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NRF_BLE_QWR_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Queued writes module.
++
++#ifndef NRF_BLE_QWR_BLE_OBSERVER_PRIO
++#define NRF_BLE_QWR_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_SCAN_OBSERVER_PRIO  
++// <i> Priority for dispatching the BLE events to the Scanning Module.
++
++#ifndef NRF_BLE_SCAN_OBSERVER_PRIO
++#define NRF_BLE_SCAN_OBSERVER_PRIO 1
++#endif
++
++// <o> PM_BLE_OBSERVER_PRIO - Priority with which BLE events are dispatched to the Peer Manager module. 
++#ifndef PM_BLE_OBSERVER_PRIO
++#define PM_BLE_OBSERVER_PRIO 1
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++
++// </e>
++
++// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
++//==========================================================
++#ifndef NRF_SDH_ENABLED
++#define NRF_SDH_ENABLED 1
++#endif
++// <h> Dispatch model 
++
++// <i> This setting configures how Stack events are dispatched to the application.
++//==========================================================
++// <o> NRF_SDH_DISPATCH_MODEL
++ 
++
++// <i> NRF_SDH_DISPATCH_MODEL_INTERRUPT: SoftDevice events are passed to the application from the interrupt context.
++// <i> NRF_SDH_DISPATCH_MODEL_APPSH: SoftDevice events are scheduled using @ref app_scheduler.
++// <i> NRF_SDH_DISPATCH_MODEL_POLLING: SoftDevice events are to be fetched manually.
++// <0=> NRF_SDH_DISPATCH_MODEL_INTERRUPT 
++// <1=> NRF_SDH_DISPATCH_MODEL_APPSH 
++// <2=> NRF_SDH_DISPATCH_MODEL_POLLING 
++
++#ifndef NRF_SDH_DISPATCH_MODEL
++#define NRF_SDH_DISPATCH_MODEL 0
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> Clock - SoftDevice clock configuration
++
++//==========================================================
++// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
++ 
++// <0=> NRF_CLOCK_LF_SRC_RC 
++// <1=> NRF_CLOCK_LF_SRC_XTAL 
++// <2=> NRF_CLOCK_LF_SRC_SYNTH 
++
++#ifndef NRF_SDH_CLOCK_LF_SRC
++#define NRF_SDH_CLOCK_LF_SRC 1
++#endif
++
++// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval. 
++#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
++#define NRF_SDH_CLOCK_LF_RC_CTIV 0
++#endif
++
++// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature. 
++// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
++// <i>  if the temperature has not changed.
++
++#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
++#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
++#endif
++
++// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
++ 
++// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM 
++// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM 
++// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM 
++// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM 
++// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM 
++// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM 
++// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM 
++// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM 
++// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM 
++// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM 
++// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM 
++// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM 
++
++#ifndef NRF_SDH_CLOCK_LF_ACCURACY
++#define NRF_SDH_CLOCK_LF_ACCURACY 7
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> SDH Observers - Observers and priority levels
++
++//==========================================================
++// <o> NRF_SDH_REQ_OBSERVER_PRIO_LEVELS - Total number of priority levels for request observers. 
++// <i> This setting configures the number of priority levels available for the SoftDevice request event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_REQ_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_REQ_OBSERVER_PRIO_LEVELS 2
++#endif
++
++// <o> NRF_SDH_STATE_OBSERVER_PRIO_LEVELS - Total number of priority levels for state observers. 
++// <i> This setting configures the number of priority levels available for the SoftDevice state event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_STATE_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_STATE_OBSERVER_PRIO_LEVELS 2
++#endif
++
++// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers. 
++// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
++#endif
++
++
++// <h> State Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> CLOCK_CONFIG_STATE_OBSERVER_PRIO  
++// <i> Priority with which state events are dispatched to the Clock driver.
++
++#ifndef CLOCK_CONFIG_STATE_OBSERVER_PRIO
++#define CLOCK_CONFIG_STATE_OBSERVER_PRIO 0
++#endif
++
++// <o> POWER_CONFIG_STATE_OBSERVER_PRIO  
++// <i> Priority with which state events are dispatched to the Power driver.
++
++#ifndef POWER_CONFIG_STATE_OBSERVER_PRIO
++#define POWER_CONFIG_STATE_OBSERVER_PRIO 0
++#endif
++
++// <o> RNG_CONFIG_STATE_OBSERVER_PRIO  
++// <i> Priority with which state events are dispatched to this module.
++
++#ifndef RNG_CONFIG_STATE_OBSERVER_PRIO
++#define RNG_CONFIG_STATE_OBSERVER_PRIO 0
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> Stack Event Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> NRF_SDH_ANT_STACK_OBSERVER_PRIO  
++// <i> This setting configures the priority with which ANT events are processed with respect to other events coming from the stack.
++// <i> Modify this setting if you need to have ANT events dispatched before or after other stack events, such as BLE or SoC.
++// <i> Zero is the highest priority.
++
++#ifndef NRF_SDH_ANT_STACK_OBSERVER_PRIO
++#define NRF_SDH_ANT_STACK_OBSERVER_PRIO 0
++#endif
++
++// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO  
++// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
++// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
++// <i> Zero is the highest priority.
++
++#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
++#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
++#endif
++
++// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO  
++// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
++// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
++// <i> Zero is the highest priority.
++
++#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
++#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++
++// </e>
++
++// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
++//==========================================================
++#ifndef NRF_SDH_SOC_ENABLED
++#define NRF_SDH_SOC_ENABLED 1
++#endif
++// <h> SoC Observers - Observers and priority levels
++
++//==========================================================
++// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers. 
++// <i> This setting configures the number of priority levels available for the SoC event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
++#endif
++
++// <h> SoC Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> BLE_ADV_SOC_OBSERVER_PRIO  
++// <i> Priority with which SoC events are dispatched to the Advertising module.
++
++#ifndef BLE_ADV_SOC_OBSERVER_PRIO
++#define BLE_ADV_SOC_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_DFU_SOC_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the DFU Service.
++
++#ifndef BLE_DFU_SOC_OBSERVER_PRIO
++#define BLE_DFU_SOC_OBSERVER_PRIO 1
++#endif
++
++// <o> CLOCK_CONFIG_SOC_OBSERVER_PRIO  
++// <i> Priority with which SoC events are dispatched to the Clock driver.
++
++#ifndef CLOCK_CONFIG_SOC_OBSERVER_PRIO
++#define CLOCK_CONFIG_SOC_OBSERVER_PRIO 0
++#endif
++
++// <o> POWER_CONFIG_SOC_OBSERVER_PRIO  
++// <i> Priority with which SoC events are dispatched to the Power driver.
++
++#ifndef POWER_CONFIG_SOC_OBSERVER_PRIO
++#define POWER_CONFIG_SOC_OBSERVER_PRIO 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <<< end of configuration section >>>
++#endif //SDK_CONFIG_H
++
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+new file mode 100644
+index 0000000..745b6a7
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+@@ -0,0 +1,166 @@
++<!DOCTYPE CrossStudio_Project_File>
++<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
++  <project Name="ble_connectivity_132v3_usb_hci_pca10056">
++    <configuration
++      Name="Common"
++      arm_architecture="v7EM"
++      arm_core_type="Cortex-M4"
++      arm_endian="Little"
++      arm_fp_abi="Hard"
++      arm_fpu_type="FPv4-SP-D16"
++      arm_linker_heap_size="512"
++      arm_linker_process_stack_size="0"
++      arm_linker_stack_size="2048"
++      arm_linker_treat_warnings_as_errors="No"
++      arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
++      arm_target_device_name="nRF52840_xxAA"
++      arm_target_interface_type="SWD"
++      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/ble/common;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s132v3/headers;../../../../../../components/softdevice/s132v3/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
++      c_preprocessor_definitions="BLE_STACK_SUPPORT_REQD;BOARD_PCA10056;BSP_DEFINES_ONLY;CONFIG_GPIO_AS_PINRESET;FLOAT_ABI_HARD;HCI_TIMER2;INITIALIZE_USER_SECTIONS;NO_VTOR_CONFIG;NRF52840_XXAA;NRF_SD_BLE_API_VERSION=3;S132;SER_CONNECTIVITY;SER_PHY_HCI_USB_CDC;SOFTDEVICE_PRESENT;SWI_DISABLE0;"
++      debug_target_connection="J-Link"
++      gcc_entry_point="Reset_Handler"
++      macros="CMSIS_CONFIG_TOOL=../../../../../../external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar"
++      debug_register_definition_file="../../../../../../modules/nrfx/mdk/nrf52840.svd"
++      debug_additional_load_file="../../../../../../components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex"
++      debug_start_from_entry_point_symbol="No"
++      gcc_debugging_level="Level 3"      linker_output_format="hex"
++      linker_printf_width_precision_supported="Yes"
++      linker_printf_fmt_level="long"
++      linker_section_placement_file="flash_placement.xml"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x100000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x40000;FLASH_START=0x1f000;FLASH_SIZE=0xe1000;RAM_START=0x200199c0;RAM_SIZE=0x26640"
++      linker_section_placements_segments="FLASH RX 0x0 0x100000;RAM RWX 0x20000000 0x40000;connectivity_version_info RX 0x50000 0x18"
++      project_directory=""
++      project_type="Executable" />
++      <folder Name="Segger Startup Files">
++        <file file_name="$(StudioDir)/source/thumb_crt0.s" />
++      </folder>
++    <folder Name="nRF_Log">
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_backend_rtt.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_backend_serial.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_backend_uart.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_default_backends.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_frontend.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_str_formatter.c" />
++    </folder>
++    <folder Name="nRF_Libraries">
++      <file file_name="../../../../../../components/libraries/util/app_error.c" />
++      <file file_name="../../../../../../components/libraries/util/app_error_handler_gcc.c" />
++      <file file_name="../../../../../../components/libraries/util/app_error_weak.c" />
++      <file file_name="../../../../../../components/libraries/scheduler/app_scheduler.c" />
++      <file file_name="../../../../../../components/libraries/timer/app_timer.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd.c" />
++      <file file_name="../../../../../../components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd_core.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd_serial_num.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd_string_desc.c" />
++      <file file_name="../../../../../../components/libraries/util/app_util_platform.c" />
++      <file file_name="../../../../../../components/libraries/crc16/crc16.c" />
++      <file file_name="../../../../../../components/libraries/util/nrf_assert.c" />
++      <file file_name="../../../../../../components/libraries/atomic_fifo/nrf_atfifo.c" />
++      <file file_name="../../../../../../components/libraries/atomic/nrf_atomic.c" />
++      <file file_name="../../../../../../components/libraries/balloc/nrf_balloc.c" />
++      <file file_name="../../../../../../external/fprintf/nrf_fprintf.c" />
++      <file file_name="../../../../../../external/fprintf/nrf_fprintf_format.c" />
++      <file file_name="../../../../../../components/libraries/memobj/nrf_memobj.c" />
++      <file file_name="../../../../../../components/libraries/queue/nrf_queue.c" />
++      <file file_name="../../../../../../components/libraries/ringbuf/nrf_ringbuf.c" />
++      <file file_name="../../../../../../components/libraries/experimental_section_vars/nrf_section_iter.c" />
++      <file file_name="../../../../../../components/libraries/strerror/nrf_strerror.c" />
++    </folder>
++    <folder Name="None">
++      <file file_name="../../../../../../modules/nrfx/mdk/ses_startup_nrf52840.s" />
++      <file file_name="../../../../../../modules/nrfx/mdk/ses_startup_nrf_common.s" />
++      <file file_name="../../../../../../modules/nrfx/mdk/system_nrf52840.c" />
++    </folder>
++    <folder Name="Board Definition">
++      <file file_name="../../../../../../components/boards/boards.c" />
++    </folder>
++    <folder Name="nRF_Serialization">
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/common/ble_dtm_init.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gatt_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gattc_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gattc_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gattc_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gatts_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gatts_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gatts_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_l2cap_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/ble_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/cond_field_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/conn_ble_l2cap_sdu_pool.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/common/conn_mw.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gattc.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gatts.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_l2cap.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/common/conn_mw_nrf_soc.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/hal/dtm_uart.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/nrf_soc_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/nrf_soc_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_cmd_decoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_dtm_cmd_decoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_error_handling.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_event_encoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_handlers.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_pkt_decoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_reset_cmd_decoder.c" />
++      <file file_name="../../../../../../components/serialization/common/ser_dbg_sd_str.c" />
++      <file file_name="../../../../../../components/serialization/common/transport/ser_hal_transport.c" />
++      <file file_name="../../../../../../components/serialization/common/transport/ser_phy/ser_phy_hci.c" />
++      <file file_name="../../../../../../components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c" />
++    </folder>
++    <folder Name="nRF_Drivers">
++      <file file_name="../../../../../../integration/nrfx/legacy/nrf_drv_clock.c" />
++      <file file_name="../../../../../../integration/nrfx/legacy/nrf_drv_power.c" />
++      <file file_name="../../../../../../integration/nrfx/legacy/nrf_drv_uart.c" />
++      <file file_name="../../../../../../components/drivers_nrf/usbd/nrf_drv_usbd.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_clock.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
++    </folder>
++    <folder Name="Application">
++      <file file_name="../../../main.c" />
++      <file file_name="../config/sdk_config.h" />
++    </folder>
++    <folder Name="nRF_Segger_RTT">
++      <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT.c" />
++      <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT_Syscalls_SES.c" />
++      <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT_printf.c" />
++    </folder>
++    <folder Name="nRF_BLE">
++      <file file_name="../../../../../../components/ble/common/ble_advdata.c" />
++      <file file_name="../../../../../../components/ble/ble_dtm/ble_dtm.c" />
++      <file file_name="../../../../../../components/ble/ble_dtm/ble_dtm_hw_nrf52.c" />
++      <file file_name="../../../../../../components/ble/common/ble_srv_common.c" />
++    </folder>
++    <folder Name="UTF8/UTF16 converter">
++      <file file_name="../../../../../../external/utf_converter/utf.c" />
++    </folder>
++    <folder Name="nRF_SoftDevice">
++      <file file_name="../../../../../../components/softdevice/common/nrf_sdh.c" />
++      <file file_name="../../../../../../components/softdevice/common/nrf_sdh_ble.c" />
++      <file file_name="../../../../../../components/softdevice/common/nrf_sdh_soc.c" />
++    </folder>
++  </project>
++  <configuration Name="Release"
++    c_preprocessor_definitions="NDEBUG"
++    gcc_optimization_level="Optimize For Size" />
++  <configuration Name="Debug"
++    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
++    gcc_optimization_level="None"/>
++</solution>
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+new file mode 100644
+index 0000000..ce75e3c
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+@@ -0,0 +1,7 @@
++<!DOCTYPE CrossStudio_Session_File>
++<session>
++  <ARMCrossStudioWindow activeProject="ble_connectivity_132v3_usb_hci_pca10056" buildConfiguration="Release"/>
++  <Files>
++    <SessionOpenFile codecName="Default" debugPath="../../../main.c" left="0" name="unnamed" path="../../../main.c" selected="1" top="0" useBinaryEdit="0" useTextEdit="1" x="0" y="0"/>
++  </Files>
++</session>
+\ No newline at end of file
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+new file mode 100644
+index 0000000..95c368d
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+@@ -0,0 +1,49 @@
++<!DOCTYPE Linker_Placement_File>
++<Root name="Flash Section Placement">
++  <MemorySegment name="FLASH" start="$(FLASH_PH_START)" size="$(FLASH_PH_SIZE)">
++    <ProgramSection load="no" name=".reserved_flash" start="$(FLASH_PH_START)" size="$(FLASH_START)-$(FLASH_PH_START)" />
++    <ProgramSection alignment="0x100" load="Yes" name=".vectors" start="$(FLASH_START)" />
++    <ProgramSection alignment="4" load="Yes" name=".init" />
++    <ProgramSection alignment="4" load="Yes" name=".init_rodata" />
++    <ProgramSection alignment="4" load="Yes" name=".text" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_ble_observers" inputsections="*(SORT(.sdh_ble_observers*))" address_symbol="__start_sdh_ble_observers" end_symbol="__stop_sdh_ble_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_filter_data"  inputsections="*(SORT(.log_filter_data*))" runin=".log_filter_data_run"/>
++    <ProgramSection alignment="4" load="Yes" name=".dtors" />
++    <ProgramSection alignment="4" load="Yes" name=".ctors" />
++    <ProgramSection alignment="4" load="Yes" name=".rodata" />
++    <ProgramSection alignment="4" load="Yes" name=".ARM.exidx" address_symbol="__exidx_start" end_symbol="__exidx_end" />
++    <ProgramSection alignment="4" load="Yes" runin=".fast_run" name=".fast" />
++    <ProgramSection alignment="4" load="Yes" runin=".data_run" name=".data" />
++    <ProgramSection alignment="4" load="Yes" runin=".tdata_run" name=".tdata" />
++  </MemorySegment>
++  <MemorySegment name="RAM" start="$(RAM_PH_START)" size="$(RAM_PH_SIZE)">
++    <ProgramSection load="no" name=".reserved_ram" start="$(RAM_PH_START)" size="$(RAM_START)-$(RAM_PH_START)" />
++    <ProgramSection alignment="0x100" load="No" name=".vectors_ram" start="$(RAM_START)" address_symbol="__app_ram_start__"/>
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections_run" address_symbol="__start_nrf_sections_run" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".log_dynamic_data_run" address_symbol="__start_log_dynamic_data" end_symbol="__stop_log_dynamic_data" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".log_filter_data_run" address_symbol="__start_log_filter_data" end_symbol="__stop_log_filter_data" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections_run_end" address_symbol="__end_nrf_sections_run" />
++    <ProgramSection alignment="4" load="No" name=".fast_run" />
++    <ProgramSection alignment="4" load="No" name=".data_run" />
++    <ProgramSection alignment="4" load="No" name=".tdata_run" />
++    <ProgramSection alignment="4" load="No" name=".bss" />
++    <ProgramSection alignment="4" load="No" name=".tbss" />
++    <ProgramSection alignment="4" load="No" name=".non_init" />
++    <ProgramSection alignment="4" size="__HEAPSIZE__" load="No" name=".heap" />
++    <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
++    <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
++  </MemorySegment>
++  <MemorySegment name="connectivity_version_info" start="0x50000" size="0x18">
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
++  </MemorySegment>
++</Root>
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+new file mode 100644
+index 0000000..b7d508e
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+@@ -0,0 +1,277 @@
++PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
++TARGETS          := nrf52840_xxaa
++OUTPUT_DIRECTORY := _build
++
++SDK_ROOT := ../../../../../..
++PROJ_DIR := ../../..
++
++$(OUTPUT_DIRECTORY)/nrf52840_xxaa.out: \
++  LINKER_SCRIPT  := ble_connectivity_gcc_nrf52.ld
++
++# Source files common to all targets
++SRC_FILES += \
++  $(SDK_ROOT)/modules/nrfx/mdk/gcc_startup_nrf52840.S \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_rtt.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_serial.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_backend_uart.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_default_backends.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_frontend.c \
++  $(SDK_ROOT)/components/libraries/log/src/nrf_log_str_formatter.c \
++  $(SDK_ROOT)/components/libraries/util/app_error.c \
++  $(SDK_ROOT)/components/libraries/util/app_error_handler_gcc.c \
++  $(SDK_ROOT)/components/libraries/util/app_error_weak.c \
++  $(SDK_ROOT)/components/libraries/scheduler/app_scheduler.c \
++  $(SDK_ROOT)/components/libraries/timer/app_timer.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
++  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd_core.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd_serial_num.c \
++  $(SDK_ROOT)/components/libraries/usbd/app_usbd_string_desc.c \
++  $(SDK_ROOT)/components/libraries/util/app_util_platform.c \
++  $(SDK_ROOT)/components/libraries/crc16/crc16.c \
++  $(SDK_ROOT)/components/libraries/util/nrf_assert.c \
++  $(SDK_ROOT)/components/libraries/atomic_fifo/nrf_atfifo.c \
++  $(SDK_ROOT)/components/libraries/atomic/nrf_atomic.c \
++  $(SDK_ROOT)/components/libraries/balloc/nrf_balloc.c \
++  $(SDK_ROOT)/external/fprintf/nrf_fprintf.c \
++  $(SDK_ROOT)/external/fprintf/nrf_fprintf_format.c \
++  $(SDK_ROOT)/components/libraries/memobj/nrf_memobj.c \
++  $(SDK_ROOT)/components/libraries/queue/nrf_queue.c \
++  $(SDK_ROOT)/components/libraries/ringbuf/nrf_ringbuf.c \
++  $(SDK_ROOT)/components/libraries/experimental_section_vars/nrf_section_iter.c \
++  $(SDK_ROOT)/components/libraries/strerror/nrf_strerror.c \
++  $(SDK_ROOT)/modules/nrfx/mdk/system_nrf52840.c \
++  $(SDK_ROOT)/components/boards/boards.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/ble_dtm_init.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gatt_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gattc_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gattc_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gattc_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gatts_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_gatts_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_gatts_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_conn.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_evt_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_l2cap_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/ble_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/ble_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/common/cond_field_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/conn_ble_l2cap_sdu_pool.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/conn_mw.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gattc.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gatts.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_l2cap.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/conn_mw_nrf_soc.c \
++  $(SDK_ROOT)/components/serialization/connectivity/hal/dtm_uart.c \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/nrf_soc_conn.c \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble/nrf_soc_struct_serialization.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_cmd_decoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_dtm_cmd_decoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_error_handling.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_event_encoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_handlers.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_pkt_decoder.c \
++  $(SDK_ROOT)/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c \
++  $(SDK_ROOT)/components/serialization/common/ser_dbg_sd_str.c \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_hal_transport.c \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/ser_phy_hci.c \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c \
++  $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_clock.c \
++  $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_power.c \
++  $(SDK_ROOT)/integration/nrfx/legacy/nrf_drv_uart.c \
++  $(SDK_ROOT)/components/drivers_nrf/usbd/nrf_drv_usbd.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
++  $(PROJ_DIR)/main.c \
++  $(SDK_ROOT)/external/segger_rtt/SEGGER_RTT.c \
++  $(SDK_ROOT)/external/segger_rtt/SEGGER_RTT_Syscalls_GCC.c \
++  $(SDK_ROOT)/external/segger_rtt/SEGGER_RTT_printf.c \
++  $(SDK_ROOT)/components/ble/common/ble_advdata.c \
++  $(SDK_ROOT)/components/ble/common/ble_conn_params.c \
++  $(SDK_ROOT)/components/ble/ble_dtm/ble_dtm.c \
++  $(SDK_ROOT)/components/ble/ble_dtm/ble_dtm_hw_nrf52.c \
++  $(SDK_ROOT)/components/ble/common/ble_srv_common.c \
++  $(SDK_ROOT)/external/utf_converter/utf.c \
++  $(SDK_ROOT)/components/softdevice/common/nrf_sdh.c \
++  $(SDK_ROOT)/components/softdevice/common/nrf_sdh_ble.c \
++  $(SDK_ROOT)/components/softdevice/common/nrf_sdh_soc.c \
++
++# Include folders common to all targets
++INC_FOLDERS += \
++  $(SDK_ROOT)/components \
++  $(SDK_ROOT)/components/serialization/connectivity/hal \
++  $(SDK_ROOT)/modules/nrfx/mdk \
++  $(SDK_ROOT)/components/libraries/scheduler \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers \
++  $(SDK_ROOT)/components/toolchain/cmsis/include \
++  $(SDK_ROOT)/components/libraries/queue \
++  $(SDK_ROOT)/components/libraries/timer \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/common \
++  $(SDK_ROOT)/components/serialization/connectivity \
++  $(SDK_ROOT)/components/libraries/strerror \
++  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware \
++  $(SDK_ROOT)/components/libraries/crc16 \
++  $(SDK_ROOT)/components/ble/ble_dtm \
++  $(SDK_ROOT)/components/serialization/common \
++  $(SDK_ROOT)/components/libraries/util \
++  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm \
++  ../config \
++  $(SDK_ROOT)/components/libraries/usbd/class/cdc \
++  $(SDK_ROOT)/components/ble/common \
++  $(SDK_ROOT)/components/libraries/balloc \
++  $(SDK_ROOT)/components/drivers_nrf/usbd \
++  $(SDK_ROOT)/components/libraries/ringbuf \
++  $(SDK_ROOT)/modules/nrfx/hal \
++  $(SDK_ROOT)/components/libraries/bsp \
++  $(SDK_ROOT)/components/libraries/log \
++  $(SDK_ROOT)/external/utf_converter \
++  $(SDK_ROOT)/modules/nrfx \
++  $(SDK_ROOT)/components/libraries/experimental_section_vars \
++  $(SDK_ROOT)/integration/nrfx/legacy \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy \
++  $(SDK_ROOT)/components/libraries/usbd \
++  $(SDK_ROOT)/components/libraries/delay \
++  $(SDK_ROOT)/external/segger_rtt \
++  $(SDK_ROOT)/components/libraries/atomic_fifo \
++  $(SDK_ROOT)/components/softdevice/s132v5/headers \
++  $(SDK_ROOT)/components/libraries/atomic \
++  $(SDK_ROOT)/components/boards \
++  $(SDK_ROOT)/components/libraries/memobj \
++  $(SDK_ROOT)/components/serialization/common/struct_ser/ble \
++  $(SDK_ROOT)/integration/nrfx \
++  $(SDK_ROOT)/components/serialization/common/transport \
++  $(SDK_ROOT)/components/softdevice/common \
++  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/config \
++  $(SDK_ROOT)/modules/nrfx/drivers/include \
++  $(SDK_ROOT)/components/softdevice/s132v5/headers/nrf52 \
++  $(SDK_ROOT)/external/fprintf \
++  $(SDK_ROOT)/components/libraries/log/src \
++
++# Libraries common to all targets
++LIB_FILES += \
++
++# Optimization flags
++OPT = -Os -g3
++# Uncomment the line below to enable link time optimization
++#OPT += -flto
++
++# C flags common to all targets
++CFLAGS += $(OPT)
++CFLAGS += -DBLE_STACK_SUPPORT_REQD
++CFLAGS += -DBOARD_PCA10056
++CFLAGS += -DBSP_DEFINES_ONLY
++CFLAGS += -DCONFIG_GPIO_AS_PINRESET
++CFLAGS += -DFLOAT_ABI_HARD
++CFLAGS += -DHCI_TIMER2
++CFLAGS += -DNRF52840_XXAA
++CFLAGS += -DNRF_SD_BLE_API_VERSION=5
++CFLAGS += -DS132
++CFLAGS += -DSER_CONNECTIVITY
++CFLAGS += -DSER_PHY_HCI_USB_CDC
++CFLAGS += -DSOFTDEVICE_PRESENT
++CFLAGS += -DSWI_DISABLE0
++CFLAGS += -mcpu=cortex-m4
++CFLAGS += -mthumb -mabi=aapcs
++CFLAGS += -Wall -Werror
++CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
++# keep every function in a separate section, this allows linker to discard unused ones
++CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
++CFLAGS += -fno-builtin -fshort-enums
++
++# C++ flags common to all targets
++CXXFLAGS += $(OPT)
++
++# Assembler flags common to all targets
++ASMFLAGS += -g3
++ASMFLAGS += -mcpu=cortex-m4
++ASMFLAGS += -mthumb -mabi=aapcs
++ASMFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
++ASMFLAGS += -DBLE_STACK_SUPPORT_REQD
++ASMFLAGS += -DBOARD_PCA10056
++ASMFLAGS += -DBSP_DEFINES_ONLY
++ASMFLAGS += -DCONFIG_GPIO_AS_PINRESET
++ASMFLAGS += -DFLOAT_ABI_HARD
++ASMFLAGS += -DHCI_TIMER2
++ASMFLAGS += -DNRF52840_XXAA
++ASMFLAGS += -DNRF_SD_BLE_API_VERSION=5
++ASMFLAGS += -DS132
++ASMFLAGS += -DSER_CONNECTIVITY
++ASMFLAGS += -DSER_PHY_HCI_USB_CDC
++ASMFLAGS += -DSOFTDEVICE_PRESENT
++ASMFLAGS += -DSWI_DISABLE0
++
++# Linker flags
++LDFLAGS += $(OPT)
++LDFLAGS += -mthumb -mabi=aapcs -L$(SDK_ROOT)/modules/nrfx/mdk -T$(LINKER_SCRIPT)
++LDFLAGS += -mcpu=cortex-m4
++LDFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
++# let linker dump unused sections
++LDFLAGS += -Wl,--gc-sections
++# use newlib in nano version
++LDFLAGS += --specs=nano.specs
++
++nrf52840_xxaa: CFLAGS += -D__HEAP_SIZE=512
++nrf52840_xxaa: CFLAGS += -D__STACK_SIZE=2048
++nrf52840_xxaa: ASMFLAGS += -D__HEAP_SIZE=512
++nrf52840_xxaa: ASMFLAGS += -D__STACK_SIZE=2048
++
++# Add standard libraries at the very end of the linker input, after all objects
++# that may need symbols provided by these libraries.
++LIB_FILES += -lc -lnosys -lm
++
++
++.PHONY: default help
++
++# Default target - first one defined
++default: nrf52840_xxaa
++
++# Print all targets that can be built
++help:
++	@echo following targets are available:
++	@echo		nrf52840_xxaa
++	@echo		flash_softdevice
++	@echo		sdk_config - starting external tool for editing sdk_config.h
++	@echo		flash      - flashing binary
++
++TEMPLATE_PATH := $(SDK_ROOT)/components/toolchain/gcc
++
++
++include $(TEMPLATE_PATH)/Makefile.common
++
++$(foreach target, $(TARGETS), $(call define_target, $(target)))
++
++.PHONY: flash flash_softdevice erase
++
++# Flash the program
++flash: default
++	@echo Flashing: $(OUTPUT_DIRECTORY)/nrf52840_xxaa.hex
++	nrfjprog -f nrf52 --program $(OUTPUT_DIRECTORY)/nrf52840_xxaa.hex --sectorerase
++	nrfjprog -f nrf52 --reset
++
++# Flash softdevice
++flash_softdevice:
++	@echo Flashing: s132_nrf52_5.1.0_softdevice.hex
++	nrfjprog -f nrf52 --program $(SDK_ROOT)/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex --sectorerase
++	nrfjprog -f nrf52 --reset
++
++erase:
++	nrfjprog -f nrf52 --eraseall
++
++SDK_CONFIG_FILE := ../config/sdk_config.h
++CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
++sdk_config:
++	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+new file mode 100644
+index 0000000..1a80caf
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+@@ -0,0 +1,106 @@
++/* Linker script to configure memory regions. */
++
++SEARCH_DIR(.)
++GROUP(-lgcc -lc -lnosys)
++
++MEMORY
++{
++  FLASH (rx) : ORIGIN = 0x23000, LENGTH = 0xdd000
++  RAM (rwx) :  ORIGIN = 0x20019380, LENGTH = 0x26c80
++  connectivity_version_info (r) : ORIGIN = 0x50000, LENGTH = 0x18
++}
++
++SECTIONS
++{
++  .connectivity_version_info :
++  {
++    PROVIDE(__start_connectivity_version_info = .);
++    KEEP(*(SORT(.connectivity_version_info*)))
++    PROVIDE(__stop_connectivity_version_info = .);
++  } > connectivity_version_info
++}
++
++SECTIONS
++{
++  . = ALIGN(4);
++  .mem_section_dummy_ram :
++  {
++  }
++  .log_dynamic_data :
++  {
++    PROVIDE(__start_log_dynamic_data = .);
++    KEEP(*(SORT(.log_dynamic_data*)))
++    PROVIDE(__stop_log_dynamic_data = .);
++  } > RAM
++  .log_filter_data :
++  {
++    PROVIDE(__start_log_filter_data = .);
++    KEEP(*(SORT(.log_filter_data*)))
++    PROVIDE(__stop_log_filter_data = .);
++  } > RAM
++
++} INSERT AFTER .data;
++
++SECTIONS
++{
++  .mem_section_dummy_rom :
++  {
++  }
++  .sdh_ble_observers :
++  {
++    PROVIDE(__start_sdh_ble_observers = .);
++    KEEP(*(SORT(.sdh_ble_observers*)))
++    PROVIDE(__stop_sdh_ble_observers = .);
++  } > FLASH
++  .sdh_soc_observers :
++  {
++    PROVIDE(__start_sdh_soc_observers = .);
++    KEEP(*(SORT(.sdh_soc_observers*)))
++    PROVIDE(__stop_sdh_soc_observers = .);
++  } > FLASH
++    .nrf_queue :
++  {
++    PROVIDE(__start_nrf_queue = .);
++    KEEP(*(.nrf_queue))
++    PROVIDE(__stop_nrf_queue = .);
++  } > FLASH
++  .log_const_data :
++  {
++    PROVIDE(__start_log_const_data = .);
++    KEEP(*(SORT(.log_const_data*)))
++    PROVIDE(__stop_log_const_data = .);
++  } > FLASH
++    .nrf_balloc :
++  {
++    PROVIDE(__start_nrf_balloc = .);
++    KEEP(*(.nrf_balloc))
++    PROVIDE(__stop_nrf_balloc = .);
++  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
++  .sdh_req_observers :
++  {
++    PROVIDE(__start_sdh_req_observers = .);
++    KEEP(*(SORT(.sdh_req_observers*)))
++    PROVIDE(__stop_sdh_req_observers = .);
++  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
++  .log_backends :
++  {
++    PROVIDE(__start_log_backends = .);
++    KEEP(*(SORT(.log_backends*)))
++    PROVIDE(__stop_log_backends = .);
++  } > FLASH
++
++} INSERT AFTER .text
++
++INCLUDE "nrf_common.ld"
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+new file mode 100644
+index 0000000..03a7e92
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+@@ -0,0 +1,4883 @@
++/**
++ * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
++ *
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without modification,
++ * are permitted provided that the following conditions are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright notice, this
++ *    list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form, except as embedded into a Nordic
++ *    Semiconductor ASA integrated circuit in a product or a software update for
++ *    such product, must reproduce the above copyright notice, this list of
++ *    conditions and the following disclaimer in the documentation and/or other
++ *    materials provided with the distribution.
++ *
++ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
++ *    contributors may be used to endorse or promote products derived from this
++ *    software without specific prior written permission.
++ *
++ * 4. This software, with or without modification, must only be used with a
++ *    Nordic Semiconductor ASA integrated circuit.
++ *
++ * 5. Any software provided in binary form under this license must not be reverse
++ *    engineered, decompiled, modified and/or disassembled.
++ *
++ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
++ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
++ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
++ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
++ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ *
++ */
++
++
++
++#ifndef SDK_CONFIG_H
++#define SDK_CONFIG_H
++// <<< Use Configuration Wizard in Context Menu >>>\n
++#ifdef USE_APP_CONFIG
++#include "app_config.h"
++#endif
++// <h> nRF_BLE 
++
++//==========================================================
++// <q> BLE_DTM_ENABLED  - ble_dtm - Module for testing RF/PHY using DTM commands
++ 
++
++#ifndef BLE_DTM_ENABLED
++#define BLE_DTM_ENABLED 1
++#endif
++
++// <e> NRF_BLE_CONN_PARAMS_ENABLED - ble_conn_params - Initiating and executing a connection parameters negotiation procedure
++//==========================================================
++#ifndef NRF_BLE_CONN_PARAMS_ENABLED
++#define NRF_BLE_CONN_PARAMS_ENABLED 1
++#endif
++// <o> NRF_BLE_CONN_PARAMS_MAX_SLAVE_LATENCY_DEVIATION - The largest acceptable deviation in slave latency. 
++// <i> The largest deviation (+ or -) from the requested slave latency that will not be renegotiated.
++
++#ifndef NRF_BLE_CONN_PARAMS_MAX_SLAVE_LATENCY_DEVIATION
++#define NRF_BLE_CONN_PARAMS_MAX_SLAVE_LATENCY_DEVIATION 499
++#endif
++
++// <o> NRF_BLE_CONN_PARAMS_MAX_SUPERVISION_TIMEOUT_DEVIATION - The largest acceptable deviation (in 10 ms units) in supervision timeout. 
++// <i> The largest deviation (+ or -, in 10 ms units) from the requested supervision timeout that will not be renegotiated.
++
++#ifndef NRF_BLE_CONN_PARAMS_MAX_SUPERVISION_TIMEOUT_DEVIATION
++#define NRF_BLE_CONN_PARAMS_MAX_SUPERVISION_TIMEOUT_DEVIATION 65535
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Drivers 
++
++//==========================================================
++// <e> NRFX_CLOCK_ENABLED - nrfx_clock - CLOCK peripheral driver
++//==========================================================
++#ifndef NRFX_CLOCK_ENABLED
++#define NRFX_CLOCK_ENABLED 1
++#endif
++// <o> NRFX_CLOCK_CONFIG_LF_SRC  - LF Clock Source
++ 
++// <0=> RC 
++// <1=> XTAL 
++// <2=> Synth 
++// <131073=> External Low Swing 
++// <196609=> External Full Swing 
++
++#ifndef NRFX_CLOCK_CONFIG_LF_SRC
++#define NRFX_CLOCK_CONFIG_LF_SRC 1
++#endif
++
++// <o> NRFX_CLOCK_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_CLOCK_CONFIG_IRQ_PRIORITY
++#define NRFX_CLOCK_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <e> NRFX_CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_CLOCK_CONFIG_LOG_ENABLED
++#define NRFX_CLOCK_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_CLOCK_CONFIG_LOG_LEVEL
++#define NRFX_CLOCK_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_CLOCK_CONFIG_INFO_COLOR
++#define NRFX_CLOCK_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_CLOCK_CONFIG_DEBUG_COLOR
++#define NRFX_CLOCK_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRFX_POWER_ENABLED - nrfx_power - POWER peripheral driver
++//==========================================================
++#ifndef NRFX_POWER_ENABLED
++#define NRFX_POWER_ENABLED 1
++#endif
++// <o> NRFX_POWER_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_POWER_CONFIG_IRQ_PRIORITY
++#define NRFX_POWER_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <q> NRFX_POWER_CONFIG_DEFAULT_DCDCEN  - The default configuration of main DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef NRFX_POWER_CONFIG_DEFAULT_DCDCEN
++#define NRFX_POWER_CONFIG_DEFAULT_DCDCEN 0
++#endif
++
++// <q> NRFX_POWER_CONFIG_DEFAULT_DCDCENHV  - The default configuration of High Voltage DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef NRFX_POWER_CONFIG_DEFAULT_DCDCENHV
++#define NRFX_POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> NRFX_PRS_ENABLED - nrfx_prs - Peripheral Resource Sharing module
++//==========================================================
++#ifndef NRFX_PRS_ENABLED
++#define NRFX_PRS_ENABLED 1
++#endif
++// <q> NRFX_PRS_BOX_0_ENABLED  - Enables box 0 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_0_ENABLED
++#define NRFX_PRS_BOX_0_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_1_ENABLED  - Enables box 1 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_1_ENABLED
++#define NRFX_PRS_BOX_1_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_2_ENABLED  - Enables box 2 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_2_ENABLED
++#define NRFX_PRS_BOX_2_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_3_ENABLED  - Enables box 3 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_3_ENABLED
++#define NRFX_PRS_BOX_3_ENABLED 0
++#endif
++
++// <q> NRFX_PRS_BOX_4_ENABLED  - Enables box 4 in the module.
++ 
++
++#ifndef NRFX_PRS_BOX_4_ENABLED
++#define NRFX_PRS_BOX_4_ENABLED 1
++#endif
++
++// <e> NRFX_PRS_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_PRS_CONFIG_LOG_ENABLED
++#define NRFX_PRS_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_PRS_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_PRS_CONFIG_LOG_LEVEL
++#define NRFX_PRS_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_PRS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_PRS_CONFIG_INFO_COLOR
++#define NRFX_PRS_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_PRS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_PRS_CONFIG_DEBUG_COLOR
++#define NRFX_PRS_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
++//==========================================================
++#ifndef NRFX_UARTE_ENABLED
++#define NRFX_UARTE_ENABLED 1
++#endif
++// <o> NRFX_UARTE0_ENABLED - Enable UARTE0 instance 
++#ifndef NRFX_UARTE0_ENABLED
++#define NRFX_UARTE0_ENABLED 0
++#endif
++
++// <o> NRFX_UARTE1_ENABLED - Enable UARTE1 instance 
++#ifndef NRFX_UARTE1_ENABLED
++#define NRFX_UARTE1_ENABLED 0
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_HWFC  - Hardware Flow Control
++ 
++// <0=> Disabled 
++// <1=> Enabled 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_HWFC
++#define NRFX_UARTE_DEFAULT_CONFIG_HWFC 0
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_PARITY  - Parity
++ 
++// <0=> Excluded 
++// <14=> Included 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_PARITY
++#define NRFX_UARTE_DEFAULT_CONFIG_PARITY 0
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3862528=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7716864=> 28800 baud 
++// <8388608=> 31250 baud 
++// <10289152=> 38400 baud 
++// <15007744=> 56000 baud 
++// <15400960=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30801920=> 115200 baud 
++// <61865984=> 230400 baud 
++// <67108864=> 250000 baud 
++// <121634816=> 460800 baud 
++// <251658240=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_BAUDRATE
++#define NRFX_UARTE_DEFAULT_CONFIG_BAUDRATE 30801920
++#endif
++
++// <o> NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
++#define NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <e> NRFX_UARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_UARTE_CONFIG_LOG_ENABLED
++#define NRFX_UARTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_UARTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_UARTE_CONFIG_LOG_LEVEL
++#define NRFX_UARTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_UARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UARTE_CONFIG_INFO_COLOR
++#define NRFX_UARTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_UARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UARTE_CONFIG_DEBUG_COLOR
++#define NRFX_UARTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRFX_UART_ENABLED - nrfx_uart - UART peripheral driver
++//==========================================================
++#ifndef NRFX_UART_ENABLED
++#define NRFX_UART_ENABLED 1
++#endif
++// <o> NRFX_UART0_ENABLED - Enable UART0 instance 
++#ifndef NRFX_UART0_ENABLED
++#define NRFX_UART0_ENABLED 0
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_HWFC  - Hardware Flow Control
++ 
++// <0=> Disabled 
++// <1=> Enabled 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_HWFC
++#define NRFX_UART_DEFAULT_CONFIG_HWFC 0
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_PARITY  - Parity
++ 
++// <0=> Excluded 
++// <14=> Included 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_PARITY
++#define NRFX_UART_DEFAULT_CONFIG_PARITY 0
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3866624=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7729152=> 28800 baud 
++// <8388608=> 31250 baud 
++// <10309632=> 38400 baud 
++// <15007744=> 56000 baud 
++// <15462400=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30924800=> 115200 baud 
++// <61845504=> 230400 baud 
++// <67108864=> 250000 baud 
++// <123695104=> 460800 baud 
++// <247386112=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_BAUDRATE
++#define NRFX_UART_DEFAULT_CONFIG_BAUDRATE 30924800
++#endif
++
++// <o> NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY
++#define NRFX_UART_DEFAULT_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <e> NRFX_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRFX_UART_CONFIG_LOG_ENABLED
++#define NRFX_UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRFX_UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRFX_UART_CONFIG_LOG_LEVEL
++#define NRFX_UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRFX_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UART_CONFIG_INFO_COLOR
++#define NRFX_UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRFX_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRFX_UART_CONFIG_DEBUG_COLOR
++#define NRFX_UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </e>
++
++// <e> NRF_CLOCK_ENABLED - nrf_drv_clock - CLOCK peripheral driver - legacy layer
++//==========================================================
++#ifndef NRF_CLOCK_ENABLED
++#define NRF_CLOCK_ENABLED 1
++#endif
++// <o> CLOCK_CONFIG_LF_SRC  - LF Clock Source
++ 
++// <0=> RC 
++// <1=> XTAL 
++// <2=> Synth 
++// <131073=> External Low Swing 
++// <196609=> External Full Swing 
++
++#ifndef CLOCK_CONFIG_LF_SRC
++#define CLOCK_CONFIG_LF_SRC 1
++#endif
++
++// <o> CLOCK_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef CLOCK_CONFIG_IRQ_PRIORITY
++#define CLOCK_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
++// <e> POWER_ENABLED - nrf_drv_power - POWER peripheral driver - legacy layer
++//==========================================================
++#ifndef POWER_ENABLED
++#define POWER_ENABLED 1
++#endif
++// <o> POWER_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef POWER_CONFIG_IRQ_PRIORITY
++#define POWER_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <q> POWER_CONFIG_DEFAULT_DCDCEN  - The default configuration of main DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef POWER_CONFIG_DEFAULT_DCDCEN
++#define POWER_CONFIG_DEFAULT_DCDCEN 0
++#endif
++
++// <q> POWER_CONFIG_DEFAULT_DCDCENHV  - The default configuration of High Voltage DCDC regulator
++ 
++
++// <i> This settings means only that components for DCDC regulator are installed and it can be enabled.
++
++#ifndef POWER_CONFIG_DEFAULT_DCDCENHV
++#define POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
++//==========================================================
++#ifndef UART_ENABLED
++#define UART_ENABLED 1
++#endif
++// <o> UART_DEFAULT_CONFIG_HWFC  - Hardware Flow Control
++ 
++// <0=> Disabled 
++// <1=> Enabled 
++
++#ifndef UART_DEFAULT_CONFIG_HWFC
++#define UART_DEFAULT_CONFIG_HWFC 0
++#endif
++
++// <o> UART_DEFAULT_CONFIG_PARITY  - Parity
++ 
++// <0=> Excluded 
++// <14=> Included 
++
++#ifndef UART_DEFAULT_CONFIG_PARITY
++#define UART_DEFAULT_CONFIG_PARITY 0
++#endif
++
++// <o> UART_DEFAULT_CONFIG_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3862528=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7716864=> 28800 baud 
++// <10289152=> 38400 baud 
++// <15400960=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30801920=> 115200 baud 
++// <61865984=> 230400 baud 
++// <67108864=> 250000 baud 
++// <121634816=> 460800 baud 
++// <251658240=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef UART_DEFAULT_CONFIG_BAUDRATE
++#define UART_DEFAULT_CONFIG_BAUDRATE 30801920
++#endif
++
++// <o> UART_DEFAULT_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef UART_DEFAULT_CONFIG_IRQ_PRIORITY
++#define UART_DEFAULT_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <q> UART_EASY_DMA_SUPPORT  - Driver supporting EasyDMA
++ 
++
++#ifndef UART_EASY_DMA_SUPPORT
++#define UART_EASY_DMA_SUPPORT 1
++#endif
++
++// <q> UART_LEGACY_SUPPORT  - Driver supporting Legacy mode
++ 
++
++#ifndef UART_LEGACY_SUPPORT
++#define UART_LEGACY_SUPPORT 1
++#endif
++
++// <e> UART0_ENABLED - Enable UART0 instance
++//==========================================================
++#ifndef UART0_ENABLED
++#define UART0_ENABLED 1
++#endif
++// <q> UART0_CONFIG_USE_EASY_DMA  - Default setting for using EasyDMA
++ 
++
++#ifndef UART0_CONFIG_USE_EASY_DMA
++#define UART0_CONFIG_USE_EASY_DMA 1
++#endif
++
++// </e>
++
++// <e> UART1_ENABLED - Enable UART1 instance
++//==========================================================
++#ifndef UART1_ENABLED
++#define UART1_ENABLED 0
++#endif
++// </e>
++
++// </e>
++
++// <e> USBD_ENABLED - nrf_drv_usbd - USB driver
++//==========================================================
++#ifndef USBD_ENABLED
++#define USBD_ENABLED 1
++#endif
++// <o> USBD_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef USBD_CONFIG_IRQ_PRIORITY
++#define USBD_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <o> USBD_CONFIG_DMASCHEDULER_MODE  - USBD SMA scheduler working scheme
++ 
++// <0=> Prioritized access 
++// <1=> Round Robin 
++
++#ifndef USBD_CONFIG_DMASCHEDULER_MODE
++#define USBD_CONFIG_DMASCHEDULER_MODE 0
++#endif
++
++// <q> USBD_CONFIG_DMASCHEDULER_ISO_BOOST  - Give priority to isochronous transfers
++ 
++
++// <i> This option gives priority to isochronous transfers.
++// <i> Enabling it assures that isochronous transfers are always processed,
++// <i> even if multiple other transfers are pending.
++// <i> Isochronous endpoints are prioritized before the usbd_dma_scheduler_algorithm
++// <i> function is called, so the option is independent of the algorithm chosen.
++
++#ifndef USBD_CONFIG_DMASCHEDULER_ISO_BOOST
++#define USBD_CONFIG_DMASCHEDULER_ISO_BOOST 1
++#endif
++
++// <q> USBD_CONFIG_ISO_IN_ZLP  - Respond to an IN token on ISO IN endpoint with ZLP when no data is ready
++ 
++
++// <i> If set, ISO IN endpoint will respond to an IN token with ZLP when no data is ready to be sent.
++// <i> Else, there will be no response.
++
++#ifndef USBD_CONFIG_ISO_IN_ZLP
++#define USBD_CONFIG_ISO_IN_ZLP 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Libraries 
++
++//==========================================================
++// <e> APP_SCHEDULER_ENABLED - app_scheduler - Events scheduler
++//==========================================================
++#ifndef APP_SCHEDULER_ENABLED
++#define APP_SCHEDULER_ENABLED 1
++#endif
++// <q> APP_SCHEDULER_WITH_PAUSE  - Enabling pause feature
++ 
++
++#ifndef APP_SCHEDULER_WITH_PAUSE
++#define APP_SCHEDULER_WITH_PAUSE 1
++#endif
++
++// <q> APP_SCHEDULER_WITH_PROFILER  - Enabling scheduler profiling
++ 
++
++#ifndef APP_SCHEDULER_WITH_PROFILER
++#define APP_SCHEDULER_WITH_PROFILER 1
++#endif
++
++// </e>
++
++// <e> APP_TIMER_ENABLED - app_timer - Application timer functionality
++//==========================================================
++#ifndef APP_TIMER_ENABLED
++#define APP_TIMER_ENABLED 1
++#endif
++// <o> APP_TIMER_CONFIG_RTC_FREQUENCY  - Configure RTC prescaler.
++ 
++// <0=> 32768 Hz 
++// <1=> 16384 Hz 
++// <3=> 8192 Hz 
++// <7=> 4096 Hz 
++// <15=> 2048 Hz 
++// <31=> 1024 Hz 
++
++#ifndef APP_TIMER_CONFIG_RTC_FREQUENCY
++#define APP_TIMER_CONFIG_RTC_FREQUENCY 0
++#endif
++
++// <o> APP_TIMER_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef APP_TIMER_CONFIG_IRQ_PRIORITY
++#define APP_TIMER_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// <o> APP_TIMER_CONFIG_OP_QUEUE_SIZE - Capacity of timer requests queue. 
++// <i> Size of the queue depends on how many timers are used
++// <i> in the system, how often timers are started and overall
++// <i> system latency. If queue size is too small app_timer calls
++// <i> will fail.
++
++#ifndef APP_TIMER_CONFIG_OP_QUEUE_SIZE
++#define APP_TIMER_CONFIG_OP_QUEUE_SIZE 10
++#endif
++
++// <q> APP_TIMER_CONFIG_USE_SCHEDULER  - Enable scheduling app_timer events to app_scheduler
++ 
++
++#ifndef APP_TIMER_CONFIG_USE_SCHEDULER
++#define APP_TIMER_CONFIG_USE_SCHEDULER 0
++#endif
++
++// <q> APP_TIMER_KEEPS_RTC_ACTIVE  - Enable RTC always on
++ 
++
++// <i> If option is enabled RTC is kept running even if there is no active timers.
++// <i> This option can be used when app_timer is used for timestamping.
++
++#ifndef APP_TIMER_KEEPS_RTC_ACTIVE
++#define APP_TIMER_KEEPS_RTC_ACTIVE 0
++#endif
++
++// <o> APP_TIMER_SAFE_WINDOW_MS - Maximum possible latency (in milliseconds) of handling app_timer event. 
++// <i> Maximum possible timeout that can be set is reduced by safe window.
++// <i> Example: RTC frequency 16384 Hz, maximum possible timeout 1024 seconds - APP_TIMER_SAFE_WINDOW_MS.
++// <i> Since RTC is not stopped when processor is halted in debugging session, this value
++// <i> must cover it if debugging is needed. It is possible to halt processor for APP_TIMER_SAFE_WINDOW_MS
++// <i> without corrupting app_timer behavior.
++
++#ifndef APP_TIMER_SAFE_WINDOW_MS
++#define APP_TIMER_SAFE_WINDOW_MS 300000
++#endif
++
++// <h> App Timer Legacy configuration - Legacy configuration.
++
++//==========================================================
++// <q> APP_TIMER_WITH_PROFILER  - Enable app_timer profiling
++ 
++
++#ifndef APP_TIMER_WITH_PROFILER
++#define APP_TIMER_WITH_PROFILER 0
++#endif
++
++// <q> APP_TIMER_CONFIG_SWI_NUMBER  - Configure SWI instance used.
++ 
++
++#ifndef APP_TIMER_CONFIG_SWI_NUMBER
++#define APP_TIMER_CONFIG_SWI_NUMBER 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </e>
++
++// <e> APP_USBD_ENABLED - app_usbd - USB Device library
++//==========================================================
++#ifndef APP_USBD_ENABLED
++#define APP_USBD_ENABLED 1
++#endif
++// <s> APP_USBD_VID - Vendor ID.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Vendor ID ordered from USB IF: http://www.usb.org/developers/vendor/
++#ifndef APP_USBD_VID
++#define APP_USBD_VID 0x1915
++#endif
++
++// <s> APP_USBD_PID - Product ID.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Selected Product ID
++#ifndef APP_USBD_PID
++#define APP_USBD_PID 0xC00A
++#endif
++
++// <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
++
++
++// <i> Device version, will be converted automatically to BCD notation. Use just decimal values.
++
++#ifndef APP_USBD_DEVICE_VER_MAJOR
++#define APP_USBD_DEVICE_VER_MAJOR 1
++#endif
++
++// <o> APP_USBD_DEVICE_VER_MINOR - Device version, minor part.  <0-99> 
++
++
++// <i> Device version, will be converted automatically to BCD notation. Use just decimal values.
++
++#ifndef APP_USBD_DEVICE_VER_MINOR
++#define APP_USBD_DEVICE_VER_MINOR 0
++#endif
++
++// <q> APP_USBD_CONFIG_SELF_POWERED  - Self-powered device, as opposed to bus-powered.
++ 
++
++#ifndef APP_USBD_CONFIG_SELF_POWERED
++#define APP_USBD_CONFIG_SELF_POWERED 1
++#endif
++
++// <o> APP_USBD_CONFIG_MAX_POWER - MaxPower field in configuration descriptor in milliamps.  <0-500> 
++
++
++#ifndef APP_USBD_CONFIG_MAX_POWER
++#define APP_USBD_CONFIG_MAX_POWER 500
++#endif
++
++// <q> APP_USBD_CONFIG_POWER_EVENTS_PROCESS  - Process power events.
++ 
++
++// <i> Enable processing power events in USB event handler.
++
++#ifndef APP_USBD_CONFIG_POWER_EVENTS_PROCESS
++#define APP_USBD_CONFIG_POWER_EVENTS_PROCESS 1
++#endif
++
++// <e> APP_USBD_CONFIG_EVENT_QUEUE_ENABLE - Enable event queue.
++
++// <i> This is the default configuration when all the events are placed into internal queue.
++// <i> Disable it when an external queue is used like app_scheduler or if you wish to process all events inside interrupts.
++// <i> Processing all events from the interrupt level adds requirement not to call any functions that modifies the USBD library state from the context higher than USB interrupt context.
++// <i> Functions that modify USBD state are functions for sleep, wakeup, start, stop, enable, and disable.
++//==========================================================
++#ifndef APP_USBD_CONFIG_EVENT_QUEUE_ENABLE
++#define APP_USBD_CONFIG_EVENT_QUEUE_ENABLE 1
++#endif
++// <o> APP_USBD_CONFIG_EVENT_QUEUE_SIZE - The size of the event queue.  <16-64> 
++
++
++// <i> The size of the queue for the events that would be processed in the main loop.
++
++#ifndef APP_USBD_CONFIG_EVENT_QUEUE_SIZE
++#define APP_USBD_CONFIG_EVENT_QUEUE_SIZE 32
++#endif
++
++// <o> APP_USBD_CONFIG_SOF_HANDLING_MODE  - Change SOF events handling mode.
++ 
++
++// <i> Normal queue   - SOF events are pushed normally into the event queue.
++// <i> Compress queue - SOF events are counted and binded with other events or executed when the queue is empty.
++// <i>                  This prevents the queue from filling up with SOF events.
++// <i> Interrupt      - SOF events are processed in interrupt.
++// <0=> Normal queue 
++// <1=> Compress queue 
++// <2=> Interrupt 
++
++#ifndef APP_USBD_CONFIG_SOF_HANDLING_MODE
++#define APP_USBD_CONFIG_SOF_HANDLING_MODE 1
++#endif
++
++// </e>
++
++// <q> APP_USBD_CONFIG_SOF_TIMESTAMP_PROVIDE  - Provide a function that generates timestamps for logs based on the current SOF.
++ 
++
++// <i> The function app_usbd_sof_timestamp_get is implemented if the logger is enabled. 
++// <i> Use it when initializing the logger. 
++// <i> SOF processing is always enabled when this configuration parameter is active. 
++// <i> Note: This option is configured outside of APP_USBD_CONFIG_LOG_ENABLED. 
++// <i> This means that it works even if the logging in this very module is disabled. 
++
++#ifndef APP_USBD_CONFIG_SOF_TIMESTAMP_PROVIDE
++#define APP_USBD_CONFIG_SOF_TIMESTAMP_PROVIDE 0
++#endif
++
++// <o> APP_USBD_CONFIG_DESC_STRING_SIZE - Maximum size of the NULL-terminated string of the string descriptor.  <31-254> 
++
++
++// <i> 31 characters can be stored in the internal USB buffer used for transfers.
++// <i> Any value higher than 31 creates an additional buffer just for descriptor strings.
++
++#ifndef APP_USBD_CONFIG_DESC_STRING_SIZE
++#define APP_USBD_CONFIG_DESC_STRING_SIZE 31
++#endif
++
++// <q> APP_USBD_CONFIG_DESC_STRING_UTF_ENABLED  - Enable UTF8 conversion.
++ 
++
++// <i> Enable UTF8-encoded characters. In normal processing, only ASCII characters are available.
++
++#ifndef APP_USBD_CONFIG_DESC_STRING_UTF_ENABLED
++#define APP_USBD_CONFIG_DESC_STRING_UTF_ENABLED 0
++#endif
++
++// <s> APP_USBD_STRINGS_LANGIDS - Supported languages identifiers.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Comma-separated list of supported languages.
++#ifndef APP_USBD_STRINGS_LANGIDS
++#define APP_USBD_STRINGS_LANGIDS APP_USBD_LANG_AND_SUBLANG(APP_USBD_LANG_ENGLISH, APP_USBD_SUBLANG_ENGLISH_US)
++#endif
++
++// <e> APP_USBD_STRING_ID_MANUFACTURER - Define manufacturer string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_MANUFACTURER
++#define APP_USBD_STRING_ID_MANUFACTURER 1
++#endif
++// <q> APP_USBD_STRINGS_MANUFACTURER_EXTERN  - Define whether @ref APP_USBD_STRINGS_MANUFACTURER is created by macro or declared as a global variable.
++ 
++
++#ifndef APP_USBD_STRINGS_MANUFACTURER_EXTERN
++#define APP_USBD_STRINGS_MANUFACTURER_EXTERN 0
++#endif
++
++// <s> APP_USBD_STRINGS_MANUFACTURER - String descriptor for the manufacturer name.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Comma-separated list of manufacturer names for each defined language.
++// <i> Use @ref APP_USBD_STRING_DESC macro to create string descriptor from a NULL-terminated string.
++// <i> Use @ref APP_USBD_STRING_RAW8_DESC macro to create string descriptor from comma-separated uint8_t values.
++// <i> Use @ref APP_USBD_STRING_RAW16_DESC macro to create string descriptor from comma-separated uint16_t values.
++// <i> Alternatively, configure the macro to point to any internal variable pointer that already contains the descriptor.
++// <i> Setting string to NULL disables that string.
++// <i> The order of manufacturer names must be the same like in @ref APP_USBD_STRINGS_LANGIDS.
++#ifndef APP_USBD_STRINGS_MANUFACTURER
++#define APP_USBD_STRINGS_MANUFACTURER APP_USBD_STRING_DESC("Nordic Semiconductor")
++#endif
++
++// </e>
++
++// <e> APP_USBD_STRING_ID_PRODUCT - Define product string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_PRODUCT
++#define APP_USBD_STRING_ID_PRODUCT 2
++#endif
++// <q> APP_USBD_STRINGS_PRODUCT_EXTERN  - Define whether @ref APP_USBD_STRINGS_PRODUCT is created by macro or declared as a global variable.
++ 
++
++#ifndef APP_USBD_STRINGS_PRODUCT_EXTERN
++#define APP_USBD_STRINGS_PRODUCT_EXTERN 0
++#endif
++
++// <s> APP_USBD_STRINGS_PRODUCT - String descriptor for the product name.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> List of product names that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
++#ifndef APP_USBD_STRINGS_PRODUCT
++#define APP_USBD_STRINGS_PRODUCT APP_USBD_STRING_DESC("nRF52 Connectivity")
++#endif
++
++// </e>
++
++// <e> APP_USBD_STRING_ID_SERIAL - Define serial number string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_SERIAL
++#define APP_USBD_STRING_ID_SERIAL 3
++#endif
++// <q> APP_USBD_STRING_SERIAL_EXTERN  - Define whether @ref APP_USBD_STRING_SERIAL is created by macro or declared as a global variable.
++ 
++
++#ifndef APP_USBD_STRING_SERIAL_EXTERN
++#define APP_USBD_STRING_SERIAL_EXTERN 1
++#endif
++
++// <s> APP_USBD_STRING_SERIAL - String descriptor for the serial number.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Serial number that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
++#ifndef APP_USBD_STRING_SERIAL
++#define APP_USBD_STRING_SERIAL g_extern_serial_number
++#endif
++
++// </e>
++
++// <e> APP_USBD_STRING_ID_CONFIGURATION - Define configuration string ID.
++
++// <i> Setting ID to 0 disables the string.
++//==========================================================
++#ifndef APP_USBD_STRING_ID_CONFIGURATION
++#define APP_USBD_STRING_ID_CONFIGURATION 4
++#endif
++// <q> APP_USBD_STRING_CONFIGURATION_EXTERN  - Define whether @ref APP_USBD_STRINGS_CONFIGURATION is created by macro or declared as global variable.
++ 
++
++#ifndef APP_USBD_STRING_CONFIGURATION_EXTERN
++#define APP_USBD_STRING_CONFIGURATION_EXTERN 0
++#endif
++
++// <s> APP_USBD_STRINGS_CONFIGURATION - String descriptor for the device configuration.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> Configuration string that is defined the same way like in @ref APP_USBD_STRINGS_MANUFACTURER.
++#ifndef APP_USBD_STRINGS_CONFIGURATION
++#define APP_USBD_STRINGS_CONFIGURATION APP_USBD_STRING_DESC("Default configuration")
++#endif
++
++// </e>
++
++// <s> APP_USBD_STRINGS_USER - Default values for user strings.
++
++// <i> Note: This value is not editable in Configuration Wizard.
++// <i> This value stores all application specific user strings with the default initialization.
++// <i> The setup is done by X-macros.
++// <i> Expected macro parameters:
++// <i> @code
++// <i> X(mnemonic, [=str_idx], ...)
++// <i> @endcode
++// <i> - @c mnemonic: Mnemonic of the string descriptor that would be added to
++// <i>                @ref app_usbd_string_desc_idx_t enumerator.
++// <i> - @c str_idx : String index value, can be set or left empty.
++// <i>                For example, WinUSB driver requires descriptor to be present on 0xEE index.
++// <i>                Then use X(USBD_STRING_WINUSB, =0xEE, (APP_USBD_STRING_DESC(...)))
++// <i> - @c ...     : List of string descriptors for each defined language.
++#ifndef APP_USBD_STRINGS_USER
++#define APP_USBD_STRINGS_USER X(APP_USER_1, , APP_USBD_STRING_DESC("User 1"))
++#endif
++
++// </e>
++
++// <q> CRC16_ENABLED  - crc16 - CRC16 calculation routines
++ 
++
++#ifndef CRC16_ENABLED
++#define CRC16_ENABLED 1
++#endif
++
++// <e> NRF_BALLOC_ENABLED - nrf_balloc - Block allocator module
++//==========================================================
++#ifndef NRF_BALLOC_ENABLED
++#define NRF_BALLOC_ENABLED 1
++#endif
++// <e> NRF_BALLOC_CONFIG_DEBUG_ENABLED - Enables debug mode in the module.
++//==========================================================
++#ifndef NRF_BALLOC_CONFIG_DEBUG_ENABLED
++#define NRF_BALLOC_CONFIG_DEBUG_ENABLED 0
++#endif
++// <o> NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS - Number of words used as head guard.  <0-255> 
++
++
++#ifndef NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS
++#define NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS 1
++#endif
++
++// <o> NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS - Number of words used as tail guard.  <0-255> 
++
++
++#ifndef NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS
++#define NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS 1
++#endif
++
++// <q> NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED  - Enables basic checks in this module.
++ 
++
++#ifndef NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED
++#define NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED 0
++#endif
++
++// <q> NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED  - Enables double memory free check in this module.
++ 
++
++#ifndef NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED
++#define NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED 0
++#endif
++
++// <q> NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED  - Enables free memory corruption check in this module.
++ 
++
++#ifndef NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED
++#define NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED 0
++#endif
++
++// <q> NRF_BALLOC_CLI_CMDS  - Enable CLI commands specific to the module
++ 
++
++#ifndef NRF_BALLOC_CLI_CMDS
++#define NRF_BALLOC_CLI_CMDS 0
++#endif
++
++// </e>
++
++// </e>
++
++// <q> NRF_FPRINTF_ENABLED  - nrf_fprintf - fprintf function.
++ 
++
++#ifndef NRF_FPRINTF_ENABLED
++#define NRF_FPRINTF_ENABLED 1
++#endif
++
++// <q> NRF_MEMOBJ_ENABLED  - nrf_memobj - Linked memory allocator module
++ 
++
++#ifndef NRF_MEMOBJ_ENABLED
++#define NRF_MEMOBJ_ENABLED 1
++#endif
++
++// <e> NRF_QUEUE_ENABLED - nrf_queue - Queue module
++//==========================================================
++#ifndef NRF_QUEUE_ENABLED
++#define NRF_QUEUE_ENABLED 1
++#endif
++// <q> NRF_QUEUE_CLI_CMDS  - Enable CLI commands specific to the module
++ 
++
++#ifndef NRF_QUEUE_CLI_CMDS
++#define NRF_QUEUE_CLI_CMDS 0
++#endif
++
++// </e>
++
++// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
++ 
++
++#ifndef NRF_SECTION_ITER_ENABLED
++#define NRF_SECTION_ITER_ENABLED 1
++#endif
++
++// <q> NRF_STRERROR_ENABLED  - nrf_strerror - Library for converting error code to string.
++ 
++
++#ifndef NRF_STRERROR_ENABLED
++#define NRF_STRERROR_ENABLED 1
++#endif
++
++// <h> app_usbd_cdc_acm - USB CDC ACM class
++
++//==========================================================
++// <q> APP_USBD_CDC_ACM_ENABLED  - Enabling USBD CDC ACM Class library
++ 
++
++#ifndef APP_USBD_CDC_ACM_ENABLED
++#define APP_USBD_CDC_ACM_ENABLED 1
++#endif
++
++// <q> APP_USBD_CDC_ACM_ZLP_ON_EPSIZE_WRITE  - Send ZLP on write with same size as endpoint
++ 
++
++// <i> If enabled, CDC ACM class will automatically send a zero length packet after transfer which has the same size as endpoint.
++// <i> This may limit throughput if a lot of binary data is sent, but in terminal mode operation it makes sure that the data is always displayed right after it is sent.
++
++#ifndef APP_USBD_CDC_ACM_ZLP_ON_EPSIZE_WRITE
++#define APP_USBD_CDC_ACM_ZLP_ON_EPSIZE_WRITE 1
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Log 
++
++//==========================================================
++// <e> NRF_LOG_BACKEND_RTT_ENABLED - nrf_log_backend_rtt - Log RTT backend
++//==========================================================
++#ifndef NRF_LOG_BACKEND_RTT_ENABLED
++#define NRF_LOG_BACKEND_RTT_ENABLED 0
++#endif
++// <o> NRF_LOG_BACKEND_RTT_TEMP_BUFFER_SIZE - Size of buffer for partially processed strings. 
++// <i> Size of the buffer is a trade-off between RAM usage and processing.
++// <i> if buffer is smaller then strings will often be fragmented.
++// <i> It is recommended to use size which will fit typical log and only the
++// <i> longer one will be fragmented.
++
++#ifndef NRF_LOG_BACKEND_RTT_TEMP_BUFFER_SIZE
++#define NRF_LOG_BACKEND_RTT_TEMP_BUFFER_SIZE 64
++#endif
++
++// <o> NRF_LOG_BACKEND_RTT_TX_RETRY_DELAY_MS - Period before retrying writing to RTT 
++#ifndef NRF_LOG_BACKEND_RTT_TX_RETRY_DELAY_MS
++#define NRF_LOG_BACKEND_RTT_TX_RETRY_DELAY_MS 1
++#endif
++
++// <o> NRF_LOG_BACKEND_RTT_TX_RETRY_CNT - Writing to RTT retries. 
++// <i> If RTT fails to accept any new data after retries
++// <i> module assumes that host is not active and on next
++// <i> request it will perform only one write attempt.
++// <i> On successful writing, module assumes that host is active
++// <i> and scheme with retry is applied again.
++
++#ifndef NRF_LOG_BACKEND_RTT_TX_RETRY_CNT
++#define NRF_LOG_BACKEND_RTT_TX_RETRY_CNT 3
++#endif
++
++// </e>
++
++// <e> NRF_LOG_BACKEND_UART_ENABLED - nrf_log_backend_uart - Log UART backend
++//==========================================================
++#ifndef NRF_LOG_BACKEND_UART_ENABLED
++#define NRF_LOG_BACKEND_UART_ENABLED 0
++#endif
++// <o> NRF_LOG_BACKEND_UART_TX_PIN - UART TX pin 
++#ifndef NRF_LOG_BACKEND_UART_TX_PIN
++#define NRF_LOG_BACKEND_UART_TX_PIN 6
++#endif
++
++// <o> NRF_LOG_BACKEND_UART_BAUDRATE  - Default Baudrate
++ 
++// <323584=> 1200 baud 
++// <643072=> 2400 baud 
++// <1290240=> 4800 baud 
++// <2576384=> 9600 baud 
++// <3862528=> 14400 baud 
++// <5152768=> 19200 baud 
++// <7716864=> 28800 baud 
++// <10289152=> 38400 baud 
++// <15400960=> 57600 baud 
++// <20615168=> 76800 baud 
++// <30801920=> 115200 baud 
++// <61865984=> 230400 baud 
++// <67108864=> 250000 baud 
++// <121634816=> 460800 baud 
++// <251658240=> 921600 baud 
++// <268435456=> 1000000 baud 
++
++#ifndef NRF_LOG_BACKEND_UART_BAUDRATE
++#define NRF_LOG_BACKEND_UART_BAUDRATE 30801920
++#endif
++
++// <o> NRF_LOG_BACKEND_UART_TEMP_BUFFER_SIZE - Size of buffer for partially processed strings. 
++// <i> Size of the buffer is a trade-off between RAM usage and processing.
++// <i> if buffer is smaller then strings will often be fragmented.
++// <i> It is recommended to use size which will fit typical log and only the
++// <i> longer one will be fragmented.
++
++#ifndef NRF_LOG_BACKEND_UART_TEMP_BUFFER_SIZE
++#define NRF_LOG_BACKEND_UART_TEMP_BUFFER_SIZE 64
++#endif
++
++// </e>
++
++// <e> NRF_LOG_ENABLED - nrf_log - Logger
++//==========================================================
++#ifndef NRF_LOG_ENABLED
++#define NRF_LOG_ENABLED 0
++#endif
++// <h> Log message pool - Configuration of log message pool
++
++//==========================================================
++// <o> NRF_LOG_MSGPOOL_ELEMENT_SIZE - Size of a single element in the pool of memory objects. 
++// <i> If a small value is set, then performance of logs processing
++// <i> is degraded because data is fragmented. Bigger value impacts
++// <i> RAM memory utilization. The size is set to fit a message with
++// <i> a timestamp and up to 2 arguments in a single memory object.
++
++#ifndef NRF_LOG_MSGPOOL_ELEMENT_SIZE
++#define NRF_LOG_MSGPOOL_ELEMENT_SIZE 20
++#endif
++
++// <o> NRF_LOG_MSGPOOL_ELEMENT_COUNT - Number of elements in the pool of memory objects 
++// <i> If a small value is set, then it may lead to a deadlock
++// <i> in certain cases if backend has high latency and holds
++// <i> multiple messages for long time. Bigger value impacts
++// <i> RAM memory usage.
++
++#ifndef NRF_LOG_MSGPOOL_ELEMENT_COUNT
++#define NRF_LOG_MSGPOOL_ELEMENT_COUNT 8
++#endif
++
++// </h> 
++//==========================================================
++
++// <q> NRF_LOG_ALLOW_OVERFLOW  - Configures behavior when circular buffer is full.
++ 
++
++// <i> If set then oldest logs are overwritten. Otherwise a 
++// <i> marker is injected informing about overflow.
++
++#ifndef NRF_LOG_ALLOW_OVERFLOW
++#define NRF_LOG_ALLOW_OVERFLOW 1
++#endif
++
++// <o> NRF_LOG_BUFSIZE  - Size of the buffer for storing logs (in bytes).
++ 
++
++// <i> Must be power of 2 and multiple of 4.
++// <i> If NRF_LOG_DEFERRED = 0 then buffer size can be reduced to minimum.
++// <128=> 128 
++// <256=> 256 
++// <512=> 512 
++// <1024=> 1024 
++// <2048=> 2048 
++// <4096=> 4096 
++// <8192=> 8192 
++// <16384=> 16384 
++
++#ifndef NRF_LOG_BUFSIZE
++#define NRF_LOG_BUFSIZE 1024
++#endif
++
++// <q> NRF_LOG_CLI_CMDS  - Enable CLI commands for the module.
++ 
++
++#ifndef NRF_LOG_CLI_CMDS
++#define NRF_LOG_CLI_CMDS 0
++#endif
++
++// <o> NRF_LOG_DEFAULT_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_LOG_DEFAULT_LEVEL
++#define NRF_LOG_DEFAULT_LEVEL 3
++#endif
++
++// <q> NRF_LOG_DEFERRED  - Enable deffered logger.
++ 
++
++// <i> Log data is buffered and can be processed in idle.
++
++#ifndef NRF_LOG_DEFERRED
++#define NRF_LOG_DEFERRED 1
++#endif
++
++// <q> NRF_LOG_FILTERS_ENABLED  - Enable dynamic filtering of logs.
++ 
++
++#ifndef NRF_LOG_FILTERS_ENABLED
++#define NRF_LOG_FILTERS_ENABLED 0
++#endif
++
++// <o> NRF_LOG_STR_PUSH_BUFFER_SIZE  - Size of the buffer dedicated for strings stored using @ref NRF_LOG_PUSH.
++ 
++// <16=> 16 
++// <32=> 32 
++// <64=> 64 
++// <128=> 128 
++// <256=> 256 
++// <512=> 512 
++// <1024=> 1024 
++
++#ifndef NRF_LOG_STR_PUSH_BUFFER_SIZE
++#define NRF_LOG_STR_PUSH_BUFFER_SIZE 128
++#endif
++
++// <o> NRF_LOG_STR_PUSH_BUFFER_SIZE  - Size of the buffer dedicated for strings stored using @ref NRF_LOG_PUSH.
++ 
++// <16=> 16 
++// <32=> 32 
++// <64=> 64 
++// <128=> 128 
++// <256=> 256 
++// <512=> 512 
++// <1024=> 1024 
++
++#ifndef NRF_LOG_STR_PUSH_BUFFER_SIZE
++#define NRF_LOG_STR_PUSH_BUFFER_SIZE 128
++#endif
++
++// <e> NRF_LOG_USES_COLORS - If enabled then ANSI escape code for colors is prefixed to every string
++//==========================================================
++#ifndef NRF_LOG_USES_COLORS
++#define NRF_LOG_USES_COLORS 0
++#endif
++// <o> NRF_LOG_COLOR_DEFAULT  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LOG_COLOR_DEFAULT
++#define NRF_LOG_COLOR_DEFAULT 0
++#endif
++
++// <o> NRF_LOG_ERROR_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LOG_ERROR_COLOR
++#define NRF_LOG_ERROR_COLOR 2
++#endif
++
++// <o> NRF_LOG_WARNING_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LOG_WARNING_COLOR
++#define NRF_LOG_WARNING_COLOR 4
++#endif
++
++// </e>
++
++// <e> NRF_LOG_USES_TIMESTAMP - Enable timestamping
++
++// <i> Function for getting the timestamp is provided by the user
++//==========================================================
++#ifndef NRF_LOG_USES_TIMESTAMP
++#define NRF_LOG_USES_TIMESTAMP 0
++#endif
++// <o> NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY - Default frequency of the timestamp (in Hz) or 0 to use app_timer frequency. 
++#ifndef NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY
++#define NRF_LOG_TIMESTAMP_DEFAULT_FREQUENCY 0
++#endif
++
++// </e>
++
++// <h> nrf_log module configuration 
++
++//==========================================================
++// <h> nrf_log in nRF_Core 
++
++//==========================================================
++// <e> NRF_MPU_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_MPU_CONFIG_LOG_ENABLED
++#define NRF_MPU_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_MPU_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_MPU_CONFIG_LOG_LEVEL
++#define NRF_MPU_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_MPU_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MPU_CONFIG_INFO_COLOR
++#define NRF_MPU_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_MPU_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MPU_CONFIG_DEBUG_COLOR
++#define NRF_MPU_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_STACK_GUARD_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_STACK_GUARD_CONFIG_LOG_ENABLED
++#define NRF_STACK_GUARD_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_STACK_GUARD_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_STACK_GUARD_CONFIG_LOG_LEVEL
++#define NRF_STACK_GUARD_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_STACK_GUARD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_STACK_GUARD_CONFIG_INFO_COLOR
++#define NRF_STACK_GUARD_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_STACK_GUARD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_STACK_GUARD_CONFIG_DEBUG_COLOR
++#define NRF_STACK_GUARD_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TASK_MANAGER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TASK_MANAGER_CONFIG_LOG_ENABLED
++#define TASK_MANAGER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TASK_MANAGER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TASK_MANAGER_CONFIG_LOG_LEVEL
++#define TASK_MANAGER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TASK_MANAGER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TASK_MANAGER_CONFIG_INFO_COLOR
++#define TASK_MANAGER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TASK_MANAGER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TASK_MANAGER_CONFIG_DEBUG_COLOR
++#define TASK_MANAGER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nrf_log in nRF_Drivers 
++
++//==========================================================
++// <e> CLOCK_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef CLOCK_CONFIG_LOG_ENABLED
++#define CLOCK_CONFIG_LOG_ENABLED 0
++#endif
++// <o> CLOCK_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef CLOCK_CONFIG_LOG_LEVEL
++#define CLOCK_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> CLOCK_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef CLOCK_CONFIG_INFO_COLOR
++#define CLOCK_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> CLOCK_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef CLOCK_CONFIG_DEBUG_COLOR
++#define CLOCK_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> COMP_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef COMP_CONFIG_LOG_ENABLED
++#define COMP_CONFIG_LOG_ENABLED 0
++#endif
++// <o> COMP_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef COMP_CONFIG_LOG_LEVEL
++#define COMP_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> COMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef COMP_CONFIG_INFO_COLOR
++#define COMP_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> COMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef COMP_CONFIG_DEBUG_COLOR
++#define COMP_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef GPIOTE_CONFIG_LOG_ENABLED
++#define GPIOTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> GPIOTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef GPIOTE_CONFIG_LOG_LEVEL
++#define GPIOTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> GPIOTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef GPIOTE_CONFIG_INFO_COLOR
++#define GPIOTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> GPIOTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef GPIOTE_CONFIG_DEBUG_COLOR
++#define GPIOTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> LPCOMP_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef LPCOMP_CONFIG_LOG_ENABLED
++#define LPCOMP_CONFIG_LOG_ENABLED 0
++#endif
++// <o> LPCOMP_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef LPCOMP_CONFIG_LOG_LEVEL
++#define LPCOMP_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> LPCOMP_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef LPCOMP_CONFIG_INFO_COLOR
++#define LPCOMP_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> LPCOMP_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef LPCOMP_CONFIG_DEBUG_COLOR
++#define LPCOMP_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> MAX3421E_HOST_CONFIG_LOG_ENABLED - Enable logging in the module
++//==========================================================
++#ifndef MAX3421E_HOST_CONFIG_LOG_ENABLED
++#define MAX3421E_HOST_CONFIG_LOG_ENABLED 0
++#endif
++// <o> MAX3421E_HOST_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef MAX3421E_HOST_CONFIG_LOG_LEVEL
++#define MAX3421E_HOST_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> MAX3421E_HOST_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef MAX3421E_HOST_CONFIG_INFO_COLOR
++#define MAX3421E_HOST_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> MAX3421E_HOST_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef MAX3421E_HOST_CONFIG_DEBUG_COLOR
++#define MAX3421E_HOST_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PDM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef PDM_CONFIG_LOG_ENABLED
++#define PDM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> PDM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PDM_CONFIG_LOG_LEVEL
++#define PDM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> PDM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PDM_CONFIG_INFO_COLOR
++#define PDM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> PDM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PDM_CONFIG_DEBUG_COLOR
++#define PDM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PPI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef PPI_CONFIG_LOG_ENABLED
++#define PPI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> PPI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PPI_CONFIG_LOG_LEVEL
++#define PPI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> PPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PPI_CONFIG_INFO_COLOR
++#define PPI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> PPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PPI_CONFIG_DEBUG_COLOR
++#define PPI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PWM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef PWM_CONFIG_LOG_ENABLED
++#define PWM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> PWM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PWM_CONFIG_LOG_LEVEL
++#define PWM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> PWM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PWM_CONFIG_INFO_COLOR
++#define PWM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> PWM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PWM_CONFIG_DEBUG_COLOR
++#define PWM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> QDEC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef QDEC_CONFIG_LOG_ENABLED
++#define QDEC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> QDEC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef QDEC_CONFIG_LOG_LEVEL
++#define QDEC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> QDEC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef QDEC_CONFIG_INFO_COLOR
++#define QDEC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> QDEC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef QDEC_CONFIG_DEBUG_COLOR
++#define QDEC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef RNG_CONFIG_LOG_ENABLED
++#define RNG_CONFIG_LOG_ENABLED 0
++#endif
++// <o> RNG_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef RNG_CONFIG_LOG_LEVEL
++#define RNG_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RNG_CONFIG_INFO_COLOR
++#define RNG_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RNG_CONFIG_DEBUG_COLOR
++#define RNG_CONFIG_DEBUG_COLOR 0
++#endif
++
++// <q> RNG_CONFIG_RANDOM_NUMBER_LOG_ENABLED  - Enables logging of random numbers.
++ 
++
++#ifndef RNG_CONFIG_RANDOM_NUMBER_LOG_ENABLED
++#define RNG_CONFIG_RANDOM_NUMBER_LOG_ENABLED 0
++#endif
++
++// </e>
++
++// <e> RTC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef RTC_CONFIG_LOG_ENABLED
++#define RTC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> RTC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef RTC_CONFIG_LOG_LEVEL
++#define RTC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> RTC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RTC_CONFIG_INFO_COLOR
++#define RTC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> RTC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef RTC_CONFIG_DEBUG_COLOR
++#define RTC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SAADC_CONFIG_LOG_ENABLED
++#define SAADC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SAADC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SAADC_CONFIG_LOG_LEVEL
++#define SAADC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SAADC_CONFIG_INFO_COLOR
++#define SAADC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SAADC_CONFIG_DEBUG_COLOR
++#define SAADC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> SPIS_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SPIS_CONFIG_LOG_ENABLED
++#define SPIS_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SPIS_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SPIS_CONFIG_LOG_LEVEL
++#define SPIS_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SPIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPIS_CONFIG_INFO_COLOR
++#define SPIS_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SPIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPIS_CONFIG_DEBUG_COLOR
++#define SPIS_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> SPI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SPI_CONFIG_LOG_ENABLED
++#define SPI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SPI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SPI_CONFIG_LOG_LEVEL
++#define SPI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPI_CONFIG_INFO_COLOR
++#define SPI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SPI_CONFIG_DEBUG_COLOR
++#define SPI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TIMER_CONFIG_LOG_ENABLED
++#define TIMER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TIMER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TIMER_CONFIG_LOG_LEVEL
++#define TIMER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TIMER_CONFIG_INFO_COLOR
++#define TIMER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TIMER_CONFIG_DEBUG_COLOR
++#define TIMER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TWIS_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TWIS_CONFIG_LOG_ENABLED
++#define TWIS_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TWIS_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TWIS_CONFIG_LOG_LEVEL
++#define TWIS_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TWIS_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWIS_CONFIG_INFO_COLOR
++#define TWIS_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TWIS_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWIS_CONFIG_DEBUG_COLOR
++#define TWIS_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> TWI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef TWI_CONFIG_LOG_ENABLED
++#define TWI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> TWI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef TWI_CONFIG_LOG_LEVEL
++#define TWI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> TWI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWI_CONFIG_INFO_COLOR
++#define TWI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> TWI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef TWI_CONFIG_DEBUG_COLOR
++#define TWI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef UART_CONFIG_LOG_ENABLED
++#define UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef UART_CONFIG_LOG_LEVEL
++#define UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef UART_CONFIG_INFO_COLOR
++#define UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef UART_CONFIG_DEBUG_COLOR
++#define UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> USBD_CONFIG_LOG_ENABLED - Enable logging in the module
++//==========================================================
++#ifndef USBD_CONFIG_LOG_ENABLED
++#define USBD_CONFIG_LOG_ENABLED 0
++#endif
++// <o> USBD_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef USBD_CONFIG_LOG_LEVEL
++#define USBD_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef USBD_CONFIG_INFO_COLOR
++#define USBD_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef USBD_CONFIG_DEBUG_COLOR
++#define USBD_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> WDT_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef WDT_CONFIG_LOG_ENABLED
++#define WDT_CONFIG_LOG_ENABLED 0
++#endif
++// <o> WDT_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef WDT_CONFIG_LOG_LEVEL
++#define WDT_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> WDT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef WDT_CONFIG_INFO_COLOR
++#define WDT_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> WDT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef WDT_CONFIG_DEBUG_COLOR
++#define WDT_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nrf_log in nRF_Libraries 
++
++//==========================================================
++// <e> APP_TIMER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_TIMER_CONFIG_LOG_ENABLED
++#define APP_TIMER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_TIMER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_TIMER_CONFIG_LOG_LEVEL
++#define APP_TIMER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_TIMER_CONFIG_INITIAL_LOG_LEVEL  - Initial severity level if dynamic filtering is enabled.
++ 
++
++// <i> If module generates a lot of logs, initial log level can
++// <i> be decreased to prevent flooding. Severity level can be
++// <i> increased on instance basis.
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_TIMER_CONFIG_INITIAL_LOG_LEVEL
++#define APP_TIMER_CONFIG_INITIAL_LOG_LEVEL 3
++#endif
++
++// <o> APP_TIMER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_TIMER_CONFIG_INFO_COLOR
++#define APP_TIMER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_TIMER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_TIMER_CONFIG_DEBUG_COLOR
++#define APP_TIMER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_CDC_ACM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_CDC_ACM_CONFIG_LOG_ENABLED
++#define APP_USBD_CDC_ACM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_CDC_ACM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_CDC_ACM_CONFIG_LOG_LEVEL
++#define APP_USBD_CDC_ACM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_CDC_ACM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CDC_ACM_CONFIG_INFO_COLOR
++#define APP_USBD_CDC_ACM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_CDC_ACM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CDC_ACM_CONFIG_DEBUG_COLOR
++#define APP_USBD_CDC_ACM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_CONFIG_LOG_ENABLED - Enable logging in the module.
++//==========================================================
++#ifndef APP_USBD_CONFIG_LOG_ENABLED
++#define APP_USBD_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_CONFIG_LOG_LEVEL
++#define APP_USBD_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CONFIG_INFO_COLOR
++#define APP_USBD_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_CONFIG_DEBUG_COLOR
++#define APP_USBD_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_DUMMY_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_DUMMY_CONFIG_LOG_ENABLED
++#define APP_USBD_DUMMY_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_DUMMY_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_DUMMY_CONFIG_LOG_LEVEL
++#define APP_USBD_DUMMY_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_DUMMY_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_DUMMY_CONFIG_INFO_COLOR
++#define APP_USBD_DUMMY_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_DUMMY_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_DUMMY_CONFIG_DEBUG_COLOR
++#define APP_USBD_DUMMY_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_MSC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_MSC_CONFIG_LOG_ENABLED
++#define APP_USBD_MSC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_MSC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_MSC_CONFIG_LOG_LEVEL
++#define APP_USBD_MSC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_MSC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_MSC_CONFIG_INFO_COLOR
++#define APP_USBD_MSC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_MSC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_MSC_CONFIG_DEBUG_COLOR
++#define APP_USBD_MSC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_ENABLED 0
++#endif
++// <o> APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR
++#define APP_USBD_NRF_DFU_TRIGGER_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_ATFIFO_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_ATFIFO_CONFIG_LOG_ENABLED
++#define NRF_ATFIFO_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_ATFIFO_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_ATFIFO_CONFIG_LOG_LEVEL
++#define NRF_ATFIFO_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_ATFIFO_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_ATFIFO_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_ATFIFO_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_ATFIFO_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_ATFIFO_CONFIG_INFO_COLOR
++#define NRF_ATFIFO_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_ATFIFO_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_ATFIFO_CONFIG_DEBUG_COLOR
++#define NRF_ATFIFO_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BALLOC_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BALLOC_CONFIG_LOG_ENABLED
++#define NRF_BALLOC_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BALLOC_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BALLOC_CONFIG_LOG_LEVEL
++#define NRF_BALLOC_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BALLOC_CONFIG_INITIAL_LOG_LEVEL  - Initial severity level if dynamic filtering is enabled.
++ 
++
++// <i> If module generates a lot of logs, initial log level can
++// <i> be decreased to prevent flooding. Severity level can be
++// <i> increased on instance basis.
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BALLOC_CONFIG_INITIAL_LOG_LEVEL
++#define NRF_BALLOC_CONFIG_INITIAL_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BALLOC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BALLOC_CONFIG_INFO_COLOR
++#define NRF_BALLOC_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BALLOC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BALLOC_CONFIG_DEBUG_COLOR
++#define NRF_BALLOC_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_ENABLED
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_LEVEL
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_INFO_COLOR
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BLOCK_DEV_EMPTY_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_EMPTY_CONFIG_DEBUG_COLOR
++#define NRF_BLOCK_DEV_EMPTY_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BLOCK_DEV_QSPI_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_LOG_ENABLED
++#define NRF_BLOCK_DEV_QSPI_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_LOG_LEVEL
++#define NRF_BLOCK_DEV_QSPI_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_BLOCK_DEV_QSPI_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_INFO_COLOR
++#define NRF_BLOCK_DEV_QSPI_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BLOCK_DEV_QSPI_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_QSPI_CONFIG_DEBUG_COLOR
++#define NRF_BLOCK_DEV_QSPI_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_BLOCK_DEV_RAM_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_LOG_ENABLED
++#define NRF_BLOCK_DEV_RAM_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_LOG_LEVEL
++#define NRF_BLOCK_DEV_RAM_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_BLOCK_DEV_RAM_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_INFO_COLOR
++#define NRF_BLOCK_DEV_RAM_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_BLOCK_DEV_RAM_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_BLOCK_DEV_RAM_CONFIG_DEBUG_COLOR
++#define NRF_BLOCK_DEV_RAM_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_CLI_BLE_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_CLI_BLE_UART_CONFIG_LOG_ENABLED
++#define NRF_CLI_BLE_UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_CLI_BLE_UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_CLI_BLE_UART_CONFIG_LOG_LEVEL
++#define NRF_CLI_BLE_UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_CLI_BLE_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_BLE_UART_CONFIG_INFO_COLOR
++#define NRF_CLI_BLE_UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_CLI_BLE_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_BLE_UART_CONFIG_DEBUG_COLOR
++#define NRF_CLI_BLE_UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_CLI_LIBUARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_CLI_LIBUARTE_CONFIG_LOG_ENABLED
++#define NRF_CLI_LIBUARTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_CLI_LIBUARTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_CLI_LIBUARTE_CONFIG_LOG_LEVEL
++#define NRF_CLI_LIBUARTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_CLI_LIBUARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_LIBUARTE_CONFIG_INFO_COLOR
++#define NRF_CLI_LIBUARTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_CLI_LIBUARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_LIBUARTE_CONFIG_DEBUG_COLOR
++#define NRF_CLI_LIBUARTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_CLI_UART_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_CLI_UART_CONFIG_LOG_ENABLED
++#define NRF_CLI_UART_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_CLI_UART_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_CLI_UART_CONFIG_LOG_LEVEL
++#define NRF_CLI_UART_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_CLI_UART_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_UART_CONFIG_INFO_COLOR
++#define NRF_CLI_UART_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_CLI_UART_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_CLI_UART_CONFIG_DEBUG_COLOR
++#define NRF_CLI_UART_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_LIBUARTE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_LIBUARTE_CONFIG_LOG_ENABLED
++#define NRF_LIBUARTE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_LIBUARTE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_LIBUARTE_CONFIG_LOG_LEVEL
++#define NRF_LIBUARTE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_LIBUARTE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LIBUARTE_CONFIG_INFO_COLOR
++#define NRF_LIBUARTE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_LIBUARTE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_LIBUARTE_CONFIG_DEBUG_COLOR
++#define NRF_LIBUARTE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_MEMOBJ_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_MEMOBJ_CONFIG_LOG_ENABLED
++#define NRF_MEMOBJ_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_MEMOBJ_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_MEMOBJ_CONFIG_LOG_LEVEL
++#define NRF_MEMOBJ_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_MEMOBJ_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MEMOBJ_CONFIG_INFO_COLOR
++#define NRF_MEMOBJ_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_MEMOBJ_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_MEMOBJ_CONFIG_DEBUG_COLOR
++#define NRF_MEMOBJ_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_PWR_MGMT_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_PWR_MGMT_CONFIG_LOG_ENABLED
++#define NRF_PWR_MGMT_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_PWR_MGMT_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_PWR_MGMT_CONFIG_LOG_LEVEL
++#define NRF_PWR_MGMT_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_PWR_MGMT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_PWR_MGMT_CONFIG_INFO_COLOR
++#define NRF_PWR_MGMT_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_PWR_MGMT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_PWR_MGMT_CONFIG_DEBUG_COLOR
++#define NRF_PWR_MGMT_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_QUEUE_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_QUEUE_CONFIG_LOG_ENABLED
++#define NRF_QUEUE_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_QUEUE_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_QUEUE_CONFIG_LOG_LEVEL
++#define NRF_QUEUE_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_QUEUE_CONFIG_LOG_INIT_FILTER_LEVEL  - Initial severity level if dynamic filtering is enabled
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_QUEUE_CONFIG_LOG_INIT_FILTER_LEVEL
++#define NRF_QUEUE_CONFIG_LOG_INIT_FILTER_LEVEL 3
++#endif
++
++// <o> NRF_QUEUE_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_QUEUE_CONFIG_INFO_COLOR
++#define NRF_QUEUE_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_QUEUE_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_QUEUE_CONFIG_DEBUG_COLOR
++#define NRF_QUEUE_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_ANT_LOG_ENABLED - Enable logging in SoftDevice handler (ANT) module.
++//==========================================================
++#ifndef NRF_SDH_ANT_LOG_ENABLED
++#define NRF_SDH_ANT_LOG_ENABLED 0
++#endif
++// <o> NRF_SDH_ANT_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_ANT_LOG_LEVEL
++#define NRF_SDH_ANT_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_ANT_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_ANT_INFO_COLOR
++#define NRF_SDH_ANT_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_ANT_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_ANT_DEBUG_COLOR
++#define NRF_SDH_ANT_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_BLE_LOG_ENABLED - Enable logging in SoftDevice handler (BLE) module.
++//==========================================================
++#ifndef NRF_SDH_BLE_LOG_ENABLED
++#define NRF_SDH_BLE_LOG_ENABLED 1
++#endif
++// <o> NRF_SDH_BLE_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_BLE_LOG_LEVEL
++#define NRF_SDH_BLE_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_BLE_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_BLE_INFO_COLOR
++#define NRF_SDH_BLE_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_BLE_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_BLE_DEBUG_COLOR
++#define NRF_SDH_BLE_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_LOG_ENABLED - Enable logging in SoftDevice handler module.
++//==========================================================
++#ifndef NRF_SDH_LOG_ENABLED
++#define NRF_SDH_LOG_ENABLED 1
++#endif
++// <o> NRF_SDH_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_LOG_LEVEL
++#define NRF_SDH_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_INFO_COLOR
++#define NRF_SDH_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_DEBUG_COLOR
++#define NRF_SDH_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SDH_SOC_LOG_ENABLED - Enable logging in SoftDevice handler (SoC) module.
++//==========================================================
++#ifndef NRF_SDH_SOC_LOG_ENABLED
++#define NRF_SDH_SOC_LOG_ENABLED 1
++#endif
++// <o> NRF_SDH_SOC_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SDH_SOC_LOG_LEVEL
++#define NRF_SDH_SOC_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SDH_SOC_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_SOC_INFO_COLOR
++#define NRF_SDH_SOC_INFO_COLOR 0
++#endif
++
++// <o> NRF_SDH_SOC_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SDH_SOC_DEBUG_COLOR
++#define NRF_SDH_SOC_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_SORTLIST_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_SORTLIST_CONFIG_LOG_ENABLED
++#define NRF_SORTLIST_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_SORTLIST_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_SORTLIST_CONFIG_LOG_LEVEL
++#define NRF_SORTLIST_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_SORTLIST_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SORTLIST_CONFIG_INFO_COLOR
++#define NRF_SORTLIST_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_SORTLIST_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_SORTLIST_CONFIG_DEBUG_COLOR
++#define NRF_SORTLIST_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> NRF_TWI_SENSOR_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef NRF_TWI_SENSOR_CONFIG_LOG_ENABLED
++#define NRF_TWI_SENSOR_CONFIG_LOG_ENABLED 0
++#endif
++// <o> NRF_TWI_SENSOR_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef NRF_TWI_SENSOR_CONFIG_LOG_LEVEL
++#define NRF_TWI_SENSOR_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> NRF_TWI_SENSOR_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_TWI_SENSOR_CONFIG_INFO_COLOR
++#define NRF_TWI_SENSOR_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> NRF_TWI_SENSOR_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef NRF_TWI_SENSOR_CONFIG_DEBUG_COLOR
++#define NRF_TWI_SENSOR_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// <e> PM_LOG_ENABLED - Enable logging in Peer Manager and its submodules.
++//==========================================================
++#ifndef PM_LOG_ENABLED
++#define PM_LOG_ENABLED 1
++#endif
++// <o> PM_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef PM_LOG_LEVEL
++#define PM_LOG_LEVEL 3
++#endif
++
++// <o> PM_LOG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PM_LOG_INFO_COLOR
++#define PM_LOG_INFO_COLOR 0
++#endif
++
++// <o> PM_LOG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef PM_LOG_DEBUG_COLOR
++#define PM_LOG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <h> nrf_log in nRF_Serialization 
++
++//==========================================================
++// <e> SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED - Enables logging in the module.
++//==========================================================
++#ifndef SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED
++#define SER_HAL_TRANSPORT_CONFIG_LOG_ENABLED 0
++#endif
++// <o> SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL  - Default Severity level
++ 
++// <0=> Off 
++// <1=> Error 
++// <2=> Warning 
++// <3=> Info 
++// <4=> Debug 
++
++#ifndef SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL
++#define SER_HAL_TRANSPORT_CONFIG_LOG_LEVEL 3
++#endif
++
++// <o> SER_HAL_TRANSPORT_CONFIG_INFO_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SER_HAL_TRANSPORT_CONFIG_INFO_COLOR
++#define SER_HAL_TRANSPORT_CONFIG_INFO_COLOR 0
++#endif
++
++// <o> SER_HAL_TRANSPORT_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
++ 
++// <0=> Default 
++// <1=> Black 
++// <2=> Red 
++// <3=> Green 
++// <4=> Yellow 
++// <5=> Blue 
++// <6=> Magenta 
++// <7=> Cyan 
++// <8=> White 
++
++#ifndef SER_HAL_TRANSPORT_CONFIG_DEBUG_COLOR
++#define SER_HAL_TRANSPORT_CONFIG_DEBUG_COLOR 0
++#endif
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// </e>
++
++// <q> NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED  - nrf_log_str_formatter - Log string formatter
++ 
++
++#ifndef NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED
++#define NRF_LOG_STR_FORMATTER_TIMESTAMP_FORMAT_ENABLED 1
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> nRF_Segger_RTT 
++
++//==========================================================
++// <h> segger_rtt - SEGGER RTT
++
++//==========================================================
++// <o> SEGGER_RTT_CONFIG_BUFFER_SIZE_UP - Size of upstream buffer. 
++// <i> Note that either @ref NRF_LOG_BACKEND_RTT_OUTPUT_BUFFER_SIZE
++// <i> or this value is actually used. It depends on which one is bigger.
++
++#ifndef SEGGER_RTT_CONFIG_BUFFER_SIZE_UP
++#define SEGGER_RTT_CONFIG_BUFFER_SIZE_UP 512
++#endif
++
++// <o> SEGGER_RTT_CONFIG_MAX_NUM_UP_BUFFERS - Size of upstream buffer. 
++#ifndef SEGGER_RTT_CONFIG_MAX_NUM_UP_BUFFERS
++#define SEGGER_RTT_CONFIG_MAX_NUM_UP_BUFFERS 2
++#endif
++
++// <o> SEGGER_RTT_CONFIG_BUFFER_SIZE_DOWN - Size of upstream buffer. 
++#ifndef SEGGER_RTT_CONFIG_BUFFER_SIZE_DOWN
++#define SEGGER_RTT_CONFIG_BUFFER_SIZE_DOWN 16
++#endif
++
++// <o> SEGGER_RTT_CONFIG_MAX_NUM_DOWN_BUFFERS - Size of upstream buffer. 
++#ifndef SEGGER_RTT_CONFIG_MAX_NUM_DOWN_BUFFERS
++#define SEGGER_RTT_CONFIG_MAX_NUM_DOWN_BUFFERS 2
++#endif
++
++// <o> SEGGER_RTT_CONFIG_DEFAULT_MODE  - RTT behavior if the buffer is full.
++ 
++
++// <i> The following modes are supported:
++// <i> - SKIP  - Do not block, output nothing.
++// <i> - TRIM  - Do not block, output as much as fits.
++// <i> - BLOCK - Wait until there is space in the buffer.
++// <0=> SKIP 
++// <1=> TRIM 
++// <2=> BLOCK_IF_FIFO_FULL 
++
++#ifndef SEGGER_RTT_CONFIG_DEFAULT_MODE
++#define SEGGER_RTT_CONFIG_DEFAULT_MODE 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> nRF_SoftDevice 
++
++//==========================================================
++// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
++//==========================================================
++#ifndef NRF_SDH_BLE_ENABLED
++#define NRF_SDH_BLE_ENABLED 1
++#endif
++// <h> BLE Stack configuration - Stack configuration parameters
++
++// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
++// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
++//==========================================================
++// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251> 
++
++
++// <i> Requested BLE GAP data length to be negotiated.
++
++#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
++#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
++#endif
++
++// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
++#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
++#endif
++
++// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
++#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
++#endif
++
++// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
++// <i> Maximum number of total concurrent connections using the default configuration.
++
++#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
++#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
++#endif
++
++// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length. 
++// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
++
++#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
++#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
++#endif
++
++// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size. 
++#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
++#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 250
++#endif
++
++// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4. 
++#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
++#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
++#endif
++
++// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs. 
++#ifndef NRF_SDH_BLE_VS_UUID_COUNT
++#define NRF_SDH_BLE_VS_UUID_COUNT 0
++#endif
++
++// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
++ 
++
++#ifndef NRF_SDH_BLE_SERVICE_CHANGED
++#define NRF_SDH_BLE_SERVICE_CHANGED 0
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> BLE Observers - Observers and priority levels
++
++//==========================================================
++// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers. 
++// <i> This setting configures the number of priority levels available for BLE event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
++#endif
++
++// <h> BLE Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> BLE_ADV_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Advertising module.
++
++#ifndef BLE_ADV_BLE_OBSERVER_PRIO
++#define BLE_ADV_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_ANCS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Apple Notification Service Client.
++
++#ifndef BLE_ANCS_C_BLE_OBSERVER_PRIO
++#define BLE_ANCS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_ANS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Alert Notification Service Client.
++
++#ifndef BLE_ANS_C_BLE_OBSERVER_PRIO
++#define BLE_ANS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_BAS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Battery Service.
++
++#ifndef BLE_BAS_BLE_OBSERVER_PRIO
++#define BLE_BAS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_BAS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Battery Service Client.
++
++#ifndef BLE_BAS_C_BLE_OBSERVER_PRIO
++#define BLE_BAS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_BPS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Blood Pressure Service.
++
++#ifndef BLE_BPS_BLE_OBSERVER_PRIO
++#define BLE_BPS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_CONN_PARAMS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Connection parameters module.
++
++#ifndef BLE_CONN_PARAMS_BLE_OBSERVER_PRIO
++#define BLE_CONN_PARAMS_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Connection State module.
++
++#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
++#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
++#endif
++
++// <o> BLE_CSCS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Cycling Speed and Cadence Service.
++
++#ifndef BLE_CSCS_BLE_OBSERVER_PRIO
++#define BLE_CSCS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_CTS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Current Time Service Client.
++
++#ifndef BLE_CTS_C_BLE_OBSERVER_PRIO
++#define BLE_CTS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_DB_DISC_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Database Discovery module.
++
++#ifndef BLE_DB_DISC_BLE_OBSERVER_PRIO
++#define BLE_DB_DISC_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_DFU_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the DFU Service.
++
++#ifndef BLE_DFU_BLE_OBSERVER_PRIO
++#define BLE_DFU_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_DIS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Device Information Client.
++
++#ifndef BLE_DIS_C_BLE_OBSERVER_PRIO
++#define BLE_DIS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_GLS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Glucose Service.
++
++#ifndef BLE_GLS_BLE_OBSERVER_PRIO
++#define BLE_GLS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HIDS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Human Interface Device Service.
++
++#ifndef BLE_HIDS_BLE_OBSERVER_PRIO
++#define BLE_HIDS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HRS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Heart Rate Service.
++
++#ifndef BLE_HRS_BLE_OBSERVER_PRIO
++#define BLE_HRS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HRS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Heart Rate Service Client.
++
++#ifndef BLE_HRS_C_BLE_OBSERVER_PRIO
++#define BLE_HRS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_HTS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Health Thermometer Service.
++
++#ifndef BLE_HTS_BLE_OBSERVER_PRIO
++#define BLE_HTS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_IAS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Immediate Alert Service.
++
++#ifndef BLE_IAS_BLE_OBSERVER_PRIO
++#define BLE_IAS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_IAS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Immediate Alert Service Client.
++
++#ifndef BLE_IAS_C_BLE_OBSERVER_PRIO
++#define BLE_IAS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LBS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the LED Button Service.
++
++#ifndef BLE_LBS_BLE_OBSERVER_PRIO
++#define BLE_LBS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LBS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the LED Button Service Client.
++
++#ifndef BLE_LBS_C_BLE_OBSERVER_PRIO
++#define BLE_LBS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LLS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Link Loss Service.
++
++#ifndef BLE_LLS_BLE_OBSERVER_PRIO
++#define BLE_LLS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_LNS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Location Navigation Service.
++
++#ifndef BLE_LNS_BLE_OBSERVER_PRIO
++#define BLE_LNS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_NUS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the UART Service.
++
++#ifndef BLE_NUS_BLE_OBSERVER_PRIO
++#define BLE_NUS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_NUS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the UART Central Service.
++
++#ifndef BLE_NUS_C_BLE_OBSERVER_PRIO
++#define BLE_NUS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_OTS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Object transfer service.
++
++#ifndef BLE_OTS_BLE_OBSERVER_PRIO
++#define BLE_OTS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_OTS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Object transfer service client.
++
++#ifndef BLE_OTS_C_BLE_OBSERVER_PRIO
++#define BLE_OTS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_RSCS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Running Speed and Cadence Service.
++
++#ifndef BLE_RSCS_BLE_OBSERVER_PRIO
++#define BLE_RSCS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_RSCS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Running Speed and Cadence Client.
++
++#ifndef BLE_RSCS_C_BLE_OBSERVER_PRIO
++#define BLE_RSCS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BLE_TPS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the TX Power Service.
++
++#ifndef BLE_TPS_BLE_OBSERVER_PRIO
++#define BLE_TPS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> BSP_BTN_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Button Control module.
++
++#ifndef BSP_BTN_BLE_OBSERVER_PRIO
++#define BSP_BTN_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the NFC pairing library.
++
++#ifndef NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO
++#define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the NFC pairing library.
++
++#ifndef NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO
++#define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the NFC pairing library.
++
++#ifndef NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO
++#define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Bond Management Service.
++
++#ifndef NRF_BLE_BMS_BLE_OBSERVER_PRIO
++#define NRF_BLE_BMS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_CGMS_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Contiuon Glucose Monitoring Service.
++
++#ifndef NRF_BLE_CGMS_BLE_OBSERVER_PRIO
++#define NRF_BLE_CGMS_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_ES_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Eddystone module.
++
++#ifndef NRF_BLE_ES_BLE_OBSERVER_PRIO
++#define NRF_BLE_ES_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_GATTS_C_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the GATT Service Client.
++
++#ifndef NRF_BLE_GATTS_C_BLE_OBSERVER_PRIO
++#define NRF_BLE_GATTS_C_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_GATT_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the GATT module.
++
++#ifndef NRF_BLE_GATT_BLE_OBSERVER_PRIO
++#define NRF_BLE_GATT_BLE_OBSERVER_PRIO 1
++#endif
++
++// <o> NRF_BLE_QWR_BLE_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the Queued writes module.
++
++#ifndef NRF_BLE_QWR_BLE_OBSERVER_PRIO
++#define NRF_BLE_QWR_BLE_OBSERVER_PRIO 2
++#endif
++
++// <o> NRF_BLE_SCAN_OBSERVER_PRIO  
++// <i> Priority for dispatching the BLE events to the Scanning Module.
++
++#ifndef NRF_BLE_SCAN_OBSERVER_PRIO
++#define NRF_BLE_SCAN_OBSERVER_PRIO 1
++#endif
++
++// <o> PM_BLE_OBSERVER_PRIO - Priority with which BLE events are dispatched to the Peer Manager module. 
++#ifndef PM_BLE_OBSERVER_PRIO
++#define PM_BLE_OBSERVER_PRIO 1
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++
++// </e>
++
++// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
++//==========================================================
++#ifndef NRF_SDH_ENABLED
++#define NRF_SDH_ENABLED 1
++#endif
++// <h> Dispatch model 
++
++// <i> This setting configures how Stack events are dispatched to the application.
++//==========================================================
++// <o> NRF_SDH_DISPATCH_MODEL
++ 
++
++// <i> NRF_SDH_DISPATCH_MODEL_INTERRUPT: SoftDevice events are passed to the application from the interrupt context.
++// <i> NRF_SDH_DISPATCH_MODEL_APPSH: SoftDevice events are scheduled using @ref app_scheduler.
++// <i> NRF_SDH_DISPATCH_MODEL_POLLING: SoftDevice events are to be fetched manually.
++// <0=> NRF_SDH_DISPATCH_MODEL_INTERRUPT 
++// <1=> NRF_SDH_DISPATCH_MODEL_APPSH 
++// <2=> NRF_SDH_DISPATCH_MODEL_POLLING 
++
++#ifndef NRF_SDH_DISPATCH_MODEL
++#define NRF_SDH_DISPATCH_MODEL 0
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> Clock - SoftDevice clock configuration
++
++//==========================================================
++// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
++ 
++// <0=> NRF_CLOCK_LF_SRC_RC 
++// <1=> NRF_CLOCK_LF_SRC_XTAL 
++// <2=> NRF_CLOCK_LF_SRC_SYNTH 
++
++#ifndef NRF_SDH_CLOCK_LF_SRC
++#define NRF_SDH_CLOCK_LF_SRC 1
++#endif
++
++// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval. 
++#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
++#define NRF_SDH_CLOCK_LF_RC_CTIV 0
++#endif
++
++// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature. 
++// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
++// <i>  if the temperature has not changed.
++
++#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
++#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
++#endif
++
++// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
++ 
++// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM 
++// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM 
++// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM 
++// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM 
++// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM 
++// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM 
++// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM 
++// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM 
++// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM 
++// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM 
++// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM 
++// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM 
++
++#ifndef NRF_SDH_CLOCK_LF_ACCURACY
++#define NRF_SDH_CLOCK_LF_ACCURACY 7
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> SDH Observers - Observers and priority levels
++
++//==========================================================
++// <o> NRF_SDH_REQ_OBSERVER_PRIO_LEVELS - Total number of priority levels for request observers. 
++// <i> This setting configures the number of priority levels available for the SoftDevice request event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_REQ_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_REQ_OBSERVER_PRIO_LEVELS 2
++#endif
++
++// <o> NRF_SDH_STATE_OBSERVER_PRIO_LEVELS - Total number of priority levels for state observers. 
++// <i> This setting configures the number of priority levels available for the SoftDevice state event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_STATE_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_STATE_OBSERVER_PRIO_LEVELS 2
++#endif
++
++// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers. 
++// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
++#endif
++
++
++// <h> State Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> CLOCK_CONFIG_STATE_OBSERVER_PRIO  
++// <i> Priority with which state events are dispatched to the Clock driver.
++
++#ifndef CLOCK_CONFIG_STATE_OBSERVER_PRIO
++#define CLOCK_CONFIG_STATE_OBSERVER_PRIO 0
++#endif
++
++// <o> POWER_CONFIG_STATE_OBSERVER_PRIO  
++// <i> Priority with which state events are dispatched to the Power driver.
++
++#ifndef POWER_CONFIG_STATE_OBSERVER_PRIO
++#define POWER_CONFIG_STATE_OBSERVER_PRIO 0
++#endif
++
++// <o> RNG_CONFIG_STATE_OBSERVER_PRIO  
++// <i> Priority with which state events are dispatched to this module.
++
++#ifndef RNG_CONFIG_STATE_OBSERVER_PRIO
++#define RNG_CONFIG_STATE_OBSERVER_PRIO 0
++#endif
++
++// </h> 
++//==========================================================
++
++// <h> Stack Event Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> NRF_SDH_ANT_STACK_OBSERVER_PRIO  
++// <i> This setting configures the priority with which ANT events are processed with respect to other events coming from the stack.
++// <i> Modify this setting if you need to have ANT events dispatched before or after other stack events, such as BLE or SoC.
++// <i> Zero is the highest priority.
++
++#ifndef NRF_SDH_ANT_STACK_OBSERVER_PRIO
++#define NRF_SDH_ANT_STACK_OBSERVER_PRIO 0
++#endif
++
++// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO  
++// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
++// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
++// <i> Zero is the highest priority.
++
++#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
++#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
++#endif
++
++// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO  
++// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
++// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
++// <i> Zero is the highest priority.
++
++#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
++#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++
++// </e>
++
++// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
++//==========================================================
++#ifndef NRF_SDH_SOC_ENABLED
++#define NRF_SDH_SOC_ENABLED 1
++#endif
++// <h> SoC Observers - Observers and priority levels
++
++//==========================================================
++// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers. 
++// <i> This setting configures the number of priority levels available for the SoC event handlers.
++// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
++
++#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
++#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
++#endif
++
++// <h> SoC Observers priorities - Invididual priorities
++
++//==========================================================
++// <o> BLE_ADV_SOC_OBSERVER_PRIO  
++// <i> Priority with which SoC events are dispatched to the Advertising module.
++
++#ifndef BLE_ADV_SOC_OBSERVER_PRIO
++#define BLE_ADV_SOC_OBSERVER_PRIO 1
++#endif
++
++// <o> BLE_DFU_SOC_OBSERVER_PRIO  
++// <i> Priority with which BLE events are dispatched to the DFU Service.
++
++#ifndef BLE_DFU_SOC_OBSERVER_PRIO
++#define BLE_DFU_SOC_OBSERVER_PRIO 1
++#endif
++
++// <o> CLOCK_CONFIG_SOC_OBSERVER_PRIO  
++// <i> Priority with which SoC events are dispatched to the Clock driver.
++
++#ifndef CLOCK_CONFIG_SOC_OBSERVER_PRIO
++#define CLOCK_CONFIG_SOC_OBSERVER_PRIO 0
++#endif
++
++// <o> POWER_CONFIG_SOC_OBSERVER_PRIO  
++// <i> Priority with which SoC events are dispatched to the Power driver.
++
++#ifndef POWER_CONFIG_SOC_OBSERVER_PRIO
++#define POWER_CONFIG_SOC_OBSERVER_PRIO 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++
++// </e>
++
++// </h> 
++//==========================================================
++
++// <<< end of configuration section >>>
++#endif //SDK_CONFIG_H
++
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+new file mode 100644
+index 0000000..437d1f5
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+@@ -0,0 +1,167 @@
++<!DOCTYPE CrossStudio_Project_File>
++<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
++  <project Name="ble_connectivity_132v5_usb_hci_pca10056">
++    <configuration
++      Name="Common"
++      arm_architecture="v7EM"
++      arm_core_type="Cortex-M4"
++      arm_endian="Little"
++      arm_fp_abi="Hard"
++      arm_fpu_type="FPv4-SP-D16"
++      arm_linker_heap_size="512"
++      arm_linker_process_stack_size="0"
++      arm_linker_stack_size="2048"
++      arm_linker_treat_warnings_as_errors="No"
++      arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
++      arm_target_device_name="nRF52840_xxAA"
++      arm_target_interface_type="SWD"
++      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/ble/common;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s132v5/headers;../../../../../../components/softdevice/s132v5/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
++      c_preprocessor_definitions="BLE_STACK_SUPPORT_REQD;BOARD_PCA10056;BSP_DEFINES_ONLY;CONFIG_GPIO_AS_PINRESET;FLOAT_ABI_HARD;HCI_TIMER2;INITIALIZE_USER_SECTIONS;NO_VTOR_CONFIG;NRF52840_XXAA;NRF_SD_BLE_API_VERSION=5;S132;SER_CONNECTIVITY;SER_PHY_HCI_USB_CDC;SOFTDEVICE_PRESENT;SWI_DISABLE0;"
++      debug_target_connection="J-Link"
++      gcc_entry_point="Reset_Handler"
++      macros="CMSIS_CONFIG_TOOL=../../../../../../external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar"
++      debug_register_definition_file="../../../../../../modules/nrfx/mdk/nrf52840.svd"
++      debug_additional_load_file="../../../../../../components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex"
++      debug_start_from_entry_point_symbol="No"
++      gcc_debugging_level="Level 3"      linker_output_format="hex"
++      linker_printf_width_precision_supported="Yes"
++      linker_printf_fmt_level="long"
++      linker_section_placement_file="flash_placement.xml"
++      linker_section_placement_macros="FLASH_PH_START=0x0;FLASH_PH_SIZE=0x100000;RAM_PH_START=0x20000000;RAM_PH_SIZE=0x40000;FLASH_START=0x23000;FLASH_SIZE=0xdd000;RAM_START=0x20019380;RAM_SIZE=0x26c80"
++      linker_section_placements_segments="FLASH RX 0x0 0x100000;RAM RWX 0x20000000 0x40000;connectivity_version_info RX 0x50000 0x18"
++      project_directory=""
++      project_type="Executable" />
++      <folder Name="Segger Startup Files">
++        <file file_name="$(StudioDir)/source/thumb_crt0.s" />
++      </folder>
++    <folder Name="nRF_Log">
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_backend_rtt.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_backend_serial.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_backend_uart.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_default_backends.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_frontend.c" />
++      <file file_name="../../../../../../components/libraries/log/src/nrf_log_str_formatter.c" />
++    </folder>
++    <folder Name="nRF_Libraries">
++      <file file_name="../../../../../../components/libraries/util/app_error.c" />
++      <file file_name="../../../../../../components/libraries/util/app_error_handler_gcc.c" />
++      <file file_name="../../../../../../components/libraries/util/app_error_weak.c" />
++      <file file_name="../../../../../../components/libraries/scheduler/app_scheduler.c" />
++      <file file_name="../../../../../../components/libraries/timer/app_timer.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd.c" />
++      <file file_name="../../../../../../components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd_core.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd_serial_num.c" />
++      <file file_name="../../../../../../components/libraries/usbd/app_usbd_string_desc.c" />
++      <file file_name="../../../../../../components/libraries/util/app_util_platform.c" />
++      <file file_name="../../../../../../components/libraries/crc16/crc16.c" />
++      <file file_name="../../../../../../components/libraries/util/nrf_assert.c" />
++      <file file_name="../../../../../../components/libraries/atomic_fifo/nrf_atfifo.c" />
++      <file file_name="../../../../../../components/libraries/atomic/nrf_atomic.c" />
++      <file file_name="../../../../../../components/libraries/balloc/nrf_balloc.c" />
++      <file file_name="../../../../../../external/fprintf/nrf_fprintf.c" />
++      <file file_name="../../../../../../external/fprintf/nrf_fprintf_format.c" />
++      <file file_name="../../../../../../components/libraries/memobj/nrf_memobj.c" />
++      <file file_name="../../../../../../components/libraries/queue/nrf_queue.c" />
++      <file file_name="../../../../../../components/libraries/ringbuf/nrf_ringbuf.c" />
++      <file file_name="../../../../../../components/libraries/experimental_section_vars/nrf_section_iter.c" />
++      <file file_name="../../../../../../components/libraries/strerror/nrf_strerror.c" />
++    </folder>
++    <folder Name="None">
++      <file file_name="../../../../../../modules/nrfx/mdk/ses_startup_nrf52840.s" />
++      <file file_name="../../../../../../modules/nrfx/mdk/ses_startup_nrf_common.s" />
++      <file file_name="../../../../../../modules/nrfx/mdk/system_nrf52840.c" />
++    </folder>
++    <folder Name="Board Definition">
++      <file file_name="../../../../../../components/boards/boards.c" />
++    </folder>
++    <folder Name="nRF_Serialization">
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/common/ble_dtm_init.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gatt_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gattc_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gattc_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gattc_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gatts_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_gatts_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_gatts_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_conn.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_l2cap_evt_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_l2cap_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/ble_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/ble_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/common/cond_field_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/conn_ble_l2cap_sdu_pool.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/common/conn_mw.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gattc.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gatts.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_l2cap.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/common/conn_mw_nrf_soc.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/hal/dtm_uart.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/nrf_soc_conn.c" />
++      <file file_name="../../../../../../components/serialization/common/struct_ser/ble/nrf_soc_struct_serialization.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_cmd_decoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_dtm_cmd_decoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_error_handling.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_event_encoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_handlers.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_pkt_decoder.c" />
++      <file file_name="../../../../../../components/serialization/connectivity/ser_conn_reset_cmd_decoder.c" />
++      <file file_name="../../../../../../components/serialization/common/ser_dbg_sd_str.c" />
++      <file file_name="../../../../../../components/serialization/common/transport/ser_hal_transport.c" />
++      <file file_name="../../../../../../components/serialization/common/transport/ser_phy/ser_phy_hci.c" />
++      <file file_name="../../../../../../components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c" />
++    </folder>
++    <folder Name="nRF_Drivers">
++      <file file_name="../../../../../../integration/nrfx/legacy/nrf_drv_clock.c" />
++      <file file_name="../../../../../../integration/nrfx/legacy/nrf_drv_power.c" />
++      <file file_name="../../../../../../integration/nrfx/legacy/nrf_drv_uart.c" />
++      <file file_name="../../../../../../components/drivers_nrf/usbd/nrf_drv_usbd.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_clock.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
++    </folder>
++    <folder Name="Application">
++      <file file_name="../../../main.c" />
++      <file file_name="../config/sdk_config.h" />
++    </folder>
++    <folder Name="nRF_Segger_RTT">
++      <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT.c" />
++      <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT_Syscalls_SES.c" />
++      <file file_name="../../../../../../external/segger_rtt/SEGGER_RTT_printf.c" />
++    </folder>
++    <folder Name="nRF_BLE">
++      <file file_name="../../../../../../components/ble/common/ble_advdata.c" />
++      <file file_name="../../../../../../components/ble/common/ble_conn_params.c" />
++      <file file_name="../../../../../../components/ble/ble_dtm/ble_dtm.c" />
++      <file file_name="../../../../../../components/ble/ble_dtm/ble_dtm_hw_nrf52.c" />
++      <file file_name="../../../../../../components/ble/common/ble_srv_common.c" />
++    </folder>
++    <folder Name="UTF8/UTF16 converter">
++      <file file_name="../../../../../../external/utf_converter/utf.c" />
++    </folder>
++    <folder Name="nRF_SoftDevice">
++      <file file_name="../../../../../../components/softdevice/common/nrf_sdh.c" />
++      <file file_name="../../../../../../components/softdevice/common/nrf_sdh_ble.c" />
++      <file file_name="../../../../../../components/softdevice/common/nrf_sdh_soc.c" />
++    </folder>
++  </project>
++  <configuration Name="Release"
++    c_preprocessor_definitions="NDEBUG"
++    gcc_optimization_level="Optimize For Size" />
++  <configuration Name="Debug"
++    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
++    gcc_optimization_level="None"/>
++</solution>
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+new file mode 100644
+index 0000000..6c26dd1
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+@@ -0,0 +1,7 @@
++<!DOCTYPE CrossStudio_Session_File>
++<session>
++  <ARMCrossStudioWindow activeProject="ble_connectivity_132v5_usb_hci_pca10056" buildConfiguration="Release"/>
++  <Files>
++    <SessionOpenFile codecName="Default" debugPath="../../../main.c" left="0" name="unnamed" path="../../../main.c" selected="1" top="0" useBinaryEdit="0" useTextEdit="1" x="0" y="0"/>
++  </Files>
++</session>
+\ No newline at end of file
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+new file mode 100644
+index 0000000..95c368d
+--- /dev/null
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+@@ -0,0 +1,49 @@
++<!DOCTYPE Linker_Placement_File>
++<Root name="Flash Section Placement">
++  <MemorySegment name="FLASH" start="$(FLASH_PH_START)" size="$(FLASH_PH_SIZE)">
++    <ProgramSection load="no" name=".reserved_flash" start="$(FLASH_PH_START)" size="$(FLASH_START)-$(FLASH_PH_START)" />
++    <ProgramSection alignment="0x100" load="Yes" name=".vectors" start="$(FLASH_START)" />
++    <ProgramSection alignment="4" load="Yes" name=".init" />
++    <ProgramSection alignment="4" load="Yes" name=".init_rodata" />
++    <ProgramSection alignment="4" load="Yes" name=".text" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_ble_observers" inputsections="*(SORT(.sdh_ble_observers*))" address_symbol="__start_sdh_ble_observers" end_symbol="__stop_sdh_ble_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_filter_data"  inputsections="*(SORT(.log_filter_data*))" runin=".log_filter_data_run"/>
++    <ProgramSection alignment="4" load="Yes" name=".dtors" />
++    <ProgramSection alignment="4" load="Yes" name=".ctors" />
++    <ProgramSection alignment="4" load="Yes" name=".rodata" />
++    <ProgramSection alignment="4" load="Yes" name=".ARM.exidx" address_symbol="__exidx_start" end_symbol="__exidx_end" />
++    <ProgramSection alignment="4" load="Yes" runin=".fast_run" name=".fast" />
++    <ProgramSection alignment="4" load="Yes" runin=".data_run" name=".data" />
++    <ProgramSection alignment="4" load="Yes" runin=".tdata_run" name=".tdata" />
++  </MemorySegment>
++  <MemorySegment name="RAM" start="$(RAM_PH_START)" size="$(RAM_PH_SIZE)">
++    <ProgramSection load="no" name=".reserved_ram" start="$(RAM_PH_START)" size="$(RAM_START)-$(RAM_PH_START)" />
++    <ProgramSection alignment="0x100" load="No" name=".vectors_ram" start="$(RAM_START)" address_symbol="__app_ram_start__"/>
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections_run" address_symbol="__start_nrf_sections_run" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".log_dynamic_data_run" address_symbol="__start_log_dynamic_data" end_symbol="__stop_log_dynamic_data" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".log_filter_data_run" address_symbol="__start_log_filter_data" end_symbol="__stop_log_filter_data" />
++    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections_run_end" address_symbol="__end_nrf_sections_run" />
++    <ProgramSection alignment="4" load="No" name=".fast_run" />
++    <ProgramSection alignment="4" load="No" name=".data_run" />
++    <ProgramSection alignment="4" load="No" name=".tdata_run" />
++    <ProgramSection alignment="4" load="No" name=".bss" />
++    <ProgramSection alignment="4" load="No" name=".tbss" />
++    <ProgramSection alignment="4" load="No" name=".non_init" />
++    <ProgramSection alignment="4" size="__HEAPSIZE__" load="No" name=".heap" />
++    <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
++    <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
++  </MemorySegment>
++  <MemorySegment name="connectivity_version_info" start="0x50000" size="0x18">
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
++  </MemorySegment>
++</Root>
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -47696,36 +58613,25 @@ index b877f5a..6816cb2 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-index 793e569..c239944 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+index 793e569..58429c4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+@@ -3839,12 +3839,12 @@
+ 
+ // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
+ #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
+ #ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+-#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
 @@ -4145,132 +4145,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47859,10 +58765,10 @@ index 793e569..c239944 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..fbea4af 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47872,21 +58778,10 @@ index f64c3a0..fbea4af 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47895,10 +58790,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..5af9fbd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -47917,36 +58812,25 @@ index d3acaad..5af9fbd 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-index ba4721d..051bb5c 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+index ba4721d..4802198 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+@@ -4017,12 +4017,12 @@
+ 
+ // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
+ #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
+ #ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+-#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
 @@ -4323,132 +4323,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48080,10 +58964,10 @@ index ba4721d..051bb5c 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..ebc07bf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48093,21 +58977,10 @@ index a71ed2f..ebc07bf 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48116,10 +58989,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..5af9fbd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -48138,36 +59011,25 @@ index d3acaad..5af9fbd 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-index ba4721d..051bb5c 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+index ba4721d..4802198 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+@@ -4017,12 +4017,12 @@
+ 
+ // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
+ #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
+ #ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+-#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
 @@ -4323,132 +4323,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48301,10 +59163,10 @@ index ba4721d..051bb5c 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..eb97046 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48314,21 +59176,10 @@ index a95d1a5..eb97046 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48337,10 +59188,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..5af9fbd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -48359,36 +59210,25 @@ index d3acaad..5af9fbd 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-index 36b0fe4..a3695bb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+index 36b0fe4..47afc6b 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+@@ -3723,12 +3723,12 @@
+ 
+ // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
+ #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
+ #ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+-#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
 @@ -4029,132 +4029,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48522,10 +59362,10 @@ index 36b0fe4..a3695bb 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..8cbfa44 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48535,21 +59375,10 @@ index 228cf40..8cbfa44 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48558,10 +59387,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 index 07cf7c6..18cdbce 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -177,6 +177,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
@@ -48578,10 +59407,10 @@ index 07cf7c6..18cdbce 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..6816cb2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -48600,36 +59429,10 @@ index b877f5a..6816cb2 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-index 994863b..0e4a0a0 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+index 994863b..0bcfe3e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -901,7 +901,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
@@ -48639,6 +59442,21 @@ index 994863b..0e4a0a0 100644
  #endif
  
  // <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
+@@ -4261,12 +4261,12 @@
+ 
+ // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
+ #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
+ #ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+-#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
 @@ -4567,132 +4567,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48772,10 +59590,10 @@ index 994863b..0e4a0a0 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 index 571ebbb..4ffca5a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -48794,21 +59612,10 @@ index 571ebbb..4ffca5a 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48817,11 +59624,11 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..a2942b9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,281 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -49104,11 +59911,11 @@ index 0000000..a2942b9
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..12fd23c
+index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -49188,6 +59995,12 @@ index 0000000..12fd23c
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -49200,12 +60013,6 @@ index 0000000..12fd23c
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -49216,11 +60023,11 @@ index 0000000..12fd23c
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..544a663
+index 0000000..e9d9297
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,4965 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -53588,12 +64395,12 @@ index 0000000..544a663
 +
 +// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
 +#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
-+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
 +#endif
 +
 +// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
 +#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
-+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
 +#endif
 +
 +// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
@@ -54187,11 +64994,11 @@ index 0000000..544a663
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..33a4962
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,168 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -54361,11 +65168,11 @@ index 0000000..33a4962
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -54375,11 +65182,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -54394,9 +65201,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -54430,10 +65237,10 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..bb6ccf2 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -182,6 +182,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
@@ -54450,10 +65257,10 @@ index 33053bc..bb6ccf2 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..6816cb2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -54472,36 +65279,10 @@ index b877f5a..6816cb2 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-index bb385de..a3cd96c 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+index bb385de..4707ba1 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -997,7 +997,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
@@ -54511,6 +65292,21 @@ index bb385de..a3cd96c 100644
  #endif
  
  // <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
+@@ -4364,12 +4364,12 @@
+ 
+ // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
+ #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+-#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
++#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links. 
+ #ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+-#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
++#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 8
+ #endif
+ 
+ // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
 @@ -4670,132 +4670,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -54644,10 +65440,10 @@ index bb385de..a3cd96c 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..2c772bc 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -54666,21 +65462,10 @@ index c7771fd..2c772bc 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_81c7e01/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_fdc124d/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -54689,10 +65474,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_81c7e01/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_fdc124d/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_81c7e01/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_fdc124d/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -54767,11 +65552,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_81c7e01/examples/readme.txt nRF5_SDK_15.2.0_81c7e01/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_fdc124d/examples/readme.txt nRF5_SDK_15.2.0_fdc124d/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_81c7e01/examples/readme.txt
++++ nRF5_SDK_15.2.0_fdc124d/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -54787,10 +65572,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_81c7e01/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_fdc124d/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_81c7e01/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_fdc124d/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif


### PR DESCRIPTION
Connectivity firmware running on nRF52840 would reset
the USB stack after successive open close iterations.

A fix for this is available in nRF5_SDK_15.2.0_fdc124d.

This commit updates the patch to include the changes from
nRF5_SDK_15.2.0_fdc124d.