### PR TITLE
Add command line arguments to configure tests

### DIFF
--- a/test/softdevice_api/test_main.cpp
+++ b/test/softdevice_api/test_main.cpp
@@ -2,12 +2,34 @@
 
 #include <iostream>
 #include <mutex>
-#include <sstream>
 
 std::ostream &nrfLogStream(std::cout);
 std::mutex nrfLogMutex;
 
-#include <internal/log.h>
-
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
+
+int main(int argc, char *argv[])
+{
+    Catch::Session session;
+
+    std::string serialPortA;
+    std::string serialPortB;
+    uint32_t iterations;
+
+    using namespace Catch::clara;
+
+    const auto cli = session.cli() |
+                     Opt(serialPortA, "serial port A")["-pa"]["--porta"]("Serial port A") |
+                     Opt(serialPortB, "serial port B")["-pb"]["--portb"]("Serial port B") |
+                     Opt(iterations, "iterations")["-it"]["--iterations"](
+                         "Number of iterations. "
+                         "Ignored for tests not having iterations.");
+
+    session.cli(cli);
+
+    const auto exitCode = session.applyCommandLine(argc, argv);
+
+    if (exitCode != 0)
+        return exitCode;
+}

--- a/test/softdevice_api/test_main.cpp
+++ b/test/softdevice_api/test_main.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <mutex>
+#include <test_setup.h>
 
 std::ostream &nrfLogStream(std::cout);
 std::mutex nrfLogMutex;
@@ -13,18 +14,47 @@ int main(int argc, char *argv[])
 {
     Catch::Session session;
 
-    std::string serialPortA;
-    std::string serialPortB;
-    uint32_t iterations;
+    auto serialPortA = std::string{};
+    auto serialPortB = std::string{};
+    auto iterations  = 0;
+    auto baudRate    = DEFAULT_BAUD_RATE;
+    auto logLevel    = SD_RPC_LOG_FATAL;
 
     using namespace Catch::clara;
 
-    const auto cli = session.cli() |
-                     Opt(serialPortA, "serial port A")["-pa"]["--porta"]("Serial port A") |
-                     Opt(serialPortB, "serial port B")["-pb"]["--portb"]("Serial port B") |
-                     Opt(iterations, "iterations")["-it"]["--iterations"](
-                         "Number of iterations. "
-                         "Ignored for tests not having iterations.");
+    const auto cli = session.cli() | Opt(serialPortA, "serial-port")["--port-a"]("serial port A, usually BLE central") |
+                     Opt(serialPortB, "serial-port")["--port-b"]("serial port B, usually BLE peripheral") |
+                     Opt(baudRate, "baud-rate")["--baud-rate"]("baud rate") |
+                         Opt(iterations, "count")["--iterations"](
+                             "number of iterations (for tests supporting that)") |
+                     Opt(
+                         [&](const std::string &value) {
+                             if (value.compare("trace"))
+                             {
+                                 logLevel = SD_RPC_LOG_TRACE;
+                             }
+                             else if (value.compare("debug"))
+                             {
+                                 logLevel = SD_RPC_LOG_DEBUG;
+                             }
+                             else if (value.compare("info"))
+                             {
+                                 logLevel = SD_RPC_LOG_INFO;
+                             }
+                             else if (value.compare("warning"))
+                             {
+                                 logLevel = SD_RPC_LOG_WARNING;
+                             }
+                             else if (value.compare("error"))
+                             {
+                                 logLevel = SD_RPC_LOG_ERROR;
+                             }
+                             else if (value.compare("fatal"))
+                             {
+                                 logLevel = SD_RPC_LOG_FATAL;
+                             }
+                         },
+                         "trace|debug|info|warning|error|fatal")["--log-level"]("pc-ble-driver log level");
 
     session.cli(cli);
 
@@ -32,4 +62,11 @@ int main(int argc, char *argv[])
 
     if (exitCode != 0)
         return exitCode;
+
+    test::ConfiguredEnvironment.serialPorts.emplace_back(serialPortA, 0);
+    test::ConfiguredEnvironment.serialPorts.emplace_back(serialPortB, 0);
+    test::ConfiguredEnvironment.numberOfIterations = iterations;
+    test::ConfiguredEnvironment.baudRate           = baudRate;
+
+    return session.run();
 }

