### PR TITLE
Fix warning and potential issue on 64-bit and BE platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.11)
 project(pc-ble-driver)
 
-include (cmake/pc-ble-driver.cmake)
+include(cmake/pc-ble-driver.cmake)
+
+include(TestBigEndian)
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+if(IS_BIG_ENDIAN)
+    message(FATAL_ERROR "Protocol implementation does not support big endian platforms.")
+endif()
 
 # Common source files
 file(GLOB LIB_BASE_C_SRC_FILES "src/common/*.c")

--- a/src/sd_api_common/sdk/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+++ b/src/sd_api_common/sdk/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
@@ -1723,12 +1723,12 @@ uint32_t ble_gap_evt_adv_set_terminated_t_enc(void const * const p_void_struct,
     SER_PUSH_uint8(&p_struct->num_completed_adv_events);
     SER_PUSH_uint16(&p_struct->adv_data.adv_data.len);
 
-    uint32_t addr = (uint32_t)p_struct->adv_data.adv_data.p_data;
+    uint32_t addr = *((uint32_t*)&(p_struct->adv_data.adv_data.p_data));
     SER_PUSH_uint32(&addr);
 
     SER_PUSH_uint16(&p_struct->adv_data.scan_rsp_data.len);
 
-    addr = (uint32_t)p_struct->adv_data.scan_rsp_data.p_data;
+    addr = *((uint32_t*)&(p_struct->adv_data.scan_rsp_data.p_data));
     SER_PUSH_uint32(&addr);
 
     SER_STRUCT_ENC_END;

--- a/src/sd_api_common/sdk/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+++ b/src/sd_api_common/sdk/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
@@ -471,7 +471,7 @@ uint32_t ble_data_t_enc(void const * const p_void_struct,
 {
     SER_STRUCT_ENC_BEGIN(ble_data_t);
 
-    uint32_t buf_id = (uint32_t)p_struct->p_data;
+    uint32_t buf_id = *((uint32_t*)&(p_struct->p_data));
     SER_PUSH_uint32(&buf_id);
     SER_PUSH_len16data(p_struct->p_data, p_struct->len);
 


### PR DESCRIPTION
The protocol between connectivity and host side only support Little Endian platforms.

The casting to uint32 from a 64-bit ptr is not safe.