--- a/test/util/include/test_setup.h
+++ b/test/util/include/test_setup.h
@@ -75,7 +75,10 @@ struct Environment
     std::vector<SerialPort> serialPorts;
     uint32_t numberOfIterations;
     sd_rpc_log_severity_t driverLogLevel;
+    uint32_t baudRate;
 };
+
+extern Environment ConfiguredEnvironment;
 
 Environment getEnvironment();
 

--- a/test/util/include/test_setup.h
+++ b/test/util/include/test_setup.h
@@ -75,6 +75,7 @@ struct Environment
     std::vector<SerialPort> serialPorts;
     uint32_t numberOfIterations;
     sd_rpc_log_severity_t driverLogLevel;
+    bool driverLogLevelSet;
     uint32_t baudRate;
 };
 

--- a/test/util/include/test_util_conversion.h
+++ b/test/util/include/test_util_conversion.h
@@ -13,8 +13,8 @@ namespace testutil {
  * @param[in] data Data to represent as a string
  * @return string representation of data
  */
- std::string asHex(const std::vector<uint8_t> &data);
- std::string asHex(const uint16_t &data);
+std::string asHex(const std::vector<uint8_t> &data);
+std::string asHex(const uint16_t &data);
 
 /**
  * @brief Function that convert a Bluetooth Low Energy address to string
@@ -22,7 +22,7 @@ namespace testutil {
  * @param[in] address Bluetooth Lower Energy address
  * @return string representation of provided address
  */
- std::string asText(const ble_gap_addr_t &address);
+std::string asText(const ble_gap_addr_t &address);
 
 /**
  * @brief Function that convert an error code to string representation
@@ -31,43 +31,43 @@ namespace testutil {
  *
  * @return textual representation of the error
  */
- std::string errorToString(const uint32_t error_code);
- std::string ioCapsToString(const uint8_t code);
- std::string roleToString(const uint8_t role);
- std::string gattAuthErrorSrcToString(const uint8_t errorSrc);
- std::string gattAuthStatusToString(const uint8_t authStatus);
- std::string hciStatusCodeToString(const uint8_t hciStatusCode);
- std::string asText(const ble_gap_evt_passkey_display_t &passkeyDisplay);
- std::string asText(const ble_gap_enc_info_t &encryptionInfo);
- std::string asText(const ble_gap_conn_params_t &connectionParams);
- std::string asText(const ble_gap_evt_connected_t &connected);
- std::string asText(const ble_gap_evt_disconnected_t &disconnected);
- std::string asText(const ble_gap_evt_scan_req_report_t &scanReqReport);
- std::string asText(const ble_gap_sec_kdist_t &keyDist);
- std::string asText(const ble_gap_evt_sec_request_t &securityRequest);
- std::string asText(const ble_gap_evt_sec_params_request_t &securityParamsRequest);
- std::string asText(const ble_gap_evt_auth_key_request_t &authKeyRequest);
- std::string asText(const ble_gap_conn_sec_mode_t &connSecMode);
- std::string asText(const ble_gap_conn_sec_t &connSec);
- std::string asText(const ble_gap_evt_rssi_changed_t &rssiChanged);
- std::string asText(const ble_gap_lesc_p256_pk_t &lsecP256Pk);
- std::string asText(const ble_gap_evt_key_pressed_t &keyPressed);
- std::string asText(const std::vector<uint8_t> &data);
- std::string asText(const ble_gap_evt_timeout_t &timeout);
+std::string errorToString(const uint32_t error_code);
+std::string ioCapsToString(const uint8_t code);
+std::string roleToString(const uint8_t role);
+std::string gattAuthErrorSrcToString(const uint8_t errorSrc);
+std::string gattAuthStatusToString(const uint8_t authStatus);
+std::string hciStatusCodeToString(const uint8_t hciStatusCode);
+std::string asText(const ble_gap_evt_passkey_display_t &passkeyDisplay);
+std::string asText(const ble_gap_enc_info_t &encryptionInfo);
+std::string asText(const ble_gap_conn_params_t &connectionParams);
+std::string asText(const ble_gap_evt_connected_t &connected);
+std::string asText(const ble_gap_evt_disconnected_t &disconnected);
+std::string asText(const ble_gap_evt_scan_req_report_t &scanReqReport);
+std::string asText(const ble_gap_sec_kdist_t &keyDist);
+std::string asText(const ble_gap_evt_sec_request_t &securityRequest);
+std::string asText(const ble_gap_evt_sec_params_request_t &securityParamsRequest);
+std::string asText(const ble_gap_evt_auth_key_request_t &authKeyRequest);
+std::string asText(const ble_gap_conn_sec_mode_t &connSecMode);
+std::string asText(const ble_gap_conn_sec_t &connSec);
+std::string asText(const ble_gap_evt_rssi_changed_t &rssiChanged);
+std::string asText(const ble_gap_lesc_p256_pk_t &lsecP256Pk);
+std::string asText(const ble_gap_evt_key_pressed_t &keyPressed);
+std::string asText(const std::vector<uint8_t> &data);
+std::string asText(const ble_gap_evt_timeout_t &timeout);
 
 #if NRF_SD_BLE_API == 6
- std::string asText(const ble_gap_adv_report_type_t &reportType);
- std::string asText(const ble_gap_aux_pointer_t &auxPointer);
- std::string asText(const ble_gap_phys_t &phys);
- std::string asText(const ble_gap_evt_phy_update_request_t &phyUpdateRequest);
- std::string asText(const ble_gap_evt_phy_update_t &phyUpdate);
- std::string asText(const ble_gap_data_length_params_t &dataLengthParams);
- std::string asText(const ble_gap_evt_data_length_update_request_t &dataLengthUpdateRequest);
- std::string asText(const ble_gap_evt_data_length_update_t &dataLengthUpdate);
- std::string asText(const ble_gap_evt_qos_channel_survey_report_t &qosChannelSurveyReport);
- std::string asText(const ble_data_t &data);
- std::string asText(const ble_gap_adv_data_t &advData);
- std::string asText(const ble_gap_evt_adv_set_terminated_t &advSetTerminated);
+std::string asText(const ble_gap_adv_report_type_t &reportType);
+std::string asText(const ble_gap_aux_pointer_t &auxPointer);
+std::string asText(const ble_gap_phys_t &phys);
+std::string asText(const ble_gap_evt_phy_update_request_t &phyUpdateRequest);
+std::string asText(const ble_gap_evt_phy_update_t &phyUpdate);
+std::string asText(const ble_gap_data_length_params_t &dataLengthParams);
+std::string asText(const ble_gap_evt_data_length_update_request_t &dataLengthUpdateRequest);
+std::string asText(const ble_gap_evt_data_length_update_t &dataLengthUpdate);
+std::string asText(const ble_gap_evt_qos_channel_survey_report_t &qosChannelSurveyReport);
+std::string asText(const ble_data_t &data);
+std::string asText(const ble_gap_adv_data_t &advData);
+std::string asText(const ble_gap_evt_adv_set_terminated_t &advSetTerminated);
 #endif // NRF_SD_BLE_API == 6
 
 std::string asText(const ble_gap_evt_adv_report_t &advReport);
@@ -96,5 +96,7 @@ std::string asText(const ble_gattc_char_t &gattc_char);
 std::string asText(const ble_gattc_handle_range_t &gattc_handle_range);
 std::string asText(const ble_gattc_desc_t &gattc_desc);
 std::string asText(const sd_rpc_log_severity_t &severity);
+
+sd_rpc_log_severity_t parseLogSeverity(const std::string &level);
 
 } // namespace testutil

--- a/test/util/src/test_setup.cpp
+++ b/test/util/src/test_setup.cpp
@@ -1,15 +1,20 @@
 #include "test_setup.h"
+#include <utility>
+#include <algorithm>
 
 namespace test {
+
+Environment ConfiguredEnvironment;
+
 SerialPort::SerialPort(std::string port, uint32_t baudRate)
-    : port(port)
+    : port(std::move(port))
     , baudRate(baudRate){};
 
 Environment getEnvironment()
 {
     Environment env;
 
-    auto baudRate    = DEFAULT_BAUD_RATE;
+    auto baudRate          = DEFAULT_BAUD_RATE;
     const auto envBaudRate = std::getenv("BLE_DRIVER_TEST_BAUD_RATE");
 
     if (envBaudRate != nullptr)
@@ -17,36 +22,63 @@ Environment getEnvironment()
         baudRate = std::stoi(envBaudRate);
     }
 
-    auto envPortA = std::getenv("BLE_DRIVER_TEST_SERIAL_PORT_A");
-
-    if (envPortA != nullptr)
+    // Command line argument override environment variable
+    if (ConfiguredEnvironment.baudRate != 0)
     {
-        env.serialPorts.push_back(SerialPort(envPortA, baudRate));
+        baudRate = ConfiguredEnvironment.baudRate;
     }
 
-    auto envPortB = std::getenv("BLE_DRIVER_TEST_SERIAL_PORT_B");
-
-    if (envPortB != nullptr)
+    // Command line argument override environment variable
+    if (std::count_if(ConfiguredEnvironment.serialPorts.begin(),
+                      ConfiguredEnvironment.serialPorts.end(),
+                      [](const SerialPort &port) -> bool { return !port.port.empty(); }) >= 2)
     {
-        env.serialPorts.push_back(SerialPort(envPortB, baudRate));
+        for (auto port : ConfiguredEnvironment.serialPorts)
+        {
+            if (!port.port.empty())
+            {
+                env.serialPorts.emplace_back(port.port, baudRate);
+            }
+        }
+    }
+    else
+    {
+        auto envPortA = std::getenv("BLE_DRIVER_TEST_SERIAL_PORT_A");
+
+        if (envPortA != nullptr)
+        {
+            env.serialPorts.emplace_back(envPortA, baudRate);
+        }
+
+        auto envPortB = std::getenv("BLE_DRIVER_TEST_SERIAL_PORT_B");
+
+        if (envPortB != nullptr)
+        {
+            env.serialPorts.emplace_back(envPortB, baudRate);
+        }
     }
 
-    auto numberOfIterations    = 100;
-    auto envNumberOfIterations = std::getenv("BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS");
+    auto numberOfIterations          = 100;
+    const auto envNumberOfIterations = std::getenv("BLE_DRIVER_TEST_OPENCLOSE_ITERATIONS");
 
     if (envNumberOfIterations != nullptr)
     {
         numberOfIterations = std::stoi(envNumberOfIterations);
     }
 
+    if (ConfiguredEnvironment.numberOfIterations != 0)
+    {
+        numberOfIterations = ConfiguredEnvironment.numberOfIterations;
+    }
+
     env.numberOfIterations = numberOfIterations;
 
-    auto driverLogLevel    = SD_RPC_LOG_INFO;
-    auto envDriverLogLevel = std::getenv("BLE_DRIVER_TEST_LOGLEVEL");
+    auto driverLogLevel          = SD_RPC_LOG_INFO;
+    const auto envDriverLogLevel = std::getenv("BLE_DRIVER_TEST_LOGLEVEL");
 
     if (envDriverLogLevel != nullptr)
     {
-        auto envDriverLogLevel_ = std::string(envDriverLogLevel);
+        const auto envDriverLogLevel_ = std::string(envDriverLogLevel);
 
         if (envDriverLogLevel_ == "trace")
         {
@@ -75,6 +107,7 @@ Environment getEnvironment()
     }
 
     env.driverLogLevel = driverLogLevel;
+    env.baudRate       = baudRate;
 
     return env;
 };

--- a/test/util/src/test_setup.cpp
+++ b/test/util/src/test_setup.cpp
@@ -66,6 +66,7 @@ Environment getEnvironment()
         numberOfIterations = std::stoi(envNumberOfIterations);
     }
 
+    // Command line argument override environment variable
     if (ConfiguredEnvironment.numberOfIterations != 0)
     {
         numberOfIterations = ConfiguredEnvironment.numberOfIterations;
@@ -73,41 +74,25 @@ Environment getEnvironment()
 
     env.numberOfIterations = numberOfIterations;
 
-    auto driverLogLevel          = SD_RPC_LOG_INFO;
-    const auto envDriverLogLevel = std::getenv("BLE_DRIVER_TEST_LOGLEVEL");
-
-    if (envDriverLogLevel != nullptr)
+    env.driverLogLevel = SD_RPC_LOG_INFO;
+    
+    // Command line argument override environment variable
+    if (ConfiguredEnvironment.driverLogLevelSet)
     {
-        const auto envDriverLogLevel_ = std::string(envDriverLogLevel);
+        env.driverLogLevel = ConfiguredEnvironment.driverLogLevel;
+    }
+    else
+    {
+        const auto envDriverLogLevel = std::getenv("BLE_DRIVER_TEST_LOGLEVEL");
 
-        if (envDriverLogLevel_ == "trace")
+        if (envDriverLogLevel != nullptr)
         {
-            driverLogLevel = SD_RPC_LOG_TRACE;
-        }
-        else if (envDriverLogLevel_ == "debug")
-        {
-            driverLogLevel = SD_RPC_LOG_DEBUG;
-        }
-        else if (envDriverLogLevel_ == "info")
-        {
-            driverLogLevel = SD_RPC_LOG_INFO;
-        }
-        else if (envDriverLogLevel_ == "warning")
-        {
-            driverLogLevel = SD_RPC_LOG_WARNING;
-        }
-        else if (envDriverLogLevel_ == "error")
-        {
-            driverLogLevel = SD_RPC_LOG_ERROR;
-        }
-        else if (envDriverLogLevel_ == "fatal")
-        {
-            driverLogLevel = SD_RPC_LOG_FATAL;
+            env.driverLogLevel = testutil::parseLogSeverity(envDriverLogLevel);
         }
     }
 
-    env.driverLogLevel = driverLogLevel;
-    env.baudRate       = baudRate;
+    env.driverLogLevelSet = true;
+    env.baudRate          = baudRate;
 
     return env;
 };

--- a/test/util/src/test_util_conversion.cpp
+++ b/test/util/src/test_util_conversion.cpp
@@ -981,4 +981,36 @@ std::string asText(const sd_rpc_log_severity_t &severity)
             break;
     };
 }
+
+sd_rpc_log_severity_t parseLogSeverity(const std::string &level)
+{
+    if (level == "trace")
+    {
+        return SD_RPC_LOG_TRACE;
+    }
+    else if (level == "debug")
+    {
+        return SD_RPC_LOG_DEBUG;
+    }
+    else if (level == "info")
+    {
+        return SD_RPC_LOG_INFO;
+    }
+    else if (level == "warning")
+    {
+        return SD_RPC_LOG_WARNING;
+    }
+    else if (level == "error")
+    {
+        return SD_RPC_LOG_ERROR;
+    }
+    else if (level == "fatal")
+    {
+        return SD_RPC_LOG_FATAL;
+    }
+
+    std::stringstream ss;
+    ss << "Not able to parse '" << level << "' to be sd_rpc_log_severity_t.";
+    throw std::invalid_argument(ss.str());
+}
 } // namespace testutil


### PR DESCRIPTION
Previously environment variables was used to configure the tests

This PR adds command line parsing of arguments to configure the tests. The values that can be configured are:
* serial ports
* baud rate
* number of iterations
* log level 

The environment variables are still used, but have lower priority than command line arguments.
