### PR TITLE
Fix/USB trigger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Where the 'Application chip' is just generic hardware (i.e. a Windows, Linux or 
 
 #### Operating system
 
-* Windows 7, 8 and 10,  32 and 64-bit (tested on Windows 7)
+* Windows 7, 8 and 10, 32 and 64-bit (tested on Windows 7)
 * Ubuntu Linux LTS 64-bit (tested on Ubuntu 18.04)
 * macOS 64-bit (tested on 10.14 Mojave)
 
@@ -62,11 +62,24 @@ To use pc-ble-driver, your Development Kit needs to have the correct firmware. T
 
 The generated libraries are compatible with the following SoftDevice API versions and nRF5x ICs:
 
-* SoftDevice s130 API version 2: `s130_nrf51_2.x.x` (nRF51 and nRF52 series ICs)
-* SoftDevice s132 API version 3: `s132_nrf52_3.x.x` (only for nRF52 series ICs)
-* SoftDevice s132 API version 5: `s132_nrf52_5.x.x` (only for nRF52 series ICs)
-* SoftDevice s132 API version 6: `s132_nrf52_6.x.x` (only for nRF52 series ICs)
-* SoftDevice s140 API version 6: `s140_nrf52_6.x.x` (only for nRF52 series ICs)
+* SoftDevice s130 API version 2: `connectivity_<version>_<115k2|1m>_with_s130_2.x.x` (nRF51 and nRF52 series ICs)
+* SoftDevice s132 API version 3: `connectivity_<version>_<115k2|1m|*usb>_with_s132_3.x.x` (only for nRF52 series ICs)
+* SoftDevice s132 API version 5: `connectivity_<version>_<115k2|1m|*usb>_with_s132_5.x.x` (only for nRF52 series ICs)
+* SoftDevice s132 API version 6: `connectivity_<version>_<115k2|1m|*usb>_with_s132_6.x.x` (only for nRF52 series ICs)
+* SoftDevice s140 API version 6: `connectivity_<version>_<115k2|1m|*usb>_with_s140_6.x.x` (only for nRF52 series ICs)
+
+*usb) only for nRF52 series ICs with USBD peripheral
+
+###### Supported Development Kits
+| PCA      | Official name                | Article number | Notes    |
+-----------|------------------------------|----------------|----------|
+| PCA10028 | nRF51 DEVELOPMENT KIT        | nRF6824        |          |
+| PCA10031 | nRF51 DONGLE                 | nRF6825        |          |
+| PCA10040 | nRF52 DEVELOPMENT KIT        | nRF6827        |          |
+| PCA10056 | nRF52840 { Development Kit } | nRF6828        | *)       |
+| PCA10059 | nRF52840 { Dongle }          | nRF6829        | Can only use connectivity firmware with Nordic USB CDC serial port support  |
+
+*) Can use both Nordic USB CDC serial port version and SEGGER J-Link-OB (VCOM) version. Using Nordic USB CDC serial port version on PCA10056 requires that you connect pins P0.16 and P0.24. The pins to QSPI chip must also be in place (they are by default). The algorithm for detecting if it is PCA10056 or PCA10059 is to check if it is possible to communicate with the QSPI chip. PCA10059 does not have a QSPI chip. The detection is used by nRF Connect DFU trigger to determine what pin to use for resetting the device when changing between DFU and application mode.
 
 ---
 

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_f1f9329/components/boards/pca10056.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_f1cf792/components/boards/pca10056.h
 index 6b3f92f..7fbfbca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/boards/pca10056.h
++++ nRF5_SDK_15.2.0_f1cf792/components/boards/pca10056.h
 @@ -90,6 +90,8 @@ extern "C" {
  #define RTS_PIN_NUMBER 5
  #define HWFC           true
@@ -11,10 +11,10 @@ index 6b3f92f..7fbfbca 100644
  #define BSP_QSPI_SCK_PIN   19
  #define BSP_QSPI_CSN_PIN   17
  #define BSP_QSPI_IO0_PIN   20
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 index 755581d..23b34db 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
++++ nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 @@ -50,10 +50,6 @@
  #include "nrf_log.h"
  NRF_LOG_MODULE_REGISTER();
@@ -62,10 +62,10 @@ index 755581d..23b34db 100644
      m_dfu_info.wAddress       = CODE_START;
      m_dfu_info.wFirmwareSize  = CODE_SIZE;
      m_dfu_info.wVersionMajor  = APP_VERSION_MAJOR;
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 index 5906a80..8befbe9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
++++ nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 @@ -63,11 +63,12 @@
   *
   * @note  If @ref APP_USBD_CONFIG_EVENT_QUEUE_ENABLE is on (1), USB events must be handled manually.
@@ -80,10 +80,10 @@ index 5906a80..8befbe9 100644
  
  /** @} */
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_f1f9329/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_f1cf792/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_f1cf792/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -93,10 +93,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -123,10 +123,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -219,10 +219,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -372,10 +372,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -447,10 +447,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -467,10 +467,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -534,10 +534,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -550,10 +550,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -576,10 +576,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -610,10 +610,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -657,10 +657,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -713,10 +713,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -764,10 +764,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -800,10 +800,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -813,10 +813,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -832,10 +832,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1131,10 +1131,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1144,10 +1144,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1232,10 +1232,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1347,10 +1347,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1369,10 +1369,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1421,10 +1421,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1442,10 +1442,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1475,10 +1475,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1497,10 +1497,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1548,10 +1548,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1636,10 +1636,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1671,10 +1671,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1692,10 +1692,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1706,10 +1706,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1746,10 +1746,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1782,10 +1782,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1805,10 +1805,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1821,10 +1821,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1921,10 +1921,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1945,10 +1945,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1975,10 +1975,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -2055,10 +2055,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2085,11 +2085,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2772,11 +2772,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2868,11 +2868,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4791,11 +4791,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5017,11 +5017,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5683,11 +5683,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6467,11 +6467,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6604,11 +6604,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6812,11 +6812,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6956,11 +6956,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7175,11 +7175,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7398,11 +7398,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7491,11 +7491,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7564,11 +7564,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7652,11 +7652,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8143,11 +8143,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8177,11 +8177,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8514,11 +8514,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9426,11 +9426,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9520,11 +9520,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11445,11 +11445,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12125,11 +12125,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12677,20 +12677,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20386,11 +20386,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20425,11 +20425,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20467,11 +20467,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21101,11 +21101,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21198,11 +21198,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23393,11 +23393,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23627,11 +23627,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24340,11 +24340,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25187,11 +25187,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25328,11 +25328,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25841,11 +25841,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26003,11 +26003,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26224,11 +26224,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26471,11 +26471,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26567,11 +26567,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26643,11 +26643,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26734,11 +26734,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27226,11 +27226,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27260,11 +27260,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27623,11 +27623,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28563,11 +28563,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28659,20 +28659,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36517,11 +36517,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36556,11 +36556,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36598,10 +36598,10 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/main.c
-index fc7996c..a833d6a 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/main.c
+index fc7996c..898d30e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/main.c
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/main.c
 @@ -57,23 +57,34 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
@@ -36724,7 +36724,7 @@ index fc7996c..a833d6a 100644
      while (app_usbd_event_queue_process())
      {
          /* Nothing to do */
-@@ -155,18 +215,48 @@ static void on_idle(void)
+@@ -155,18 +215,62 @@ static void on_idle(void)
  #endif
  }
  
@@ -36733,7 +36733,14 @@ index fc7996c..a833d6a 100644
 +  return DWT->CYCCNT;
 +}
 +
-+     
++void pin_to_default(uint8_t pin)
++{
++    if (pin != NRF_QSPI_PIN_NOT_CONNECTED)
++    {
++        nrf_gpio_cfg_default(pin);
++    }
++}
++
  /**@brief Main function of the connectivity application. */
  int main(void)
  {
@@ -36768,14 +36775,21 @@ index fc7996c..a833d6a 100644
 +    }
 +    else if (err_code == NRF_ERROR_TIMEOUT)
 +    {
-+        pin_reset = PCA10059_PIN_RESET;
 +        //pca10059 assumed when no qspi memory
++        nrf_drv_qspi_uninit();
++        pin_reset = PCA10059_PIN_RESET;
++        pin_to_default(config.pins.csn_pin);
++        pin_to_default(config.pins.io0_pin);
++        pin_to_default(config.pins.io1_pin);
++        pin_to_default(config.pins.io2_pin);
++        pin_to_default(config.pins.io3_pin);
++        pin_to_default(config.pins.sck_pin);
 +    }
 +#endif //BOARD_DETECTION
  
  #if (defined(SER_PHY_HCI_DEBUG_ENABLE) || defined(SER_PHY_DEBUG_APP_ENABLE))
      debug_init(NULL);
-@@ -192,6 +282,8 @@ int main(void)
+@@ -192,6 +296,8 @@ int main(void)
      }
  
      nrf_drv_clock_hfclk_request(NULL);
@@ -36784,7 +36798,7 @@ index fc7996c..a833d6a 100644
      while (!nrf_drv_clock_hfclk_is_running())
      {}
  
-@@ -199,6 +291,10 @@ int main(void)
+@@ -199,6 +305,10 @@ int main(void)
      usbd_init();
  #endif
  
@@ -36795,7 +36809,7 @@ index fc7996c..a833d6a 100644
      /* Open serialization HAL Transport layer and subscribe for HAL Transport events. */
      err_code = ser_hal_transport_open(ser_conn_hal_transport_event_handle);
      APP_ERROR_CHECK(err_code);
-@@ -210,12 +306,14 @@ int main(void)
+@@ -210,12 +320,14 @@ int main(void)
      err_code = nrf_sdh_enable_request();
      APP_ERROR_CHECK(err_code);
  
@@ -36811,7 +36825,7 @@ index fc7996c..a833d6a 100644
          /* Process SoftDevice events. */
          app_sched_execute();
          if (nrf_sdh_is_suspended())
-@@ -235,6 +333,7 @@ int main(void)
+@@ -235,6 +347,7 @@ int main(void)
          APP_ERROR_CHECK(err_code);
  
          on_idle();
@@ -36819,10 +36833,10 @@ index fc7996c..a833d6a 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index 611a3b6..0a1645f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36843,10 +36857,10 @@ index 611a3b6..0a1645f 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..19a16d1 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -37117,10 +37131,10 @@ index c5caa64..19a16d1 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37132,10 +37146,10 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37144,10 +37158,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37168,10 +37182,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37442,10 +37456,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37457,10 +37471,10 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37469,10 +37483,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37493,10 +37507,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37767,10 +37781,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37782,10 +37796,10 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37794,10 +37808,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37818,10 +37832,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..cad5969 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -38092,10 +38106,10 @@ index 17cad13..cad5969 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -38107,10 +38121,10 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -38119,11 +38133,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -38387,11 +38401,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..7110f07
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -38499,11 +38513,11 @@ index 0000000..7110f07
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..19a16d1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4558 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -43063,11 +43077,11 @@ index 0000000..19a16d1
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -43223,11 +43237,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -43237,11 +43251,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -43292,11 +43306,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -43561,11 +43575,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..9e0c093
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -43673,11 +43687,11 @@ index 0000000..9e0c093
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..ffe8c67
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4579 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -48258,11 +48272,11 @@ index 0000000..ffe8c67
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -48419,11 +48433,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -48433,11 +48447,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -48488,10 +48502,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index e8a3735..7b95e77 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48510,10 +48524,10 @@ index e8a3735..7b95e77 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..3119381 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -48784,10 +48798,10 @@ index 6539e77..3119381 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48797,10 +48811,10 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48809,10 +48823,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48831,10 +48845,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49105,10 +49119,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49118,10 +49132,10 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49130,10 +49144,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49152,10 +49166,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49426,10 +49440,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49439,10 +49453,10 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49451,10 +49465,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49473,10 +49487,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..f0c345a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -49747,10 +49761,10 @@ index 7b74df4..f0c345a 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49760,10 +49774,10 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49772,11 +49786,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..29138b1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -50060,11 +50074,11 @@ index 0000000..29138b1
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -50172,11 +50186,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..14a8586
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -55401,11 +55415,11 @@ index 0000000..14a8586
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..bd45579
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
@@ -55576,11 +55590,11 @@ index 0000000..bd45579
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -55590,11 +55604,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -55645,11 +55659,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..8d850ae
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 @@ -0,0 +1,283 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -55934,11 +55948,11 @@ index 0000000..8d850ae
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..1a80caf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -56046,11 +56060,11 @@ index 0000000..1a80caf
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..f0b6542
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5244 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -61296,11 +61310,11 @@ index 0000000..f0b6542
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..d93607c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 @@ -0,0 +1,170 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
@@ -61472,11 +61486,11 @@ index 0000000..d93607c
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -61486,11 +61500,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -61541,10 +61555,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 index 87059cc..0d8cc08 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 @@ -85,6 +85,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -61553,10 +61567,10 @@ index 87059cc..0d8cc08 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -61575,10 +61589,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 index 793e569..d43945e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -61999,10 +62013,10 @@ index 793e569..d43945e 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..0221ede 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62020,10 +62034,10 @@ index f64c3a0..0221ede 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62032,10 +62046,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 index f5648fe..98f1192 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62044,10 +62058,10 @@ index f5648fe..98f1192 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62066,10 +62080,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62490,10 +62504,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..430528f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62511,10 +62525,10 @@ index a71ed2f..430528f 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62523,10 +62537,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 index e498e6c..1147b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62535,10 +62549,10 @@ index e498e6c..1147b6f 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62557,10 +62571,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62981,10 +62995,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..44ff831 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63002,10 +63016,10 @@ index a95d1a5..44ff831 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63014,10 +63028,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 index aad2de3..d3b8468 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 @@ -81,6 +81,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -63026,10 +63040,10 @@ index aad2de3..d3b8468 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63048,10 +63062,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 index 36b0fe4..bc8c8d0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -63472,10 +63486,10 @@ index 36b0fe4..bc8c8d0 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..29b2865 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63493,10 +63507,10 @@ index 228cf40..29b2865 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63505,10 +63519,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 index 07cf7c6..b4c2628 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -25,6 +25,7 @@ SRC_FILES += \
    $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
    $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
@@ -63577,10 +63591,10 @@ index 07cf7c6..b4c2628 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63599,10 +63613,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 index 994863b..14a8586 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -46,6 +46,102 @@
  #ifdef USE_APP_CONFIG
  #include "app_config.h"
@@ -64149,10 +64163,10 @@ index 994863b..14a8586 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 index 571ebbb..6be7f69 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -15,8 +15,8 @@
        arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
        arm_target_device_name="nRF52840_xxAA"
@@ -64197,10 +64211,10 @@ index 571ebbb..6be7f69 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -64209,11 +64223,11 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..b704d10
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -64497,11 +64511,11 @@ index 0000000..b704d10
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -64609,11 +64623,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..c244199
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -69838,11 +69852,11 @@ index 0000000..c244199
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..735cba9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -70013,11 +70027,11 @@ index 0000000..735cba9
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -70027,11 +70041,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -70082,10 +70096,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..b4bde15 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -96,6 +96,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -70110,10 +70124,10 @@ index 33053bc..b4bde15 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -70132,10 +70146,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 index bb385de..c244199 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -133,7 +133,7 @@
  // <i> gaps. Tailor this value to adhere to this limitation.
  
@@ -70574,10 +70588,10 @@ index bb385de..c244199 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..e6a0b2c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -70604,10 +70618,10 @@ index c7771fd..e6a0b2c 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -70616,10 +70630,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_f1f9329/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_f1cf792/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_f1f9329/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_f1cf792/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -70694,11 +70708,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_f1f9329/examples/readme.txt nRF5_SDK_15.2.0_f1f9329/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_f1cf792/examples/readme.txt nRF5_SDK_15.2.0_f1cf792/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1f9329/examples/readme.txt
++++ nRF5_SDK_15.2.0_f1cf792/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -70714,10 +70728,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_f1f9329/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_f1cf792/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_f1f9329/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_f1cf792/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif
@@ -70787,3 +70801,9 @@ index bba3d13..139d375 100644
      if (nrfx_power_usb_handler_get() != NULL)
      {
          ret_code_t err_code = nrf_drv_power_sd_usbevt_enable(true);
+diff --git nRF5_SDK_15.2.0_f1cf792/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_f1cf92.patch nRF5_SDK_15.2.0_f1cf792/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_f1cf92.patch
+new file mode 100644
+index 0000000..e69de29
+diff --git nRF5_SDK_15.2.0_f1cf792/patch-summary.txt nRF5_SDK_15.2.0_f1cf792/patch-summary.txt
+new file mode 100644
+index 0000000..e69de29

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_f1cf792/components/boards/pca10056.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_80108de/components/boards/pca10056.h
 index 6b3f92f..7fbfbca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/boards/pca10056.h
++++ nRF5_SDK_15.2.0_80108de/components/boards/pca10056.h
 @@ -90,6 +90,8 @@ extern "C" {
  #define RTS_PIN_NUMBER 5
  #define HWFC           true
@@ -11,10 +11,10 @@ index 6b3f92f..7fbfbca 100644
  #define BSP_QSPI_SCK_PIN   19
  #define BSP_QSPI_CSN_PIN   17
  #define BSP_QSPI_IO0_PIN   20
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_80108de/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 index 755581d..23b34db 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
++++ nRF5_SDK_15.2.0_80108de/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 @@ -50,10 +50,6 @@
  #include "nrf_log.h"
  NRF_LOG_MODULE_REGISTER();
@@ -62,10 +62,10 @@ index 755581d..23b34db 100644
      m_dfu_info.wAddress       = CODE_START;
      m_dfu_info.wFirmwareSize  = CODE_SIZE;
      m_dfu_info.wVersionMajor  = APP_VERSION_MAJOR;
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_80108de/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 index 5906a80..8befbe9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
++++ nRF5_SDK_15.2.0_80108de/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 @@ -63,11 +63,12 @@
   *
   * @note  If @ref APP_USBD_CONFIG_EVENT_QUEUE_ENABLE is on (1), USB events must be handled manually.
@@ -80,10 +80,10 @@ index 5906a80..8befbe9 100644
  
  /** @} */
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_f1cf792/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_80108de/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_80108de/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -93,10 +93,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -123,10 +123,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -219,10 +219,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -372,10 +372,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -447,10 +447,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -467,10 +467,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -534,10 +534,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -550,10 +550,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_80108de/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -576,10 +576,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_80108de/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -610,10 +610,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_80108de/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -657,10 +657,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_80108de/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -713,10 +713,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_80108de/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -764,10 +764,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -800,10 +800,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -813,10 +813,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -832,10 +832,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1131,10 +1131,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1144,10 +1144,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1232,10 +1232,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1347,10 +1347,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1369,10 +1369,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1421,10 +1421,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1442,10 +1442,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1475,10 +1475,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1497,10 +1497,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1548,10 +1548,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1636,10 +1636,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1671,10 +1671,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1692,10 +1692,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1706,10 +1706,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1746,10 +1746,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1782,10 +1782,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1805,10 +1805,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1821,10 +1821,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1921,10 +1921,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_80108de/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1945,10 +1945,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_80108de/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1975,10 +1975,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_80108de/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -2055,10 +2055,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_80108de/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2085,11 +2085,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2772,11 +2772,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2868,11 +2868,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4791,11 +4791,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5017,11 +5017,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5683,11 +5683,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6467,11 +6467,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6604,11 +6604,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6812,11 +6812,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6956,11 +6956,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7175,11 +7175,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7398,11 +7398,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7491,11 +7491,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7564,11 +7564,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7652,11 +7652,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8143,11 +8143,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8177,11 +8177,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8514,11 +8514,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9426,11 +9426,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9520,11 +9520,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11445,11 +11445,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12125,11 +12125,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12677,20 +12677,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20386,11 +20386,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20425,11 +20425,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20467,11 +20467,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21101,11 +21101,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21198,11 +21198,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23393,11 +23393,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23627,11 +23627,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24340,11 +24340,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25187,11 +25187,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25328,11 +25328,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25841,11 +25841,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26003,11 +26003,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26224,11 +26224,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26471,11 +26471,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26567,11 +26567,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26643,11 +26643,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26734,11 +26734,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27226,11 +27226,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27260,11 +27260,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27623,11 +27623,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28563,11 +28563,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28659,20 +28659,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36517,11 +36517,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36556,11 +36556,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_80108de/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36598,10 +36598,10 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/main.c
-index fc7996c..898d30e 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/main.c
+index fc7996c..24df30a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/main.c
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/main.c
 @@ -57,23 +57,34 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
@@ -36724,7 +36724,7 @@ index fc7996c..898d30e 100644
      while (app_usbd_event_queue_process())
      {
          /* Nothing to do */
-@@ -155,18 +215,62 @@ static void on_idle(void)
+@@ -155,18 +215,64 @@ static void on_idle(void)
  #endif
  }
  
@@ -36733,6 +36733,7 @@ index fc7996c..898d30e 100644
 +  return DWT->CYCCNT;
 +}
 +
++#if BOARD_DETECTION
 +void pin_to_default(uint8_t pin)
 +{
 +    if (pin != NRF_QSPI_PIN_NOT_CONNECTED)
@@ -36740,6 +36741,7 @@ index fc7996c..898d30e 100644
 +        nrf_gpio_cfg_default(pin);
 +    }
 +}
++#endif
 +
  /**@brief Main function of the connectivity application. */
  int main(void)
@@ -36789,7 +36791,7 @@ index fc7996c..898d30e 100644
  
  #if (defined(SER_PHY_HCI_DEBUG_ENABLE) || defined(SER_PHY_DEBUG_APP_ENABLE))
      debug_init(NULL);
-@@ -192,6 +296,8 @@ int main(void)
+@@ -192,6 +298,8 @@ int main(void)
      }
  
      nrf_drv_clock_hfclk_request(NULL);
@@ -36798,7 +36800,7 @@ index fc7996c..898d30e 100644
      while (!nrf_drv_clock_hfclk_is_running())
      {}
  
-@@ -199,6 +305,10 @@ int main(void)
+@@ -199,6 +307,10 @@ int main(void)
      usbd_init();
  #endif
  
@@ -36809,7 +36811,7 @@ index fc7996c..898d30e 100644
      /* Open serialization HAL Transport layer and subscribe for HAL Transport events. */
      err_code = ser_hal_transport_open(ser_conn_hal_transport_event_handle);
      APP_ERROR_CHECK(err_code);
-@@ -210,12 +320,14 @@ int main(void)
+@@ -210,12 +322,14 @@ int main(void)
      err_code = nrf_sdh_enable_request();
      APP_ERROR_CHECK(err_code);
  
@@ -36825,7 +36827,7 @@ index fc7996c..898d30e 100644
          /* Process SoftDevice events. */
          app_sched_execute();
          if (nrf_sdh_is_suspended())
-@@ -235,6 +347,7 @@ int main(void)
+@@ -235,6 +349,7 @@ int main(void)
          APP_ERROR_CHECK(err_code);
  
          on_idle();
@@ -36833,10 +36835,10 @@ index fc7996c..898d30e 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index 611a3b6..0a1645f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index 611a3b6..1584391 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36857,10 +36859,36 @@ index 611a3b6..0a1645f 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+@@ -69,6 +76,12 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -81,12 +94,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..19a16d1 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -37131,10 +37159,10 @@ index c5caa64..19a16d1 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37146,10 +37174,21 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+index 6b7653b..c9cc513 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37158,10 +37197,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..57c5fcf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..5b7dc28 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37182,10 +37221,36 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37456,10 +37521,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37471,10 +37536,21 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37483,10 +37559,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..57c5fcf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..5b7dc28 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37507,10 +37583,36 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37781,10 +37883,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37796,10 +37898,21 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37808,10 +37921,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..57c5fcf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..5b7dc28 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37832,10 +37945,36 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..cad5969 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -38106,10 +38245,10 @@ index 17cad13..cad5969 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -38121,10 +38260,21 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -38133,11 +38283,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -38401,11 +38551,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..7110f07
+index 0000000..12b76c1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -38485,6 +38635,12 @@ index 0000000..7110f07
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
 +  .sdh_stack_observers :
 +  {
 +    PROVIDE(__start_sdh_stack_observers = .);
@@ -38497,12 +38653,6 @@ index 0000000..7110f07
 +    KEEP(*(SORT(.sdh_req_observers*)))
 +    PROVIDE(__stop_sdh_req_observers = .);
 +  } > FLASH
-+  .sdh_state_observers :
-+  {
-+    PROVIDE(__start_sdh_state_observers = .);
-+    KEEP(*(SORT(.sdh_state_observers*)))
-+    PROVIDE(__stop_sdh_state_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -38513,11 +38663,11 @@ index 0000000..7110f07
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..19a16d1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4558 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -43077,11 +43227,11 @@ index 0000000..19a16d1
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -43237,11 +43387,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -43251,11 +43401,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..c9cc513
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -43270,9 +43420,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -43306,11 +43456,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -43575,11 +43725,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..9e0c093
+index 0000000..9877300
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -43659,6 +43809,12 @@ index 0000000..9e0c093
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
 +  .sdh_stack_observers :
 +  {
 +    PROVIDE(__start_sdh_stack_observers = .);
@@ -43671,12 +43827,6 @@ index 0000000..9e0c093
 +    KEEP(*(SORT(.sdh_req_observers*)))
 +    PROVIDE(__stop_sdh_req_observers = .);
 +  } > FLASH
-+  .sdh_state_observers :
-+  {
-+    PROVIDE(__start_sdh_state_observers = .);
-+    KEEP(*(SORT(.sdh_state_observers*)))
-+    PROVIDE(__stop_sdh_state_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -43687,11 +43837,11 @@ index 0000000..9e0c093
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..ffe8c67
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4579 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -48272,11 +48422,11 @@ index 0000000..ffe8c67
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -48433,11 +48583,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -48447,11 +48597,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..c9cc513
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -48466,9 +48616,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -48502,10 +48652,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index e8a3735..7b95e77 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index e8a3735..7161fc8 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48524,10 +48674,36 @@ index e8a3735..7b95e77 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+@@ -69,6 +76,12 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -81,12 +94,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..3119381 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -48798,10 +48974,10 @@ index 6539e77..3119381 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48811,10 +48987,21 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+index 6b7653b..c9cc513 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48823,10 +49010,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..6b8f0fb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..ce61515 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48845,10 +49032,36 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49119,10 +49332,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49132,10 +49345,21 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49144,10 +49368,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..6b8f0fb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..ce61515 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49166,10 +49390,36 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49440,10 +49690,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49453,10 +49703,21 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49465,10 +49726,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..6b8f0fb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..ce61515 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49487,10 +49748,36 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..f0c345a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -49761,10 +50048,10 @@ index 7b74df4..f0c345a 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49774,10 +50061,21 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49786,11 +50084,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..29138b1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -50074,11 +50372,11 @@ index 0000000..29138b1
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..a7a64cd
+index 0000000..0267096
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -50158,6 +50456,12 @@ index 0000000..a7a64cd
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
 +  .sdh_stack_observers :
 +  {
 +    PROVIDE(__start_sdh_stack_observers = .);
@@ -50170,12 +50474,6 @@ index 0000000..a7a64cd
 +    KEEP(*(SORT(.sdh_req_observers*)))
 +    PROVIDE(__stop_sdh_req_observers = .);
 +  } > FLASH
-+  .sdh_state_observers :
-+  {
-+    PROVIDE(__start_sdh_state_observers = .);
-+    KEEP(*(SORT(.sdh_state_observers*)))
-+    PROVIDE(__stop_sdh_state_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -50186,11 +50484,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..14a8586
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -55415,11 +55713,11 @@ index 0000000..14a8586
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..bd45579
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
@@ -55590,11 +55888,11 @@ index 0000000..bd45579
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -55604,11 +55902,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..c9cc513
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -55623,9 +55921,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -55659,11 +55957,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..8d850ae
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 @@ -0,0 +1,283 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -55948,11 +56246,11 @@ index 0000000..8d850ae
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..1a80caf
+index 0000000..211f001
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -56032,6 +56330,12 @@ index 0000000..1a80caf
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
 +  .sdh_stack_observers :
 +  {
 +    PROVIDE(__start_sdh_stack_observers = .);
@@ -56044,12 +56348,6 @@ index 0000000..1a80caf
 +    KEEP(*(SORT(.sdh_req_observers*)))
 +    PROVIDE(__stop_sdh_req_observers = .);
 +  } > FLASH
-+  .sdh_state_observers :
-+  {
-+    PROVIDE(__start_sdh_state_observers = .);
-+    KEEP(*(SORT(.sdh_state_observers*)))
-+    PROVIDE(__stop_sdh_state_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -56060,11 +56358,11 @@ index 0000000..1a80caf
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..f0b6542
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5244 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -61310,11 +61608,11 @@ index 0000000..f0b6542
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..d93607c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 @@ -0,0 +1,170 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
@@ -61486,11 +61784,11 @@ index 0000000..d93607c
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -61500,11 +61798,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..c9cc513
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -61519,9 +61817,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -61555,10 +61853,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 index 87059cc..0d8cc08 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 @@ -85,6 +85,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -61567,10 +61865,10 @@ index 87059cc..0d8cc08 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..150d772 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..f354cbc 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -61589,10 +61887,36 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+@@ -69,6 +76,12 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -81,12 +94,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 index 793e569..d43945e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -62013,10 +62337,10 @@ index 793e569..d43945e 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..0221ede 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62034,10 +62358,21 @@ index f64c3a0..0221ede 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+index 6b7653b..c9cc513 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62046,10 +62381,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 index f5648fe..98f1192 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62058,10 +62393,10 @@ index f5648fe..98f1192 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..0b2a7eb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..a5e33ee 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62080,10 +62415,36 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62504,10 +62865,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..430528f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62525,10 +62886,21 @@ index a71ed2f..430528f 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62537,10 +62909,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 index e498e6c..1147b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62549,10 +62921,10 @@ index e498e6c..1147b6f 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..0b2a7eb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..a5e33ee 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62571,10 +62943,36 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62995,10 +63393,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..44ff831 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63016,10 +63414,21 @@ index a95d1a5..44ff831 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63028,10 +63437,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 index aad2de3..d3b8468 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 @@ -81,6 +81,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -63040,10 +63449,10 @@ index aad2de3..d3b8468 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..0b2a7eb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..a5e33ee 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63062,10 +63471,36 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+@@ -63,6 +70,12 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -75,12 +88,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 index 36b0fe4..bc8c8d0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -63486,10 +63921,10 @@ index 36b0fe4..bc8c8d0 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..29b2865 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63507,10 +63942,21 @@ index 228cf40..29b2865 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+index a801e6e..0708731 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63519,10 +63965,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 index 07cf7c6..b4c2628 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -25,6 +25,7 @@ SRC_FILES += \
    $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
    $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
@@ -63591,10 +64037,10 @@ index 07cf7c6..b4c2628 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..150d772 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..f354cbc 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63613,10 +64059,36 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+@@ -69,6 +76,12 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -81,12 +94,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 index 994863b..14a8586 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -46,6 +46,102 @@
  #ifdef USE_APP_CONFIG
  #include "app_config.h"
@@ -64163,10 +64635,10 @@ index 994863b..14a8586 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 index 571ebbb..6be7f69 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -15,8 +15,8 @@
        arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
        arm_target_device_name="nRF52840_xxAA"
@@ -64211,10 +64683,21 @@ index 571ebbb..6be7f69 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..c9cc513 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -64223,11 +64706,11 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..b704d10
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -64511,11 +64994,11 @@ index 0000000..b704d10
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..a7a64cd
+index 0000000..0267096
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -64595,6 +65078,12 @@ index 0000000..a7a64cd
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
 +  .sdh_stack_observers :
 +  {
 +    PROVIDE(__start_sdh_stack_observers = .);
@@ -64607,12 +65096,6 @@ index 0000000..a7a64cd
 +    KEEP(*(SORT(.sdh_req_observers*)))
 +    PROVIDE(__stop_sdh_req_observers = .);
 +  } > FLASH
-+  .sdh_state_observers :
-+  {
-+    PROVIDE(__start_sdh_state_observers = .);
-+    KEEP(*(SORT(.sdh_state_observers*)))
-+    PROVIDE(__stop_sdh_state_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -64623,11 +65106,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..c244199
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -69852,11 +70335,11 @@ index 0000000..c244199
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..735cba9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -70027,11 +70510,11 @@ index 0000000..735cba9
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -70041,11 +70524,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..c9cc513
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -70060,9 +70543,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -70096,10 +70579,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..b4bde15 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -96,6 +96,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -70124,10 +70607,10 @@ index 33053bc..b4bde15 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..150d772 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..f354cbc 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -70146,10 +70629,36 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+@@ -69,6 +76,12 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
++  .sdh_state_observers :
++  {
++    PROVIDE(__start_sdh_state_observers = .);
++    KEEP(*(SORT(.sdh_state_observers*)))
++    PROVIDE(__stop_sdh_state_observers = .);
++  } > FLASH
+   .sdh_stack_observers :
+   {
+     PROVIDE(__start_sdh_stack_observers = .);
+@@ -81,12 +94,6 @@ SECTIONS
+     KEEP(*(SORT(.sdh_req_observers*)))
+     PROVIDE(__stop_sdh_req_observers = .);
+   } > FLASH
+-  .sdh_state_observers :
+-  {
+-    PROVIDE(__start_sdh_state_observers = .);
+-    KEEP(*(SORT(.sdh_state_observers*)))
+-    PROVIDE(__stop_sdh_state_observers = .);
+-  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 index bb385de..c244199 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -133,7 +133,7 @@
  // <i> gaps. Tailor this value to adhere to this limitation.
  
@@ -70588,10 +71097,10 @@ index bb385de..c244199 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..e6a0b2c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -70618,10 +71127,21 @@ index c7771fd..e6a0b2c 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..c9cc513 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_f1cf792/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_80108de/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -70630,10 +71150,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_f1cf792/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_80108de/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_f1cf792/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_80108de/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -70708,11 +71228,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_f1cf792/examples/readme.txt nRF5_SDK_15.2.0_f1cf792/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_80108de/examples/readme.txt nRF5_SDK_15.2.0_80108de/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_f1cf792/examples/readme.txt
++++ nRF5_SDK_15.2.0_80108de/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -70728,10 +71248,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_f1cf792/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_80108de/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_f1cf792/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_80108de/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif
@@ -70801,9 +71321,3 @@ index bba3d13..139d375 100644
      if (nrfx_power_usb_handler_get() != NULL)
      {
          ret_code_t err_code = nrf_drv_power_sd_usbevt_enable(true);
-diff --git nRF5_SDK_15.2.0_f1cf792/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_f1cf92.patch nRF5_SDK_15.2.0_f1cf792/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_f1cf92.patch
-new file mode 100644
-index 0000000..e69de29
-diff --git nRF5_SDK_15.2.0_f1cf792/patch-summary.txt nRF5_SDK_15.2.0_f1cf792/patch-summary.txt
-new file mode 100644
-index 0000000..e69de29

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_a184e1b/components/boards/pca10056.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_e18d5d2/components/boards/pca10056.h
 index 6b3f92f..7fbfbca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/boards/pca10056.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/boards/pca10056.h
 @@ -90,6 +90,8 @@ extern "C" {
  #define RTS_PIN_NUMBER 5
  #define HWFC           true
@@ -11,10 +11,79 @@ index 6b3f92f..7fbfbca 100644
  #define BSP_QSPI_SCK_PIN   19
  #define BSP_QSPI_CSN_PIN   17
  #define BSP_QSPI_IO0_PIN   20
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_a184e1b/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
+index 755581d..23b34db 100644
+--- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
+@@ -50,10 +50,6 @@
+ #include "nrf_log.h"
+ NRF_LOG_MODULE_REGISTER();
+ 
+-#ifndef BSP_SELF_PINRESET_PIN
+-#error "This module is intended to be used with boards that have the GP pin shortened with the RESET pin."
+-#endif
+-
+ /**
+  * @brief Enable power USB detection.
+  *
+@@ -71,6 +67,7 @@ NRF_LOG_MODULE_REGISTER();
+ 
+ static uint8_t                                m_version_string[] = APP_NAME " " VERSION_STRING; ///< Human-readable version string.
+ static app_usbd_nrf_dfu_trigger_nordic_info_t m_dfu_info;                                       ///< Struct with various information about the current firmware.
++static uint32_t m_pin_reset;
+ 
+ static void dfu_trigger_evt_handler(app_usbd_class_inst_t        const *  p_inst,
+                                     app_usbd_nrf_dfu_trigger_user_event_t event)
+@@ -82,8 +79,8 @@ static void dfu_trigger_evt_handler(app_usbd_class_inst_t        const *  p_inst
+         case APP_USBD_NRF_DFU_TRIGGER_USER_EVT_DETACH:
+             NRF_LOG_INFO("DFU Detach request received. Triggering a pin reset.");
+             NRF_LOG_FINAL_FLUSH();
+-            nrf_gpio_cfg_output(BSP_SELF_PINRESET_PIN);
+-            nrf_gpio_pin_clear(BSP_SELF_PINRESET_PIN);
++            nrf_gpio_cfg_output(m_pin_reset);
++            nrf_gpio_pin_clear(m_pin_reset);
+             break;
+         default:
+             break;
+@@ -173,7 +170,7 @@ static void usbd_evt_handler(app_usbd_internal_evt_t const * const p_event)
+ }
+ #endif
+ 
+-ret_code_t nrf_dfu_trigger_usb_init(void)
++ret_code_t nrf_dfu_trigger_usb_init(uint32_t pin_reset)
+ {
+     ret_code_t  ret;
+     static bool initialized = false;
+@@ -183,6 +180,7 @@ ret_code_t nrf_dfu_trigger_usb_init(void)
+         return NRF_SUCCESS;
+     }
+ 
++    m_pin_reset               = pin_reset;
+     m_dfu_info.wAddress       = CODE_START;
+     m_dfu_info.wFirmwareSize  = CODE_SIZE;
+     m_dfu_info.wVersionMajor  = APP_VERSION_MAJOR;
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+index 5906a80..8befbe9 100644
+--- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+@@ -63,11 +63,12 @@
+  *
+  * @note  If @ref APP_USBD_CONFIG_EVENT_QUEUE_ENABLE is on (1), USB events must be handled manually.
+  *        See @ref app_usbd_event_queue_process.
++ * @param pin_reset Pin which is shortened with the actual pin reset.
+  *
+  * @retval NRF_SUCCESS  On successful initialization.
+  * @return An error code on failure, for example if called at a wrong time.
+  */
+-ret_code_t nrf_dfu_trigger_usb_init(void);
++ret_code_t nrf_dfu_trigger_usb_init(uint32_t pin_reset);
+ 
+ /** @} */
+ 
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_e18d5d2/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -24,10 +93,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -54,10 +123,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -150,10 +219,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -303,10 +372,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -378,10 +447,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -398,10 +467,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -465,10 +534,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -481,10 +550,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -507,10 +576,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -541,10 +610,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -588,10 +657,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -644,10 +713,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -695,10 +764,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -731,10 +800,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -744,10 +813,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -763,10 +832,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1062,10 +1131,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1075,10 +1144,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1163,10 +1232,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1278,10 +1347,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1300,10 +1369,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1352,10 +1421,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1373,10 +1442,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1406,10 +1475,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1428,10 +1497,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1479,10 +1548,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1567,10 +1636,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1602,10 +1671,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1623,10 +1692,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1637,10 +1706,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1677,10 +1746,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1713,10 +1782,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1736,10 +1805,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1752,10 +1821,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1852,10 +1921,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1876,10 +1945,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1906,10 +1975,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -1986,10 +2055,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2016,11 +2085,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2703,11 +2772,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2799,11 +2868,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4722,11 +4791,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4948,11 +5017,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5614,11 +5683,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6398,11 +6467,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6535,11 +6604,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6743,11 +6812,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6887,11 +6956,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7106,11 +7175,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7329,11 +7398,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7422,11 +7491,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7495,11 +7564,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7583,11 +7652,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8074,11 +8143,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8108,11 +8177,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8445,11 +8514,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9357,11 +9426,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9451,11 +9520,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11376,11 +11445,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12056,11 +12125,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12608,20 +12677,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20317,11 +20386,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20356,11 +20425,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20398,11 +20467,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21032,11 +21101,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21129,11 +21198,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23324,11 +23393,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23558,11 +23627,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24271,11 +24340,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25118,11 +25187,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25259,11 +25328,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25772,11 +25841,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25934,11 +26003,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26155,11 +26224,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26402,11 +26471,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26498,11 +26567,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26574,11 +26643,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26665,11 +26734,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27157,11 +27226,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27191,11 +27260,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27554,11 +27623,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28494,11 +28563,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28590,20 +28659,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36448,11 +36517,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36487,11 +36556,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36529,11 +36598,11 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/main.c
-index fc7996c..5135556 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/main.c
+index fc7996c..56a819e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/main.c
-@@ -57,23 +57,22 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/main.c
+@@ -57,22 +57,28 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
  #include "nrf_drv_clock.h"
@@ -36552,15 +36621,20 @@ index fc7996c..5135556 100644
 +#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
  #include "nrf_dfu_trigger_usb.h"
  #endif
++
++#ifdef QSPI_ENABLED
++#include "nrf_drv_qspi.h"
++#endif
  #include "app_usbd.h"
  
  static volatile bool m_usb_started;
  
--
++#define PCA10056_PIN_RESET 24
++#define PCA10059_PIN_RESET 19
+ 
  static void usbd_user_evt_handler(app_usbd_event_type_t event)
  {
-     switch (event)
-@@ -120,9 +119,6 @@ static void usbd_init(void)
+@@ -120,9 +126,6 @@ static void usbd_init(void)
  
  static void usbd_enable(void)
  {
@@ -36570,7 +36644,7 @@ index fc7996c..5135556 100644
      APP_ERROR_CHECK(app_usbd_power_events_enable()); 
  
      /* Process USB events until USB is started. This is related to the fact that
-@@ -138,16 +134,68 @@ static void usbd_enable(void)
+@@ -138,16 +141,68 @@ static void usbd_enable(void)
  }
  #endif //APP_USBD_ENABLED
  
@@ -36642,7 +36716,7 @@ index fc7996c..5135556 100644
      while (app_usbd_event_queue_process())
      {
          /* Nothing to do */
-@@ -155,12 +203,20 @@ static void on_idle(void)
+@@ -155,18 +210,50 @@ static void on_idle(void)
  #endif
  }
  
@@ -36651,9 +36725,12 @@ index fc7996c..5135556 100644
 +  return DWT->CYCCNT;
 +}
 +
++     
  /**@brief Main function of the connectivity application. */
  int main(void)
  {
++    
++
 +    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 +    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 +
@@ -36661,10 +36738,38 @@ index fc7996c..5135556 100644
  
 -    APP_ERROR_CHECK(NRF_LOG_INIT(NULL));
 +    APP_ERROR_CHECK(NRF_LOG_INIT(timestamp, 64000000));
++
  
      NRF_LOG_DEFAULT_BACKENDS_INIT();
  
-@@ -192,6 +248,8 @@ int main(void)
+     NRF_LOG_INFO("BLE connectivity started");
+ 
+-    bsp_board_init(BSP_INIT_LEDS);
++    nrf_drv_qspi_config_t config = NRF_DRV_QSPI_DEFAULT_CONFIG;
++
++#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
++    uint32_t pin_reset = PCA10059_PIN_RESET;
++#endif
++
++#if QSPI_ENABLED
++    //Using qspi memory to de
++    err_code = nrf_drv_qspi_init(&config, NULL, NULL);
++    if (err_code == NRF_SUCCESS)
++    {
++        //qspi memory is present on pca10056
++        pin_reset = PCA10056_PIN_RESET;
++        nrf_drv_qspi_uninit();
++    }
++    else if (err_code == NRF_ERROR_TIMEOUT)
++    {
++        pin_reset = PCA10059_PIN_RESET;
++        //pca10059 assumed when no qspi memory
++    }
++#endif
+ 
+ #if (defined(SER_PHY_HCI_DEBUG_ENABLE) || defined(SER_PHY_DEBUG_APP_ENABLE))
+     debug_init(NULL);
+@@ -192,6 +279,8 @@ int main(void)
      }
  
      nrf_drv_clock_hfclk_request(NULL);
@@ -36673,18 +36778,18 @@ index fc7996c..5135556 100644
      while (!nrf_drv_clock_hfclk_is_running())
      {}
  
-@@ -199,6 +257,10 @@ int main(void)
+@@ -199,6 +288,10 @@ int main(void)
      usbd_init();
  #endif
  
 +#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
-+    APP_ERROR_CHECK(nrf_dfu_trigger_usb_init());
++    APP_ERROR_CHECK(nrf_dfu_trigger_usb_init(pin_reset));
 +#endif
 +
      /* Open serialization HAL Transport layer and subscribe for HAL Transport events. */
      err_code = ser_hal_transport_open(ser_conn_hal_transport_event_handle);
      APP_ERROR_CHECK(err_code);
-@@ -210,12 +272,14 @@ int main(void)
+@@ -210,12 +303,14 @@ int main(void)
      err_code = nrf_sdh_enable_request();
      APP_ERROR_CHECK(err_code);
  
@@ -36700,7 +36805,7 @@ index fc7996c..5135556 100644
          /* Process SoftDevice events. */
          app_sched_execute();
          if (nrf_sdh_is_suspended())
-@@ -235,6 +299,7 @@ int main(void)
+@@ -235,6 +330,7 @@ int main(void)
          APP_ERROR_CHECK(err_code);
  
          on_idle();
@@ -36708,10 +36813,10 @@ index fc7996c..5135556 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index 611a3b6..0a1645f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36732,11 +36837,148 @@ index 611a3b6..0a1645f 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-index c5caa64..dfd12e6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+index c5caa64..19a16d1 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-@@ -4133,132 +4133,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+@@ -518,6 +518,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -4133,132 +4263,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -36869,10 +37111,10 @@ index c5caa64..dfd12e6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -36884,10 +37126,10 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36896,10 +37138,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36920,11 +37162,148 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-index 878122b..ada8ae6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-@@ -4339,132 +4339,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+@@ -747,6 +747,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> SPIS_ENABLED - nrf_drv_spis - SPIS peripheral driver - legacy layer
+ //==========================================================
+ #ifndef SPIS_ENABLED
+@@ -4339,132 +4469,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -37057,10 +37436,10 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37072,10 +37451,10 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37084,10 +37463,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37108,11 +37487,148 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-index 878122b..ada8ae6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-@@ -4339,132 +4339,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+@@ -747,6 +747,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> SPIS_ENABLED - nrf_drv_spis - SPIS peripheral driver - legacy layer
+ //==========================================================
+ #ifndef SPIS_ENABLED
+@@ -4339,132 +4469,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -37245,10 +37761,10 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37260,10 +37776,10 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37272,10 +37788,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37296,11 +37812,148 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-index 17cad13..dcef5bd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+index 17cad13..cad5969 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-@@ -4017,132 +4017,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+@@ -518,6 +518,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -4017,132 +4147,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -37433,10 +38086,10 @@ index 17cad13..dcef5bd 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37448,10 +38101,10 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37460,11 +38113,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -37728,11 +38381,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..7110f07
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -37840,12 +38493,12 @@ index 0000000..7110f07
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..dfd12e6
+index 0000000..19a16d1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
-@@ -0,0 +1,4428 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+@@ -0,0 +1,4558 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -38362,6 +39015,136 @@ index 0000000..dfd12e6
 +
 +#ifndef CLOCK_CONFIG_IRQ_PRIORITY
 +#define CLOCK_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
 +#endif
 +
 +// </e>
@@ -42274,11 +43057,11 @@ index 0000000..dfd12e6
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -42434,11 +43217,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -42448,11 +43231,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -42503,11 +43286,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -42772,11 +43555,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..9e0c093
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -42884,12 +43667,12 @@ index 0000000..9e0c093
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..d464764
+index 0000000..ffe8c67
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
-@@ -0,0 +1,4449 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+@@ -0,0 +1,4579 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -43427,6 +44210,136 @@ index 0000000..d464764
 +
 +#ifndef CLOCK_CONFIG_IRQ_PRIORITY
 +#define CLOCK_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
 +#endif
 +
 +// </e>
@@ -47339,11 +48252,11 @@ index 0000000..d464764
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -47500,11 +48413,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -47514,11 +48427,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -47569,10 +48482,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index e8a3735..7b95e77 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47591,11 +48504,148 @@ index e8a3735..7b95e77 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-index 6539e77..b33d1e8 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+index 6539e77..3119381 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-@@ -3998,132 +3998,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+@@ -397,6 +397,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -3998,132 +4128,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -47728,10 +48778,10 @@ index 6539e77..b33d1e8 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47741,10 +48791,10 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47753,10 +48803,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47775,11 +48825,148 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-index 4adb2af..24057c5 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-@@ -4148,132 +4148,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+@@ -598,6 +598,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> SPIS_ENABLED - nrf_drv_spis - SPIS peripheral driver - legacy layer
+ //==========================================================
+ #ifndef SPIS_ENABLED
+@@ -4148,132 +4278,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -47912,10 +49099,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47925,10 +49112,10 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47937,10 +49124,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47959,11 +49146,148 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-index 4adb2af..24057c5 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-@@ -4148,132 +4148,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+@@ -598,6 +598,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> SPIS_ENABLED - nrf_drv_spis - SPIS peripheral driver - legacy layer
+ //==========================================================
+ #ifndef SPIS_ENABLED
+@@ -4148,132 +4278,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -48096,10 +49420,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48109,10 +49433,10 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48121,10 +49445,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48143,11 +49467,148 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-index 7b74df4..fce649b 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+index 7b74df4..f0c345a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-@@ -3882,132 +3882,6 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+@@ -397,6 +397,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 0
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -3882,132 +4012,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -48280,10 +49741,10 @@ index 7b74df4..fce649b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48293,10 +49754,10 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48305,12 +49766,12 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
-index 0000000..af9dc2a
+index 0000000..29138b1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
-@@ -0,0 +1,281 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+@@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
 +OUTPUT_DIRECTORY := _build
@@ -48409,6 +49870,7 @@ index 0000000..af9dc2a
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
 +  $(PROJ_DIR)/main.c \
@@ -48592,11 +50054,11 @@ index 0000000..af9dc2a
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -48704,12 +50166,12 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..988b9b0
+index 0000000..14a8586
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
-@@ -0,0 +1,4965 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+@@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -49088,6 +50550,134 @@ index 0000000..988b9b0
 +
 +// </e>
 +
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
 +// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
 +//==========================================================
 +#ifndef NRFX_UARTE_ENABLED
@@ -49409,6 +50999,136 @@ index 0000000..988b9b0
 +
 +#ifndef POWER_CONFIG_DEFAULT_DCDCENHV
 +#define POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
 +#endif
 +
 +// </e>
@@ -53675,12 +55395,12 @@ index 0000000..988b9b0
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
-index 0000000..4f6d528
+index 0000000..bd45579
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
-@@ -0,0 +1,168 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+@@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
 +  <project Name="ble_connectivity_132v3_usb_hci_pca10056">
@@ -53815,6 +55535,7 @@ index 0000000..4f6d528
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
 +    </folder>
@@ -53849,11 +55570,11 @@ index 0000000..4f6d528
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -53863,11 +55584,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -53918,12 +55639,12 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
-index 0000000..711d0ba
+index 0000000..8d850ae
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
-@@ -0,0 +1,282 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+@@ -0,0 +1,283 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
 +OUTPUT_DIRECTORY := _build
@@ -54022,6 +55743,7 @@ index 0000000..711d0ba
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
 +  $(PROJ_DIR)/main.c \
@@ -54206,11 +55928,11 @@ index 0000000..711d0ba
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..1a80caf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -54318,12 +56040,12 @@ index 0000000..1a80caf
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..4f7851b
+index 0000000..f0b6542
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
-@@ -0,0 +1,4986 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+@@ -0,0 +1,5244 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -54723,6 +56445,134 @@ index 0000000..4f7851b
 +
 +// </e>
 +
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
 +// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
 +//==========================================================
 +#ifndef NRFX_UARTE_ENABLED
@@ -55044,6 +56894,136 @@ index 0000000..4f7851b
 +
 +#ifndef POWER_CONFIG_DEFAULT_DCDCENHV
 +#define POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
 +#endif
 +
 +// </e>
@@ -59310,12 +61290,12 @@ index 0000000..4f7851b
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
-index 0000000..bef124b
+index 0000000..d93607c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
-@@ -0,0 +1,169 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+@@ -0,0 +1,170 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
 +  <project Name="ble_connectivity_132v5_usb_hci_pca10056">
@@ -59450,6 +61430,7 @@ index 0000000..bef124b
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
 +    </folder>
@@ -59485,11 +61466,11 @@ index 0000000..bef124b
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -59499,11 +61480,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -59554,10 +61535,22 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
+index 87059cc..0d8cc08 100644
+--- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
+@@ -85,6 +85,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
+   $(PROJ_DIR)/main.c \
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59576,11 +61569,283 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-index 793e569..58429c4 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+index 793e569..d43945e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-@@ -3839,12 +3839,12 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+@@ -240,6 +240,134 @@
+ 
+ // </e>
+ 
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
+ //==========================================================
+ #ifndef NRFX_UARTE_ENABLED
+@@ -523,6 +651,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -3839,12 +4097,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -59595,7 +61860,7 @@ index 793e569..58429c4 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4145,132 +4145,6 @@
+@@ -4145,132 +4403,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -59728,10 +61993,10 @@ index 793e569..58429c4 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-index f64c3a0..fbea4af 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+index f64c3a0..0221ede 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59741,10 +62006,18 @@ index f64c3a0..fbea4af 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+@@ -121,6 +121,7 @@
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
+     </folder>
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59753,10 +62026,22 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
+index f5648fe..98f1192 100644
+--- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
+@@ -83,6 +83,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59775,11 +62060,283 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-index ba4721d..4802198 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-@@ -4017,12 +4017,12 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+@@ -347,6 +347,134 @@
+ 
+ // </e>
+ 
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
+ //==========================================================
+ #ifndef NRFX_SPIS_ENABLED
+@@ -738,6 +866,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> SPIS_ENABLED - nrf_drv_spis - SPIS peripheral driver - legacy layer
+ //==========================================================
+ #ifndef SPIS_ENABLED
+@@ -4017,12 +4275,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -59794,7 +62351,7 @@ index ba4721d..4802198 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4323,132 +4323,6 @@
+@@ -4323,132 +4581,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -59927,10 +62484,10 @@ index ba4721d..4802198 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-index a71ed2f..ebc07bf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+index a71ed2f..430528f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59940,10 +62497,18 @@ index a71ed2f..ebc07bf 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+@@ -119,6 +119,7 @@
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_gpiote.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59952,10 +62517,22 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
+index e498e6c..1147b6f 100644
+--- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
+@@ -83,6 +83,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59974,11 +62551,283 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-index ba4721d..4802198 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-@@ -4017,12 +4017,12 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+@@ -347,6 +347,134 @@
+ 
+ // </e>
+ 
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> NRFX_SPIS_ENABLED - nrfx_spis - SPIS peripheral driver
+ //==========================================================
+ #ifndef NRFX_SPIS_ENABLED
+@@ -738,6 +866,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> SPIS_ENABLED - nrf_drv_spis - SPIS peripheral driver - legacy layer
+ //==========================================================
+ #ifndef SPIS_ENABLED
+@@ -4017,12 +4275,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -59993,7 +62842,7 @@ index ba4721d..4802198 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4323,132 +4323,6 @@
+@@ -4323,132 +4581,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -60126,10 +62975,10 @@ index ba4721d..4802198 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-index a95d1a5..eb97046 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+index a95d1a5..44ff831 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -60139,10 +62988,18 @@ index a95d1a5..eb97046 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+@@ -119,6 +119,7 @@
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_gpiote.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60151,10 +63008,22 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
+index aad2de3..d3b8468 100644
+--- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
+@@ -81,6 +81,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
+   $(PROJ_DIR)/main.c \
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -60173,11 +63042,283 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-index 36b0fe4..47afc6b 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+index 36b0fe4..bc8c8d0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-@@ -3723,12 +3723,12 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+@@ -240,6 +240,134 @@
+ 
+ // </e>
+ 
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
+ //==========================================================
+ #ifndef NRFX_UARTE_ENABLED
+@@ -523,6 +651,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -3723,12 +3981,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -60192,7 +63333,7 @@ index 36b0fe4..47afc6b 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4029,132 +4029,6 @@
+@@ -4029,132 +4287,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -60325,10 +63466,10 @@ index 36b0fe4..47afc6b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-index 228cf40..8cbfa44 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+index 228cf40..29b2865 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -60338,10 +63479,18 @@ index 228cf40..8cbfa44 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+@@ -117,6 +117,7 @@
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
+     </folder>
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60350,10 +63499,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-index 07cf7c6..e9abd24 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+index 07cf7c6..b4c2628 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -25,6 +25,7 @@ SRC_FILES += \
    $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
    $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
@@ -60370,7 +63519,15 @@ index 07cf7c6..e9abd24 100644
    $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_conn.c \
    $(SDK_ROOT)/components/serialization/connectivity/codecs/common/ble_dtm_init.c \
    $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c \
-@@ -123,7 +125,7 @@ INC_FOLDERS += \
+@@ -94,6 +96,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
+   $(PROJ_DIR)/main.c \
+@@ -123,7 +126,7 @@ INC_FOLDERS += \
    $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware \
    $(SDK_ROOT)/integration/nrfx/legacy \
    $(SDK_ROOT)/components/libraries/crc16 \
@@ -60379,7 +63536,7 @@ index 07cf7c6..e9abd24 100644
    $(SDK_ROOT)/components/serialization/common \
    $(SDK_ROOT)/components/libraries/util \
    $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm \
-@@ -145,15 +147,18 @@ INC_FOLDERS += \
+@@ -145,15 +148,18 @@ INC_FOLDERS += \
    $(SDK_ROOT)/components/libraries/delay \
    $(SDK_ROOT)/external/segger_rtt \
    $(SDK_ROOT)/components/libraries/atomic_fifo \
@@ -60398,7 +63555,7 @@ index 07cf7c6..e9abd24 100644
    $(SDK_ROOT)/external/fprintf \
    $(SDK_ROOT)/components/libraries/log/src \
  
-@@ -177,6 +182,7 @@ CFLAGS += -DNRF52840_XXAA
+@@ -177,6 +183,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
  CFLAGS += -DSER_CONNECTIVITY
@@ -60406,7 +63563,7 @@ index 07cf7c6..e9abd24 100644
  CFLAGS += -DSOFTDEVICE_PRESENT
  CFLAGS += -DSWI_DISABLE0
  CFLAGS += -mcpu=cortex-m4
-@@ -205,6 +211,7 @@ ASMFLAGS += -DNRF52840_XXAA
+@@ -205,6 +212,7 @@ ASMFLAGS += -DNRF52840_XXAA
  ASMFLAGS += -DNRF_SD_BLE_API_VERSION=6
  ASMFLAGS += -DS140
  ASMFLAGS += -DSER_CONNECTIVITY
@@ -60414,10 +63571,10 @@ index 07cf7c6..e9abd24 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -60436,10 +63593,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-index 994863b..988b9b0 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+index 994863b..14a8586 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -46,6 +46,102 @@
  #ifdef USE_APP_CONFIG
  #include "app_config.h"
@@ -60543,7 +63700,279 @@ index 994863b..988b9b0 100644
  // <h> nRF_BLE 
  
  //==========================================================
-@@ -901,7 +997,7 @@
+@@ -280,6 +376,134 @@
+ 
+ // </e>
+ 
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
+ //==========================================================
+ #ifndef NRFX_UARTE_ENABLED
+@@ -605,6 +829,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -901,7 +1255,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
  #ifndef APP_USBD_PID
@@ -60552,7 +63981,7 @@ index 994863b..988b9b0 100644
  #endif
  
  // <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
-@@ -1144,6 +1240,13 @@
+@@ -1144,6 +1498,13 @@
  
  // </e>
  
@@ -60566,7 +63995,7 @@ index 994863b..988b9b0 100644
  // <q> CRC16_ENABLED  - crc16 - CRC16 calculation routines
   
  
-@@ -4261,12 +4364,12 @@
+@@ -4261,12 +4622,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -60581,7 +64010,7 @@ index 994863b..988b9b0 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4567,132 +4670,6 @@
+@@ -4567,132 +4928,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -60714,10 +64143,10 @@ index 994863b..988b9b0 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-index 571ebbb..6904047 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+index 571ebbb..6be7f69 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -15,8 +15,8 @@
        arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
        arm_target_device_name="nRF52840_xxAA"
@@ -60754,10 +64183,18 @@ index 571ebbb..6904047 100644
      </folder>
      <folder Name="nRF_Serialization">
        <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_conn.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -130,6 +132,7 @@
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
+     </folder>
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60766,12 +64203,12 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
-index 0000000..a2942b9
+index 0000000..b704d10
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
-@@ -0,0 +1,281 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+@@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
 +OUTPUT_DIRECTORY := _build
@@ -60870,6 +64307,7 @@ index 0000000..a2942b9
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
 +  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
 +  $(PROJ_DIR)/main.c \
@@ -61053,11 +64491,11 @@ index 0000000..a2942b9
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -61165,12 +64603,12 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..e9d9297
+index 0000000..c244199
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
-@@ -0,0 +1,4965 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+@@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -61549,6 +64987,134 @@ index 0000000..e9d9297
 +
 +// </e>
 +
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
 +// <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
 +//==========================================================
 +#ifndef NRFX_UARTE_ENABLED
@@ -61870,6 +65436,136 @@ index 0000000..e9d9297
 +
 +#ifndef POWER_CONFIG_DEFAULT_DCDCENHV
 +#define POWER_CONFIG_DEFAULT_DCDCENHV 0
++#endif
++
++// </e>
++
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
 +#endif
 +
 +// </e>
@@ -66136,12 +69832,12 @@ index 0000000..e9d9297
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
-index 0000000..33a4962
+index 0000000..735cba9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
-@@ -0,0 +1,168 @@
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+@@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
 +  <project Name="ble_connectivity_132v3_usb_hci_pca10059">
@@ -66276,6 +69972,7 @@ index 0000000..33a4962
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
 +      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
 +    </folder>
@@ -66310,11 +70007,11 @@ index 0000000..33a4962
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -66324,11 +70021,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -66379,11 +70076,19 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-index 33053bc..bb6ccf2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+index 33053bc..b4bde15 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-@@ -182,6 +182,7 @@ CFLAGS += -DNRF52840_XXAA
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+@@ -96,6 +96,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/prs/nrfx_prs.c \
++  $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_qspi.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
+   $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
+   $(PROJ_DIR)/main.c \
+@@ -182,6 +183,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
  CFLAGS += -DSER_CONNECTIVITY
@@ -66391,7 +70096,7 @@ index 33053bc..bb6ccf2 100644
  CFLAGS += -DSOFTDEVICE_PRESENT
  CFLAGS += -DSWI_DISABLE0
  CFLAGS += -mcpu=cortex-m4
-@@ -210,6 +211,7 @@ ASMFLAGS += -DNRF52840_XXAA
+@@ -210,6 +212,7 @@ ASMFLAGS += -DNRF52840_XXAA
  ASMFLAGS += -DNRF_SD_BLE_API_VERSION=6
  ASMFLAGS += -DS140
  ASMFLAGS += -DSER_CONNECTIVITY
@@ -66399,10 +70104,10 @@ index 33053bc..bb6ccf2 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -66421,10 +70126,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-index bb385de..e9d9297 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+index bb385de..c244199 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -133,7 +133,7 @@
  // <i> gaps. Tailor this value to adhere to this limitation.
  
@@ -66434,7 +70139,279 @@ index bb385de..e9d9297 100644
  #endif
  
  // </h> 
-@@ -997,7 +997,7 @@
+@@ -376,6 +376,134 @@
+ 
+ // </e>
+ 
++// <e> NRFX_QSPI_ENABLED - nrfx_qspi - QSPI peripheral driver
++//==========================================================
++#ifndef NRFX_QSPI_ENABLED
++#define NRFX_QSPI_ENABLED 1
++#endif
++// <o> NRFX_QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef NRFX_QSPI_CONFIG_SCK_DELAY
++#define NRFX_QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> NRFX_QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef NRFX_QSPI_CONFIG_XIP_OFFSET
++#define NRFX_QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef NRFX_QSPI_CONFIG_READOC
++#define NRFX_QSPI_CONFIG_READOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef NRFX_QSPI_CONFIG_WRITEOC
++#define NRFX_QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef NRFX_QSPI_CONFIG_ADDRMODE
++#define NRFX_QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef NRFX_QSPI_CONFIG_MODE
++#define NRFX_QSPI_CONFIG_MODE 0
++#endif
++
++// <o> NRFX_QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef NRFX_QSPI_CONFIG_FREQUENCY
++#define NRFX_QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> NRFX_QSPI_PIN_SCK - SCK pin value.
++#ifndef NRFX_QSPI_PIN_SCK
++#define NRFX_QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_CSN - CSN pin value.
++#ifndef NRFX_QSPI_PIN_CSN
++#define NRFX_QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO0 - IO0 pin value.
++#ifndef NRFX_QSPI_PIN_IO0
++#define NRFX_QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO1 - IO1 pin value.
++#ifndef NRFX_QSPI_PIN_IO1
++#define NRFX_QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO2 - IO2 pin value.
++#ifndef NRFX_QSPI_PIN_IO2
++#define NRFX_QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> NRFX_QSPI_PIN_IO3 - IO3 pin value.
++#ifndef NRFX_QSPI_PIN_IO3
++#define NRFX_QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> NRFX_QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef NRFX_QSPI_CONFIG_IRQ_PRIORITY
++#define NRFX_QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> NRFX_UARTE_ENABLED - nrfx_uarte - UARTE peripheral driver
+ //==========================================================
+ #ifndef NRFX_UARTE_ENABLED
+@@ -701,6 +829,136 @@
+ 
+ // </e>
+ 
++// <e> QSPI_ENABLED - nrf_drv_qspi - QSPI peripheral driver - legacy layer
++//==========================================================
++#ifndef QSPI_ENABLED
++#define QSPI_ENABLED 1
++#endif
++// <o> QSPI_CONFIG_SCK_DELAY - tSHSL, tWHSL and tSHWL in number of 16 MHz periods (62.5 ns).  <0-255> 
++
++
++#ifndef QSPI_CONFIG_SCK_DELAY
++#define QSPI_CONFIG_SCK_DELAY 1
++#endif
++
++// <o> QSPI_CONFIG_XIP_OFFSET - Address offset in the external memory for Execute in Place operation. 
++#ifndef QSPI_CONFIG_XIP_OFFSET
++#define QSPI_CONFIG_XIP_OFFSET 0
++#endif
++
++// <o> QSPI_CONFIG_READOC  - Number of data lines and opcode used for reading.
++ 
++// <0=> FastRead 
++// <1=> Read2O 
++// <2=> Read2IO 
++// <3=> Read4O 
++// <4=> Read4IO 
++
++#ifndef QSPI_CONFIG_READOC
++#define QSPI_CONFIG_READOC 0
++#endif
++
++// <o> QSPI_CONFIG_WRITEOC  - Number of data lines and opcode used for writing.
++ 
++// <0=> PP 
++// <1=> PP2O 
++// <2=> PP4O 
++// <3=> PP4IO 
++
++#ifndef QSPI_CONFIG_WRITEOC
++#define QSPI_CONFIG_WRITEOC 0
++#endif
++
++// <o> QSPI_CONFIG_ADDRMODE  - Addressing mode.
++ 
++// <0=> 24bit 
++// <1=> 32bit 
++
++#ifndef QSPI_CONFIG_ADDRMODE
++#define QSPI_CONFIG_ADDRMODE 0
++#endif
++
++// <o> QSPI_CONFIG_MODE  - SPI mode.
++ 
++// <0=> Mode 0 
++// <1=> Mode 1 
++
++#ifndef QSPI_CONFIG_MODE
++#define QSPI_CONFIG_MODE 0
++#endif
++
++// <o> QSPI_CONFIG_FREQUENCY  - Frequency divider.
++ 
++// <0=> 32MHz/1 
++// <1=> 32MHz/2 
++// <2=> 32MHz/3 
++// <3=> 32MHz/4 
++// <4=> 32MHz/5 
++// <5=> 32MHz/6 
++// <6=> 32MHz/7 
++// <7=> 32MHz/8 
++// <8=> 32MHz/9 
++// <9=> 32MHz/10 
++// <10=> 32MHz/11 
++// <11=> 32MHz/12 
++// <12=> 32MHz/13 
++// <13=> 32MHz/14 
++// <14=> 32MHz/15 
++// <15=> 32MHz/16 
++
++#ifndef QSPI_CONFIG_FREQUENCY
++#define QSPI_CONFIG_FREQUENCY 15
++#endif
++
++// <s> QSPI_PIN_SCK - SCK pin value.
++#ifndef QSPI_PIN_SCK
++#define QSPI_PIN_SCK NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_CSN - CSN pin value.
++#ifndef QSPI_PIN_CSN
++#define QSPI_PIN_CSN NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO0 - IO0 pin value.
++#ifndef QSPI_PIN_IO0
++#define QSPI_PIN_IO0 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO1 - IO1 pin value.
++#ifndef QSPI_PIN_IO1
++#define QSPI_PIN_IO1 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO2 - IO2 pin value.
++#ifndef QSPI_PIN_IO2
++#define QSPI_PIN_IO2 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <s> QSPI_PIN_IO3 - IO3 pin value.
++#ifndef QSPI_PIN_IO3
++#define QSPI_PIN_IO3 NRF_QSPI_PIN_NOT_CONNECTED
++#endif
++
++// <o> QSPI_CONFIG_IRQ_PRIORITY  - Interrupt priority
++ 
++
++// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
++// <0=> 0 (highest) 
++// <1=> 1 
++// <2=> 2 
++// <3=> 3 
++// <4=> 4 
++// <5=> 5 
++// <6=> 6 
++// <7=> 7 
++
++#ifndef QSPI_CONFIG_IRQ_PRIORITY
++#define QSPI_CONFIG_IRQ_PRIORITY 6
++#endif
++
++// </e>
++
+ // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver - legacy layer
+ //==========================================================
+ #ifndef UART_ENABLED
+@@ -997,7 +1255,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
  #ifndef APP_USBD_PID
@@ -66443,7 +70420,7 @@ index bb385de..e9d9297 100644
  #endif
  
  // <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
-@@ -4364,12 +4364,12 @@
+@@ -4364,12 +4622,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -66458,7 +70435,7 @@ index bb385de..e9d9297 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4670,132 +4670,6 @@
+@@ -4670,132 +4928,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -66591,10 +70568,10 @@ index bb385de..e9d9297 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-index c7771fd..2c772bc 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+index c7771fd..e6a0b2c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -66613,10 +70590,18 @@ index c7771fd..2c772bc 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -132,6 +132,7 @@
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_power_clock.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/prs/nrfx_prs.c" />
++      <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_qspi.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
+       <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
+     </folder>
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -66625,10 +70610,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_a184e1b/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_e18d5d2/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_a184e1b/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_e18d5d2/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -66703,11 +70688,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_a184e1b/examples/readme.txt nRF5_SDK_15.2.0_a184e1b/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_e18d5d2/examples/readme.txt nRF5_SDK_15.2.0_e18d5d2/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_a184e1b/examples/readme.txt
++++ nRF5_SDK_15.2.0_e18d5d2/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -66723,10 +70708,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_a184e1b/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_e18d5d2/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_a184e1b/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_e18d5d2/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,20 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_c9fc670/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_a184e1b/components/boards/pca10056.h
+index 6b3f92f..7fbfbca 100644
+--- nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h
++++ nRF5_SDK_15.2.0_a184e1b/components/boards/pca10056.h
+@@ -90,6 +90,8 @@ extern "C" {
+ #define RTS_PIN_NUMBER 5
+ #define HWFC           true
+ 
++#define BSP_SELF_PINRESET_PIN NRF_GPIO_PIN_MAP(0,24)
++
+ #define BSP_QSPI_SCK_PIN   19
+ #define BSP_QSPI_CSN_PIN   17
+ #define BSP_QSPI_IO0_PIN   20
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_a184e1b/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_a184e1b/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -11,10 +24,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -41,10 +54,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -137,10 +150,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -290,10 +303,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -365,10 +378,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -385,10 +398,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -452,10 +465,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -468,10 +481,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -494,10 +507,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -528,10 +541,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -575,10 +588,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -631,10 +644,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -682,10 +695,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -718,10 +731,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -731,10 +744,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -750,10 +763,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1049,10 +1062,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1062,10 +1075,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1150,10 +1163,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1265,10 +1278,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1287,10 +1300,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1339,10 +1352,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1360,10 +1373,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1393,10 +1406,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1415,10 +1428,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1466,10 +1479,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1554,10 +1567,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1589,10 +1602,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1610,10 +1623,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1624,10 +1637,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1664,10 +1677,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1700,10 +1713,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1723,10 +1736,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1739,10 +1752,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1839,10 +1852,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_a184e1b/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1863,10 +1876,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1893,10 +1906,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -1973,10 +1986,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2003,11 +2016,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2690,11 +2703,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2786,11 +2799,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4709,11 +4722,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4935,11 +4948,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5601,11 +5614,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6385,11 +6398,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6522,11 +6535,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6730,11 +6743,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6874,11 +6887,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7093,11 +7106,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7316,11 +7329,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7409,11 +7422,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7482,11 +7495,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7570,11 +7583,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8061,11 +8074,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8095,11 +8108,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8432,11 +8445,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9344,11 +9357,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9438,11 +9451,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11363,11 +11376,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12043,11 +12056,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12595,20 +12608,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20304,11 +20317,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20343,11 +20356,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20385,11 +20398,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21019,11 +21032,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21116,11 +21129,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23311,11 +23324,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23545,11 +23558,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24258,11 +24271,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25105,11 +25118,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25246,11 +25259,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25759,11 +25772,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25921,11 +25934,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26142,11 +26155,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26389,11 +26402,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26485,11 +26498,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26561,11 +26574,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26652,11 +26665,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27144,11 +27157,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27178,11 +27191,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27541,11 +27554,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28481,11 +28494,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28577,20 +28590,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36435,11 +36448,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36474,11 +36487,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_a184e1b/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36516,11 +36529,11 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/main.c
-index fc7996c..a56e94c 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/main.c
+index fc7996c..5135556 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/main.c
-@@ -57,13 +57,13 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/main.c
+@@ -57,23 +57,22 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
  #include "nrf_drv_clock.h"
@@ -36535,8 +36548,11 @@ index fc7996c..a56e94c 100644
 +#include "ser_config.h"
  #if defined(APP_USBD_ENABLED) && APP_USBD_ENABLED
  #include "app_usbd_serial_num.h"
- #ifdef BOARD_PCA10059
-@@ -73,7 +73,6 @@
+-#ifdef BOARD_PCA10059
++#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
+ #include "nrf_dfu_trigger_usb.h"
+ #endif
+ #include "app_usbd.h"
  
  static volatile bool m_usb_started;
  
@@ -36661,7 +36677,7 @@ index fc7996c..a56e94c 100644
      usbd_init();
  #endif
  
-+#ifdef BOARD_PCA10059
++#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
 +    APP_ERROR_CHECK(nrf_dfu_trigger_usb_init());
 +#endif
 +
@@ -36692,10 +36708,10 @@ index fc7996c..a56e94c 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index 611a3b6..0a1645f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36716,10 +36732,10 @@ index 611a3b6..0a1645f 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..dfd12e6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -4133,132 +4133,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -36853,10 +36869,10 @@ index c5caa64..dfd12e6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -36868,10 +36884,10 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36880,10 +36896,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36904,10 +36920,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..ada8ae6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -4339,132 +4339,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -37041,10 +37057,10 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37056,10 +37072,10 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37068,10 +37084,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37092,10 +37108,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..ada8ae6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -4339,132 +4339,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -37229,10 +37245,10 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37244,10 +37260,10 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37256,10 +37272,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37280,10 +37296,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..dcef5bd 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -4017,132 +4017,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -37417,10 +37433,10 @@ index 17cad13..dcef5bd 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37432,10 +37448,10 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37444,11 +37460,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -37712,11 +37728,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..7110f07
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -37824,11 +37840,11 @@ index 0000000..7110f07
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..dfd12e6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4428 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -42258,11 +42274,11 @@ index 0000000..dfd12e6
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -42418,11 +42434,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -42432,11 +42448,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -42487,11 +42503,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -42756,11 +42772,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..9e0c093
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -42868,11 +42884,11 @@ index 0000000..9e0c093
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..d464764
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4449 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -47323,11 +47339,11 @@ index 0000000..d464764
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -47484,11 +47500,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -47498,11 +47514,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -47553,10 +47569,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index e8a3735..7b95e77 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47575,10 +47591,10 @@ index e8a3735..7b95e77 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..b33d1e8 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -3998,132 +3998,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47712,10 +47728,10 @@ index 6539e77..b33d1e8 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47725,10 +47741,10 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47737,10 +47753,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47759,10 +47775,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..24057c5 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -4148,132 +4148,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47896,10 +47912,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47909,10 +47925,10 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47921,10 +47937,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47943,10 +47959,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..24057c5 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -4148,132 +4148,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48080,10 +48096,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48093,10 +48109,10 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48105,10 +48121,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48127,10 +48143,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..fce649b 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -3882,132 +3882,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48264,10 +48280,10 @@ index 7b74df4..fce649b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48277,10 +48293,10 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48289,12 +48305,12 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
-index 0000000..70d9b8b
+index 0000000..af9dc2a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
-@@ -0,0 +1,276 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+@@ -0,0 +1,281 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
 +OUTPUT_DIRECTORY := _build
@@ -48322,6 +48338,7 @@ index 0000000..70d9b8b
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
 +  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd_core.c \
++  $(SDK_ROOT)/components/libraries/usbd/class/nrf_dfu_trigger/app_usbd_nrf_dfu_trigger.c \
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd_serial_num.c \
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd_string_desc.c \
 +  $(SDK_ROOT)/components/libraries/util/app_util_platform.c \
@@ -48339,6 +48356,7 @@ index 0000000..70d9b8b
 +  $(SDK_ROOT)/components/libraries/strerror/nrf_strerror.c \
 +  $(SDK_ROOT)/modules/nrfx/mdk/system_nrf52840.c \
 +  $(SDK_ROOT)/components/boards/boards.c \
++  $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_conn.c \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/ble_dtm_init.c \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c \
@@ -48421,7 +48439,7 @@ index 0000000..70d9b8b
 +  $(SDK_ROOT)/components/libraries/strerror \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware \
 +  $(SDK_ROOT)/components/libraries/crc16 \
-+  $(SDK_ROOT)/components/ble/ble_dtm \
++  $(SDK_ROOT)/components/libraries/bootloader/dfu \
 +  $(SDK_ROOT)/components/serialization/common \
 +  $(SDK_ROOT)/components/libraries/util \
 +  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm \
@@ -48445,15 +48463,18 @@ index 0000000..70d9b8b
 +  $(SDK_ROOT)/components/libraries/delay \
 +  $(SDK_ROOT)/external/segger_rtt \
 +  $(SDK_ROOT)/components/libraries/atomic_fifo \
++  $(SDK_ROOT)/components/ble/ble_dtm \
 +  $(SDK_ROOT)/components/libraries/atomic \
 +  $(SDK_ROOT)/components/boards \
 +  $(SDK_ROOT)/components/libraries/memobj \
 +  $(SDK_ROOT)/components/serialization/common/struct_ser/ble \
 +  $(SDK_ROOT)/components/softdevice/s132v3/headers \
++  $(SDK_ROOT)/components/libraries/usbd/class/nrf_dfu_trigger \
 +  $(SDK_ROOT)/components/serialization/common/transport \
 +  $(SDK_ROOT)/components/softdevice/common \
 +  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/config \
 +  $(SDK_ROOT)/modules/nrfx/drivers/include \
++  $(SDK_ROOT)/components/libraries/block_dev \
 +  $(SDK_ROOT)/external/fprintf \
 +  $(SDK_ROOT)/components/libraries/log/src \
 +
@@ -48571,11 +48592,11 @@ index 0000000..70d9b8b
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -48683,12 +48704,12 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..0bcfe3e
+index 0000000..988b9b0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
-@@ -0,0 +1,4862 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+@@ -0,0 +1,4965 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -48737,6 +48758,102 @@ index 0000000..0bcfe3e
 +#ifdef USE_APP_CONFIG
 +#include "app_config.h"
 +#endif
++// <h> Application 
++
++//==========================================================
++// <h> application_info - Software Component
++
++//==========================================================
++// <s> APP_NAME - Application name
++#ifndef APP_NAME
++#define APP_NAME "ble-connectivity"
++#endif
++
++// <o> APP_ID - Application ID 
++#ifndef APP_ID
++#define APP_ID 0
++#endif
++
++// <h> APP_VERSION - Application version (semantic versioning)
++
++//==========================================================
++// <o> APP_VERSION_MAJOR - Major version  <0-1000> 
++
++
++#ifndef APP_VERSION_MAJOR
++#define APP_VERSION_MAJOR 0
++#endif
++
++// <o> APP_VERSION_MINOR - Minor version  <0-1000> 
++
++
++#ifndef APP_VERSION_MINOR
++#define APP_VERSION_MINOR 1
++#endif
++
++// <o> APP_VERSION_PATCH - Patch version  <0-1000> 
++
++
++#ifndef APP_VERSION_PATCH
++#define APP_VERSION_PATCH 0
++#endif
++
++// <s> APP_VERSION_PRERELEASE - Prerelease, eg. "-1.alpha"
++
++// <i> If not empty, this string should include the leading hyphen (-).
++// <i> This string might be normalized at run-time to not contain characters
++// <i> illegal in Semantic Versioning.
++#ifndef APP_VERSION_PRERELEASE
++#define APP_VERSION_PRERELEASE ""
++#endif
++
++// <s> APP_VERSION_METADATA - Metadata, e.g. "+some-string.01-01-2018-23-59-59"
++
++// <i> If not empty, this string should include the leading plus (+).
++// <i> This string might be normalized at run-time to not contain characters
++// <i> illegal in Semantic Versioning.
++#ifndef APP_VERSION_METADATA
++#define APP_VERSION_METADATA "+" __DATE__ " " __TIME__
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> Board Definition 
++
++//==========================================================
++// <h> nrf_dfu_trigger_usb - USB DFU Trigger library
++
++//==========================================================
++// <q> NRF_DFU_TRIGGER_USB_USB_SHARED  - Flag indicating whether USB is used for other purposes in the application.
++ 
++
++#ifndef NRF_DFU_TRIGGER_USB_USB_SHARED
++#define NRF_DFU_TRIGGER_USB_USB_SHARED 1
++#endif
++
++// <o> NRF_DFU_TRIGGER_USB_INTERFACE_NUM - The USB interface to use for the DFU Trigger library.  <0-255> 
++
++
++// <i> According to the USB Specification, interface numbers cannot have
++// <i> gaps. Tailor this value to adhere to this limitation.
++
++#ifndef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
++#define NRF_DFU_TRIGGER_USB_INTERFACE_NUM 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
 +// <h> nRF_BLE 
 +
 +//==========================================================
@@ -49834,6 +49951,13 @@ index 0000000..0bcfe3e
 +#endif
 +
 +// </e>
++
++// <q> APP_USBD_NRF_DFU_TRIGGER_ENABLED  - app_usbd_nrf_dfu_trigger - USBD Nordic DFU Trigger class
++ 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_ENABLED
++#define APP_USBD_NRF_DFU_TRIGGER_ENABLED 1
++#endif
 +
 +// <q> CRC16_ENABLED  - crc16 - CRC16 calculation routines
 + 
@@ -53551,12 +53675,12 @@ index 0000000..0bcfe3e
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
-index 0000000..745b6a7
+index 0000000..4f6d528
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
-@@ -0,0 +1,166 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+@@ -0,0 +1,168 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
 +  <project Name="ble_connectivity_132v3_usb_hci_pca10056">
@@ -53574,7 +53698,7 @@ index 0000000..745b6a7
 +      arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
 +      arm_target_device_name="nRF52840_xxAA"
 +      arm_target_interface_type="SWD"
-+      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/ble/common;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s132v3/headers;../../../../../../components/softdevice/s132v3/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
++      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/ble/common;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/block_dev;../../../../../../components/libraries/bootloader/dfu;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/usbd/class/nrf_dfu_trigger;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s132v3/headers;../../../../../../components/softdevice/s132v3/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
 +      c_preprocessor_definitions="BLE_STACK_SUPPORT_REQD;BOARD_PCA10056;BSP_DEFINES_ONLY;CONFIG_GPIO_AS_PINRESET;FLOAT_ABI_HARD;HCI_TIMER2;INITIALIZE_USER_SECTIONS;NO_VTOR_CONFIG;NRF52840_XXAA;NRF_SD_BLE_API_VERSION=3;S132;SER_CONNECTIVITY;SER_PHY_HCI_USB_CDC;SOFTDEVICE_PRESENT;SWI_DISABLE0;"
 +      debug_target_connection="J-Link"
 +      gcc_entry_point="Reset_Handler"
@@ -53610,6 +53734,7 @@ index 0000000..745b6a7
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd_core.c" />
++      <file file_name="../../../../../../components/libraries/usbd/class/nrf_dfu_trigger/app_usbd_nrf_dfu_trigger.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd_serial_num.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd_string_desc.c" />
 +      <file file_name="../../../../../../components/libraries/util/app_util_platform.c" />
@@ -53633,6 +53758,7 @@ index 0000000..745b6a7
 +    </folder>
 +    <folder Name="Board Definition">
 +      <file file_name="../../../../../../components/boards/boards.c" />
++      <file file_name="../../../../../../components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c" />
 +    </folder>
 +    <folder Name="nRF_Serialization">
 +      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_conn.c" />
@@ -53723,11 +53849,11 @@ index 0000000..745b6a7
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -53737,11 +53863,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -53792,12 +53918,12 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
-index 0000000..b7d508e
+index 0000000..711d0ba
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
-@@ -0,0 +1,277 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+@@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
 +OUTPUT_DIRECTORY := _build
@@ -53825,6 +53951,7 @@ index 0000000..b7d508e
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
 +  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd_core.c \
++  $(SDK_ROOT)/components/libraries/usbd/class/nrf_dfu_trigger/app_usbd_nrf_dfu_trigger.c \
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd_serial_num.c \
 +  $(SDK_ROOT)/components/libraries/usbd/app_usbd_string_desc.c \
 +  $(SDK_ROOT)/components/libraries/util/app_util_platform.c \
@@ -53842,6 +53969,7 @@ index 0000000..b7d508e
 +  $(SDK_ROOT)/components/libraries/strerror/nrf_strerror.c \
 +  $(SDK_ROOT)/modules/nrfx/mdk/system_nrf52840.c \
 +  $(SDK_ROOT)/components/boards/boards.c \
++  $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_conn.c \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/common/ble_dtm_init.c \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c \
@@ -53925,7 +54053,7 @@ index 0000000..b7d508e
 +  $(SDK_ROOT)/components/libraries/strerror \
 +  $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware \
 +  $(SDK_ROOT)/components/libraries/crc16 \
-+  $(SDK_ROOT)/components/ble/ble_dtm \
++  $(SDK_ROOT)/components/libraries/bootloader/dfu \
 +  $(SDK_ROOT)/components/serialization/common \
 +  $(SDK_ROOT)/components/libraries/util \
 +  $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm \
@@ -53947,17 +54075,20 @@ index 0000000..b7d508e
 +  $(SDK_ROOT)/components/libraries/delay \
 +  $(SDK_ROOT)/external/segger_rtt \
 +  $(SDK_ROOT)/components/libraries/atomic_fifo \
++  $(SDK_ROOT)/components/ble/ble_dtm \
 +  $(SDK_ROOT)/components/softdevice/s132v5/headers \
 +  $(SDK_ROOT)/components/libraries/atomic \
 +  $(SDK_ROOT)/components/boards \
 +  $(SDK_ROOT)/components/libraries/memobj \
 +  $(SDK_ROOT)/components/serialization/common/struct_ser/ble \
 +  $(SDK_ROOT)/integration/nrfx \
++  $(SDK_ROOT)/components/libraries/usbd/class/nrf_dfu_trigger \
 +  $(SDK_ROOT)/components/serialization/common/transport \
 +  $(SDK_ROOT)/components/softdevice/common \
 +  $(SDK_ROOT)/components/serialization/common/transport/ser_phy/config \
 +  $(SDK_ROOT)/modules/nrfx/drivers/include \
 +  $(SDK_ROOT)/components/softdevice/s132v5/headers/nrf52 \
++  $(SDK_ROOT)/components/libraries/block_dev \
 +  $(SDK_ROOT)/external/fprintf \
 +  $(SDK_ROOT)/components/libraries/log/src \
 +
@@ -54075,11 +54206,11 @@ index 0000000..b7d508e
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..1a80caf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -54187,12 +54318,12 @@ index 0000000..1a80caf
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
-index 0000000..03a7e92
+index 0000000..4f7851b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
-@@ -0,0 +1,4883 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+@@ -0,0 +1,4986 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
 + *
@@ -54241,6 +54372,102 @@ index 0000000..03a7e92
 +#ifdef USE_APP_CONFIG
 +#include "app_config.h"
 +#endif
++// <h> Application 
++
++//==========================================================
++// <h> application_info - Software Component
++
++//==========================================================
++// <s> APP_NAME - Application name
++#ifndef APP_NAME
++#define APP_NAME "ble-connectivity"
++#endif
++
++// <o> APP_ID - Application ID 
++#ifndef APP_ID
++#define APP_ID 0
++#endif
++
++// <h> APP_VERSION - Application version (semantic versioning)
++
++//==========================================================
++// <o> APP_VERSION_MAJOR - Major version  <0-1000> 
++
++
++#ifndef APP_VERSION_MAJOR
++#define APP_VERSION_MAJOR 0
++#endif
++
++// <o> APP_VERSION_MINOR - Minor version  <0-1000> 
++
++
++#ifndef APP_VERSION_MINOR
++#define APP_VERSION_MINOR 1
++#endif
++
++// <o> APP_VERSION_PATCH - Patch version  <0-1000> 
++
++
++#ifndef APP_VERSION_PATCH
++#define APP_VERSION_PATCH 0
++#endif
++
++// <s> APP_VERSION_PRERELEASE - Prerelease, eg. "-1.alpha"
++
++// <i> If not empty, this string should include the leading hyphen (-).
++// <i> This string might be normalized at run-time to not contain characters
++// <i> illegal in Semantic Versioning.
++#ifndef APP_VERSION_PRERELEASE
++#define APP_VERSION_PRERELEASE ""
++#endif
++
++// <s> APP_VERSION_METADATA - Metadata, e.g. "+some-string.01-01-2018-23-59-59"
++
++// <i> If not empty, this string should include the leading plus (+).
++// <i> This string might be normalized at run-time to not contain characters
++// <i> illegal in Semantic Versioning.
++#ifndef APP_VERSION_METADATA
++#define APP_VERSION_METADATA "+" __DATE__ " " __TIME__
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> Board Definition 
++
++//==========================================================
++// <h> nrf_dfu_trigger_usb - USB DFU Trigger library
++
++//==========================================================
++// <q> NRF_DFU_TRIGGER_USB_USB_SHARED  - Flag indicating whether USB is used for other purposes in the application.
++ 
++
++#ifndef NRF_DFU_TRIGGER_USB_USB_SHARED
++#define NRF_DFU_TRIGGER_USB_USB_SHARED 1
++#endif
++
++// <o> NRF_DFU_TRIGGER_USB_INTERFACE_NUM - The USB interface to use for the DFU Trigger library.  <0-255> 
++
++
++// <i> According to the USB Specification, interface numbers cannot have
++// <i> gaps. Tailor this value to adhere to this limitation.
++
++#ifndef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
++#define NRF_DFU_TRIGGER_USB_INTERFACE_NUM 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
 +// <h> nRF_BLE 
 +
 +//==========================================================
@@ -55360,6 +55587,13 @@ index 0000000..03a7e92
 +
 +// </e>
 +
++// <q> APP_USBD_NRF_DFU_TRIGGER_ENABLED  - app_usbd_nrf_dfu_trigger - USBD Nordic DFU Trigger class
++ 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_ENABLED
++#define APP_USBD_NRF_DFU_TRIGGER_ENABLED 1
++#endif
++
 +// <q> CRC16_ENABLED  - crc16 - CRC16 calculation routines
 + 
 +
@@ -59076,12 +59310,12 @@ index 0000000..03a7e92
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
-index 0000000..437d1f5
+index 0000000..bef124b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
-@@ -0,0 +1,167 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+@@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
 +  <project Name="ble_connectivity_132v5_usb_hci_pca10056">
@@ -59099,7 +59333,7 @@ index 0000000..437d1f5
 +      arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
 +      arm_target_device_name="nRF52840_xxAA"
 +      arm_target_interface_type="SWD"
-+      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/ble/common;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s132v5/headers;../../../../../../components/softdevice/s132v5/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
++      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/ble/common;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/block_dev;../../../../../../components/libraries/bootloader/dfu;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/usbd/class/nrf_dfu_trigger;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s132v5/headers;../../../../../../components/softdevice/s132v5/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
 +      c_preprocessor_definitions="BLE_STACK_SUPPORT_REQD;BOARD_PCA10056;BSP_DEFINES_ONLY;CONFIG_GPIO_AS_PINRESET;FLOAT_ABI_HARD;HCI_TIMER2;INITIALIZE_USER_SECTIONS;NO_VTOR_CONFIG;NRF52840_XXAA;NRF_SD_BLE_API_VERSION=5;S132;SER_CONNECTIVITY;SER_PHY_HCI_USB_CDC;SOFTDEVICE_PRESENT;SWI_DISABLE0;"
 +      debug_target_connection="J-Link"
 +      gcc_entry_point="Reset_Handler"
@@ -59135,6 +59369,7 @@ index 0000000..437d1f5
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd_core.c" />
++      <file file_name="../../../../../../components/libraries/usbd/class/nrf_dfu_trigger/app_usbd_nrf_dfu_trigger.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd_serial_num.c" />
 +      <file file_name="../../../../../../components/libraries/usbd/app_usbd_string_desc.c" />
 +      <file file_name="../../../../../../components/libraries/util/app_util_platform.c" />
@@ -59158,6 +59393,7 @@ index 0000000..437d1f5
 +    </folder>
 +    <folder Name="Board Definition">
 +      <file file_name="../../../../../../components/boards/boards.c" />
++      <file file_name="../../../../../../components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c" />
 +    </folder>
 +    <folder Name="nRF_Serialization">
 +      <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_conn.c" />
@@ -59249,11 +59485,11 @@ index 0000000..437d1f5
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -59263,11 +59499,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -59318,10 +59554,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59340,10 +59576,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 index 793e569..58429c4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 @@ -3839,12 +3839,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -59492,10 +59728,10 @@ index 793e569..58429c4 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..fbea4af 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59505,10 +59741,10 @@ index f64c3a0..fbea4af 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59517,10 +59753,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59539,10 +59775,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 index ba4721d..4802198 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 @@ -4017,12 +4017,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -59691,10 +59927,10 @@ index ba4721d..4802198 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..ebc07bf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59704,10 +59940,10 @@ index a71ed2f..ebc07bf 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59716,10 +59952,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59738,10 +59974,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 index ba4721d..4802198 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 @@ -4017,12 +4017,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -59890,10 +60126,10 @@ index ba4721d..4802198 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..eb97046 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59903,10 +60139,10 @@ index a95d1a5..eb97046 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59915,10 +60151,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59937,10 +60173,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 index 36b0fe4..47afc6b 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 @@ -3723,12 +3723,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -60089,10 +60325,10 @@ index 36b0fe4..47afc6b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..8cbfa44 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -60102,10 +60338,10 @@ index 228cf40..8cbfa44 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60114,11 +60350,55 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-index 07cf7c6..18cdbce 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+index 07cf7c6..e9abd24 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-@@ -177,6 +177,7 @@ CFLAGS += -DNRF52840_XXAA
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+@@ -25,6 +25,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
+   $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
+   $(SDK_ROOT)/components/libraries/usbd/app_usbd_core.c \
++  $(SDK_ROOT)/components/libraries/usbd/class/nrf_dfu_trigger/app_usbd_nrf_dfu_trigger.c \
+   $(SDK_ROOT)/components/libraries/usbd/app_usbd_serial_num.c \
+   $(SDK_ROOT)/components/libraries/usbd/app_usbd_string_desc.c \
+   $(SDK_ROOT)/components/libraries/util/app_util_platform.c \
+@@ -42,6 +43,7 @@ SRC_FILES += \
+   $(SDK_ROOT)/components/libraries/strerror/nrf_strerror.c \
+   $(SDK_ROOT)/modules/nrfx/mdk/system_nrf52840.c \
+   $(SDK_ROOT)/components/boards/boards.c \
++  $(SDK_ROOT)/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c \
+   $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_conn.c \
+   $(SDK_ROOT)/components/serialization/connectivity/codecs/common/ble_dtm_init.c \
+   $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c \
+@@ -123,7 +125,7 @@ INC_FOLDERS += \
+   $(SDK_ROOT)/components/serialization/connectivity/codecs/ble/middleware \
+   $(SDK_ROOT)/integration/nrfx/legacy \
+   $(SDK_ROOT)/components/libraries/crc16 \
+-  $(SDK_ROOT)/components/ble/ble_dtm \
++  $(SDK_ROOT)/components/libraries/bootloader/dfu \
+   $(SDK_ROOT)/components/serialization/common \
+   $(SDK_ROOT)/components/libraries/util \
+   $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm \
+@@ -145,15 +147,18 @@ INC_FOLDERS += \
+   $(SDK_ROOT)/components/libraries/delay \
+   $(SDK_ROOT)/external/segger_rtt \
+   $(SDK_ROOT)/components/libraries/atomic_fifo \
++  $(SDK_ROOT)/components/ble/ble_dtm \
+   $(SDK_ROOT)/components/libraries/atomic \
+   $(SDK_ROOT)/components/boards \
+   $(SDK_ROOT)/components/libraries/memobj \
+   $(SDK_ROOT)/components/serialization/common/struct_ser/ble \
+   $(SDK_ROOT)/integration/nrfx \
++  $(SDK_ROOT)/components/libraries/usbd/class/nrf_dfu_trigger \
+   $(SDK_ROOT)/components/serialization/common/transport \
+   $(SDK_ROOT)/components/softdevice/common \
+   $(SDK_ROOT)/components/softdevice/s140/headers/nrf52 \
+   $(SDK_ROOT)/modules/nrfx/drivers/include \
++  $(SDK_ROOT)/components/libraries/block_dev \
+   $(SDK_ROOT)/external/fprintf \
+   $(SDK_ROOT)/components/libraries/log/src \
+ 
+@@ -177,6 +182,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
  CFLAGS += -DSER_CONNECTIVITY
@@ -60126,7 +60406,7 @@ index 07cf7c6..18cdbce 100644
  CFLAGS += -DSOFTDEVICE_PRESENT
  CFLAGS += -DSWI_DISABLE0
  CFLAGS += -mcpu=cortex-m4
-@@ -205,6 +206,7 @@ ASMFLAGS += -DNRF52840_XXAA
+@@ -205,6 +211,7 @@ ASMFLAGS += -DNRF52840_XXAA
  ASMFLAGS += -DNRF_SD_BLE_API_VERSION=6
  ASMFLAGS += -DS140
  ASMFLAGS += -DSER_CONNECTIVITY
@@ -60134,10 +60414,10 @@ index 07cf7c6..18cdbce 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -60156,11 +60436,114 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-index 994863b..0bcfe3e 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+index 994863b..988b9b0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-@@ -901,7 +901,7 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+@@ -46,6 +46,102 @@
+ #ifdef USE_APP_CONFIG
+ #include "app_config.h"
+ #endif
++// <h> Application 
++
++//==========================================================
++// <h> application_info - Software Component
++
++//==========================================================
++// <s> APP_NAME - Application name
++#ifndef APP_NAME
++#define APP_NAME "ble-connectivity"
++#endif
++
++// <o> APP_ID - Application ID 
++#ifndef APP_ID
++#define APP_ID 0
++#endif
++
++// <h> APP_VERSION - Application version (semantic versioning)
++
++//==========================================================
++// <o> APP_VERSION_MAJOR - Major version  <0-1000> 
++
++
++#ifndef APP_VERSION_MAJOR
++#define APP_VERSION_MAJOR 0
++#endif
++
++// <o> APP_VERSION_MINOR - Minor version  <0-1000> 
++
++
++#ifndef APP_VERSION_MINOR
++#define APP_VERSION_MINOR 1
++#endif
++
++// <o> APP_VERSION_PATCH - Patch version  <0-1000> 
++
++
++#ifndef APP_VERSION_PATCH
++#define APP_VERSION_PATCH 0
++#endif
++
++// <s> APP_VERSION_PRERELEASE - Prerelease, eg. "-1.alpha"
++
++// <i> If not empty, this string should include the leading hyphen (-).
++// <i> This string might be normalized at run-time to not contain characters
++// <i> illegal in Semantic Versioning.
++#ifndef APP_VERSION_PRERELEASE
++#define APP_VERSION_PRERELEASE ""
++#endif
++
++// <s> APP_VERSION_METADATA - Metadata, e.g. "+some-string.01-01-2018-23-59-59"
++
++// <i> If not empty, this string should include the leading plus (+).
++// <i> This string might be normalized at run-time to not contain characters
++// <i> illegal in Semantic Versioning.
++#ifndef APP_VERSION_METADATA
++#define APP_VERSION_METADATA "+" __DATE__ " " __TIME__
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
++// <h> Board Definition 
++
++//==========================================================
++// <h> nrf_dfu_trigger_usb - USB DFU Trigger library
++
++//==========================================================
++// <q> NRF_DFU_TRIGGER_USB_USB_SHARED  - Flag indicating whether USB is used for other purposes in the application.
++ 
++
++#ifndef NRF_DFU_TRIGGER_USB_USB_SHARED
++#define NRF_DFU_TRIGGER_USB_USB_SHARED 1
++#endif
++
++// <o> NRF_DFU_TRIGGER_USB_INTERFACE_NUM - The USB interface to use for the DFU Trigger library.  <0-255> 
++
++
++// <i> According to the USB Specification, interface numbers cannot have
++// <i> gaps. Tailor this value to adhere to this limitation.
++
++#ifndef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
++#define NRF_DFU_TRIGGER_USB_INTERFACE_NUM 0
++#endif
++
++// </h> 
++//==========================================================
++
++// </h> 
++//==========================================================
++
+ // <h> nRF_BLE 
+ 
+ //==========================================================
+@@ -901,7 +997,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
  #ifndef APP_USBD_PID
@@ -60169,7 +60552,21 @@ index 994863b..0bcfe3e 100644
  #endif
  
  // <o> APP_USBD_DEVICE_VER_MAJOR - Device version, major part.  <0-99> 
-@@ -4261,12 +4261,12 @@
+@@ -1144,6 +1240,13 @@
+ 
+ // </e>
+ 
++// <q> APP_USBD_NRF_DFU_TRIGGER_ENABLED  - app_usbd_nrf_dfu_trigger - USBD Nordic DFU Trigger class
++ 
++
++#ifndef APP_USBD_NRF_DFU_TRIGGER_ENABLED
++#define APP_USBD_NRF_DFU_TRIGGER_ENABLED 1
++#endif
++
+ // <q> CRC16_ENABLED  - crc16 - CRC16 calculation routines
+  
+ 
+@@ -4261,12 +4364,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
  #ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
@@ -60184,7 +60581,7 @@ index 994863b..0bcfe3e 100644
  #endif
  
  // <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count. 
-@@ -4567,132 +4567,6 @@
+@@ -4567,132 +4670,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
  
@@ -60317,15 +60714,17 @@ index 994863b..0bcfe3e 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-index 571ebbb..4ffca5a 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+index 571ebbb..6904047 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-@@ -16,7 +16,7 @@
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+@@ -15,8 +15,8 @@
+       arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
-       c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s140/headers;../../../../../../components/softdevice/s140/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
+-      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s140/headers;../../../../../../components/softdevice/s140/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
 -      c_preprocessor_definitions="BLE_STACK_SUPPORT_REQD;BOARD_PCA10056;BSP_DEFINES_ONLY;CONFIG_GPIO_AS_PINRESET;FLOAT_ABI_HARD;HCI_TIMER2;INITIALIZE_USER_SECTIONS;NO_VTOR_CONFIG;NRF52840_XXAA;NRF_SD_BLE_API_VERSION=6;S140;SER_CONNECTIVITY;SOFTDEVICE_PRESENT;SWI_DISABLE0;"
++      c_user_include_directories="../../../config;../../../../../../components;../../../../../../components/ble/ble_dtm;../../../../../../components/boards;../../../../../../components/drivers_nrf/usbd;../../../../../../components/libraries/atomic;../../../../../../components/libraries/atomic_fifo;../../../../../../components/libraries/balloc;../../../../../../components/libraries/block_dev;../../../../../../components/libraries/bootloader/dfu;../../../../../../components/libraries/bsp;../../../../../../components/libraries/crc16;../../../../../../components/libraries/delay;../../../../../../components/libraries/experimental_section_vars;../../../../../../components/libraries/log;../../../../../../components/libraries/log/src;../../../../../../components/libraries/memobj;../../../../../../components/libraries/queue;../../../../../../components/libraries/ringbuf;../../../../../../components/libraries/scheduler;../../../../../../components/libraries/strerror;../../../../../../components/libraries/timer;../../../../../../components/libraries/usbd;../../../../../../components/libraries/usbd/class/cdc;../../../../../../components/libraries/usbd/class/cdc/acm;../../../../../../components/libraries/usbd/class/nrf_dfu_trigger;../../../../../../components/libraries/util;../../../../../../components/serialization/common;../../../../../../components/serialization/common/struct_ser/ble;../../../../../../components/serialization/common/transport;../../../../../../components/serialization/common/transport/ser_phy;../../../../../../components/serialization/common/transport/ser_phy/config;../../../../../../components/serialization/connectivity;../../../../../../components/serialization/connectivity/codecs/ble/middleware;../../../../../../components/serialization/connectivity/codecs/ble/serializers;../../../../../../components/serialization/connectivity/codecs/common;../../../../../../components/serialization/connectivity/hal;../../../../../../components/softdevice/common;../../../../../../components/softdevice/s140/headers;../../../../../../components/softdevice/s140/headers/nrf52;../../../../../../components/toolchain/cmsis/include;../../../../../../external/fprintf;../../../../../../external/segger_rtt;../../../../../../external/utf_converter;../../../../../../integration/nrfx;../../../../../../integration/nrfx/legacy;../../../../../../modules/nrfx;../../../../../../modules/nrfx/drivers/include;../../../../../../modules/nrfx/hal;../../../../../../modules/nrfx/mdk;../config;"
 +      c_preprocessor_definitions="BLE_STACK_SUPPORT_REQD;BOARD_PCA10056;BSP_DEFINES_ONLY;CONFIG_GPIO_AS_PINRESET;FLOAT_ABI_HARD;HCI_TIMER2;INITIALIZE_USER_SECTIONS;NO_VTOR_CONFIG;NRF52840_XXAA;NRF_SD_BLE_API_VERSION=6;S140;SER_CONNECTIVITY;SER_PHY_HCI_USB_CDC;SOFTDEVICE_PRESENT;SWI_DISABLE0;"
        debug_target_connection="J-Link"
        gcc_entry_point="Reset_Handler"
@@ -60339,10 +60738,26 @@ index 571ebbb..4ffca5a 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -51,6 +51,7 @@
+       <file file_name="../../../../../../components/libraries/usbd/app_usbd.c" />
+       <file file_name="../../../../../../components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c" />
+       <file file_name="../../../../../../components/libraries/usbd/app_usbd_core.c" />
++      <file file_name="../../../../../../components/libraries/usbd/class/nrf_dfu_trigger/app_usbd_nrf_dfu_trigger.c" />
+       <file file_name="../../../../../../components/libraries/usbd/app_usbd_serial_num.c" />
+       <file file_name="../../../../../../components/libraries/usbd/app_usbd_string_desc.c" />
+       <file file_name="../../../../../../components/libraries/util/app_util_platform.c" />
+@@ -74,6 +75,7 @@
+     </folder>
+     <folder Name="Board Definition">
+       <file file_name="../../../../../../components/boards/boards.c" />
++      <file file_name="../../../../../../components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c" />
+     </folder>
+     <folder Name="nRF_Serialization">
+       <file file_name="../../../../../../components/serialization/connectivity/codecs/ble/serializers/ble_conn.c" />
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60351,11 +60766,11 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..a2942b9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,281 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -60638,11 +61053,11 @@ index 0000000..a2942b9
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -60750,11 +61165,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..e9d9297
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,4965 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -65721,11 +66136,11 @@ index 0000000..e9d9297
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..33a4962
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,168 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -65895,11 +66310,11 @@ index 0000000..33a4962
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -65909,11 +66324,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -65964,10 +66379,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..bb6ccf2 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -182,6 +182,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
@@ -65984,10 +66399,10 @@ index 33053bc..bb6ccf2 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -66006,10 +66421,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 index bb385de..e9d9297 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -133,7 +133,7 @@
  // <i> gaps. Tailor this value to adhere to this limitation.
  
@@ -66176,10 +66591,10 @@ index bb385de..e9d9297 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..2c772bc 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -66198,10 +66613,10 @@ index c7771fd..2c772bc 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_a184e1b/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -66210,10 +66625,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_c9fc670/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_a184e1b/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_c9fc670/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_a184e1b/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -66288,11 +66703,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_c9fc670/examples/readme.txt nRF5_SDK_15.2.0_c9fc670/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_a184e1b/examples/readme.txt nRF5_SDK_15.2.0_a184e1b/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_c9fc670/examples/readme.txt
++++ nRF5_SDK_15.2.0_a184e1b/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -66308,10 +66723,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_c9fc670/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_a184e1b/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_c9fc670/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_a184e1b/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif
@@ -66381,9 +66796,3 @@ index bba3d13..139d375 100644
      if (nrfx_power_usb_handler_get() != NULL)
      {
          ret_code_t err_code = nrf_drv_power_sd_usbevt_enable(true);
-diff --git nRF5_SDK_15.2.0_c9fc670/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_c9fc670.patch nRF5_SDK_15.2.0_c9fc670/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_c9fc670.patch
-new file mode 100644
-index 0000000..e69de29
-diff --git nRF5_SDK_15.2.0_c9fc670/patch-summary.txt nRF5_SDK_15.2.0_c9fc670/patch-summary.txt
-new file mode 100644
-index 0000000..e69de29

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_0ca4156/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_c9fc670/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_c9fc670/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -11,10 +11,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -41,10 +41,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -137,10 +137,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -290,10 +290,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -365,10 +365,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -385,10 +385,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -452,10 +452,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -468,10 +468,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_0ca4156/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -494,10 +494,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_0ca4156/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -528,10 +528,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -575,10 +575,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -631,10 +631,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -682,10 +682,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -718,10 +718,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -731,10 +731,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -750,10 +750,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1049,10 +1049,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1062,10 +1062,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1150,10 +1150,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1265,10 +1265,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1287,10 +1287,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1339,10 +1339,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1360,10 +1360,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1393,10 +1393,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1415,10 +1415,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1466,10 +1466,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1554,10 +1554,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1589,10 +1589,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1610,10 +1610,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1624,10 +1624,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1664,10 +1664,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1700,10 +1700,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1723,10 +1723,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1739,10 +1739,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1839,10 +1839,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_c9fc670/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1863,10 +1863,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_0ca4156/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1893,10 +1893,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_0ca4156/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -1973,10 +1973,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2003,11 +2003,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2690,11 +2690,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2786,11 +2786,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4709,11 +4709,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4935,11 +4935,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5601,11 +5601,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6385,11 +6385,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6522,11 +6522,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6730,11 +6730,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6874,11 +6874,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7093,11 +7093,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7316,11 +7316,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7409,11 +7409,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7482,11 +7482,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7570,11 +7570,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8061,11 +8061,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8095,11 +8095,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8432,11 +8432,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9344,11 +9344,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9438,11 +9438,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11363,11 +11363,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12043,11 +12043,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12595,20 +12595,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20304,11 +20304,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20343,11 +20343,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20385,11 +20385,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21019,11 +21019,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21116,11 +21116,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23311,11 +23311,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23545,11 +23545,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24258,11 +24258,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25105,11 +25105,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25246,11 +25246,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25759,11 +25759,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25921,11 +25921,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26142,11 +26142,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26389,11 +26389,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26485,11 +26485,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26561,11 +26561,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26652,11 +26652,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27144,11 +27144,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27178,11 +27178,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27541,11 +27541,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28481,11 +28481,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28577,20 +28577,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36435,11 +36435,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36474,11 +36474,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_c9fc670/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36516,10 +36516,10 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/main.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/main.c
 index fc7996c..a56e94c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/main.c
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/main.c
 @@ -57,13 +57,13 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
@@ -36692,10 +36692,10 @@ index fc7996c..a56e94c 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index 611a3b6..0a1645f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36716,10 +36716,10 @@ index 611a3b6..0a1645f 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..dfd12e6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -4133,132 +4133,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -36853,10 +36853,10 @@ index c5caa64..dfd12e6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -36868,10 +36868,10 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -36880,10 +36880,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36904,10 +36904,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..ada8ae6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -4339,132 +4339,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -37041,10 +37041,10 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37056,10 +37056,10 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37068,10 +37068,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37092,10 +37092,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..ada8ae6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -4339,132 +4339,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -37229,10 +37229,10 @@ index 878122b..ada8ae6 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37244,10 +37244,10 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37256,10 +37256,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37280,10 +37280,10 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..dcef5bd 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -4017,132 +4017,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -37417,10 +37417,10 @@ index 17cad13..dcef5bd 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37432,10 +37432,10 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37444,11 +37444,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -37712,11 +37712,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..7110f07
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -37824,11 +37824,11 @@ index 0000000..7110f07
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..dfd12e6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4428 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -42258,11 +42258,11 @@ index 0000000..dfd12e6
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -42418,11 +42418,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -42432,11 +42432,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -42487,11 +42487,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -42756,11 +42756,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..9e0c093
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -42868,11 +42868,11 @@ index 0000000..9e0c093
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..d464764
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4449 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -47323,11 +47323,11 @@ index 0000000..d464764
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -47484,11 +47484,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -47498,11 +47498,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -47553,10 +47553,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index e8a3735..7b95e77 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47575,10 +47575,10 @@ index e8a3735..7b95e77 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..b33d1e8 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -3998,132 +3998,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47712,10 +47712,10 @@ index 6539e77..b33d1e8 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47725,10 +47725,10 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47737,10 +47737,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47759,10 +47759,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..24057c5 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -4148,132 +4148,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -47896,10 +47896,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -47909,10 +47909,10 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -47921,10 +47921,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -47943,10 +47943,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..24057c5 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -4148,132 +4148,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48080,10 +48080,10 @@ index 4adb2af..24057c5 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48093,10 +48093,10 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48105,10 +48105,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48127,10 +48127,10 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..fce649b 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -3882,132 +3882,6 @@
  #define NFC_BLE_PAIR_LIB_BLE_OBSERVER_PRIO 1
  #endif
@@ -48264,10 +48264,10 @@ index 7b74df4..fce649b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48277,10 +48277,10 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48289,11 +48289,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..70d9b8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,276 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -48571,11 +48571,11 @@ index 0000000..70d9b8b
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -48683,11 +48683,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..0bcfe3e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,4862 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -53551,11 +53551,11 @@ index 0000000..0bcfe3e
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..745b6a7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 @@ -0,0 +1,166 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
@@ -53723,11 +53723,11 @@ index 0000000..745b6a7
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -53737,11 +53737,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -53792,11 +53792,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..b7d508e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 @@ -0,0 +1,277 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -54075,11 +54075,11 @@ index 0000000..b7d508e
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..1a80caf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -54187,11 +54187,11 @@ index 0000000..1a80caf
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..03a7e92
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 @@ -0,0 +1,4883 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -59076,11 +59076,11 @@ index 0000000..03a7e92
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..437d1f5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 @@ -0,0 +1,167 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
@@ -59249,11 +59249,11 @@ index 0000000..437d1f5
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -59263,11 +59263,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -59318,10 +59318,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59340,10 +59340,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 index 793e569..58429c4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 @@ -3839,12 +3839,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -59492,10 +59492,10 @@ index 793e569..58429c4 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..fbea4af 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59505,10 +59505,10 @@ index f64c3a0..fbea4af 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59517,10 +59517,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59539,10 +59539,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 index ba4721d..4802198 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 @@ -4017,12 +4017,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -59691,10 +59691,10 @@ index ba4721d..4802198 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..ebc07bf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59704,10 +59704,10 @@ index a71ed2f..ebc07bf 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59716,10 +59716,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59738,10 +59738,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 index ba4721d..4802198 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 @@ -4017,12 +4017,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -59890,10 +59890,10 @@ index ba4721d..4802198 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..eb97046 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -59903,10 +59903,10 @@ index a95d1a5..eb97046 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -59915,10 +59915,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -59937,10 +59937,10 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 index 36b0fe4..47afc6b 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 @@ -3723,12 +3723,12 @@
  
  // <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links. 
@@ -60089,10 +60089,10 @@ index 36b0fe4..47afc6b 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..8cbfa44 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -60102,10 +60102,10 @@ index 228cf40..8cbfa44 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60114,10 +60114,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 index 07cf7c6..18cdbce 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -177,6 +177,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
@@ -60134,10 +60134,10 @@ index 07cf7c6..18cdbce 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -60156,10 +60156,10 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 index 994863b..0bcfe3e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -901,7 +901,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
@@ -60317,10 +60317,10 @@ index 994863b..0bcfe3e 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 index 571ebbb..4ffca5a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -60339,10 +60339,10 @@ index 571ebbb..4ffca5a 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -60351,11 +60351,11 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..a2942b9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,281 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -60638,11 +60638,11 @@ index 0000000..a2942b9
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
 index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -60750,11 +60750,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..e9d9297
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,4965 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -65721,11 +65721,11 @@ index 0000000..e9d9297
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..33a4962
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,168 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -65895,11 +65895,11 @@ index 0000000..33a4962
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -65909,11 +65909,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
 index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -65964,10 +65964,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..bb6ccf2 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -182,6 +182,7 @@ CFLAGS += -DNRF52840_XXAA
  CFLAGS += -DNRF_SD_BLE_API_VERSION=6
  CFLAGS += -DS140
@@ -65984,10 +65984,10 @@ index 33053bc..bb6ccf2 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -66006,10 +66006,19 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-index bb385de..4707ba1 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+index bb385de..e9d9297 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+@@ -133,7 +133,7 @@
+ // <i> gaps. Tailor this value to adhere to this limitation.
+ 
+ #ifndef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
+-#define NRF_DFU_TRIGGER_USB_INTERFACE_NUM 2
++#define NRF_DFU_TRIGGER_USB_INTERFACE_NUM 0
+ #endif
+ 
+ // </h> 
 @@ -997,7 +997,7 @@
  // <i> Note: This value is not editable in Configuration Wizard.
  // <i> Selected Product ID
@@ -66167,10 +66176,10 @@ index bb385de..4707ba1 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..2c772bc 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -66189,10 +66198,10 @@ index c7771fd..2c772bc 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_0ca4156/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_c9fc670/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -66201,10 +66210,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_0ca4156/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_c9fc670/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_0ca4156/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_c9fc670/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -66279,11 +66288,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_0ca4156/examples/readme.txt nRF5_SDK_15.2.0_0ca4156/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_c9fc670/examples/readme.txt nRF5_SDK_15.2.0_c9fc670/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_0ca4156/examples/readme.txt
++++ nRF5_SDK_15.2.0_c9fc670/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -66299,10 +66308,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_0ca4156/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_c9fc670/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_0ca4156/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_c9fc670/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif
@@ -66372,3 +66381,9 @@ index bba3d13..139d375 100644
      if (nrfx_power_usb_handler_get() != NULL)
      {
          ret_code_t err_code = nrf_drv_power_sd_usbevt_enable(true);
+diff --git nRF5_SDK_15.2.0_c9fc670/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_c9fc670.patch nRF5_SDK_15.2.0_c9fc670/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_c9fc670.patch
+new file mode 100644
+index 0000000..e69de29
+diff --git nRF5_SDK_15.2.0_c9fc670/patch-summary.txt nRF5_SDK_15.2.0_c9fc670/patch-summary.txt
+new file mode 100644
+index 0000000..e69de29

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_39354f6/components/boards/pca10056.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_f1f9329/components/boards/pca10056.h
 index 6b3f92f..7fbfbca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h
-+++ nRF5_SDK_15.2.0_39354f6/components/boards/pca10056.h
++++ nRF5_SDK_15.2.0_f1f9329/components/boards/pca10056.h
 @@ -90,6 +90,8 @@ extern "C" {
  #define RTS_PIN_NUMBER 5
  #define HWFC           true
@@ -11,10 +11,10 @@ index 6b3f92f..7fbfbca 100644
  #define BSP_QSPI_SCK_PIN   19
  #define BSP_QSPI_CSN_PIN   17
  #define BSP_QSPI_IO0_PIN   20
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 index 755581d..23b34db 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
-+++ nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
++++ nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 @@ -50,10 +50,6 @@
  #include "nrf_log.h"
  NRF_LOG_MODULE_REGISTER();
@@ -62,10 +62,10 @@ index 755581d..23b34db 100644
      m_dfu_info.wAddress       = CODE_START;
      m_dfu_info.wFirmwareSize  = CODE_SIZE;
      m_dfu_info.wVersionMajor  = APP_VERSION_MAJOR;
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 index 5906a80..8befbe9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
-+++ nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
++++ nRF5_SDK_15.2.0_f1f9329/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 @@ -63,11 +63,12 @@
   *
   * @note  If @ref APP_USBD_CONFIG_EVENT_QUEUE_ENABLE is on (1), USB events must be handled manually.
@@ -80,10 +80,10 @@ index 5906a80..8befbe9 100644
  
  /** @} */
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_39354f6/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_f1f9329/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_39354f6/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_f1f9329/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -93,10 +93,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -123,10 +123,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -219,10 +219,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -372,10 +372,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -447,10 +447,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -467,10 +467,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -534,10 +534,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -550,10 +550,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -576,10 +576,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -610,10 +610,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -657,10 +657,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -713,10 +713,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -764,10 +764,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -800,10 +800,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -813,10 +813,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -832,10 +832,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1131,10 +1131,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1144,10 +1144,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1232,10 +1232,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1347,10 +1347,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1369,10 +1369,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1421,10 +1421,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1442,10 +1442,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1475,10 +1475,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1497,10 +1497,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1548,10 +1548,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1636,10 +1636,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1671,10 +1671,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1692,10 +1692,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1706,10 +1706,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1746,10 +1746,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1782,10 +1782,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1805,10 +1805,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1821,10 +1821,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1921,10 +1921,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_f1f9329/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1945,10 +1945,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1975,10 +1975,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -2055,10 +2055,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2085,11 +2085,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2772,11 +2772,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2868,11 +2868,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4791,11 +4791,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5017,11 +5017,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5683,11 +5683,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6467,11 +6467,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6604,11 +6604,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6812,11 +6812,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6956,11 +6956,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7175,11 +7175,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7398,11 +7398,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7491,11 +7491,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7564,11 +7564,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7652,11 +7652,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8143,11 +8143,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8177,11 +8177,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8514,11 +8514,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9426,11 +9426,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9520,11 +9520,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11445,11 +11445,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12125,11 +12125,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12677,20 +12677,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20386,11 +20386,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20425,11 +20425,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20467,11 +20467,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21101,11 +21101,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21198,11 +21198,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23393,11 +23393,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23627,11 +23627,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24340,11 +24340,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25187,11 +25187,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25328,11 +25328,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25841,11 +25841,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26003,11 +26003,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26224,11 +26224,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26471,11 +26471,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26567,11 +26567,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26643,11 +26643,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26734,11 +26734,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27226,11 +27226,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27260,11 +27260,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27623,11 +27623,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28563,11 +28563,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28659,20 +28659,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36517,11 +36517,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36556,11 +36556,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_f1f9329/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36598,11 +36598,11 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/main.c
-index fc7996c..811dcc4 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/main.c
+index fc7996c..a833d6a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/main.c
-@@ -57,22 +57,28 @@
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/main.c
+@@ -57,23 +57,34 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
  #include "nrf_drv_clock.h"
@@ -36613,28 +36613,36 @@ index fc7996c..811dcc4 100644
  #include "nrf_log_default_backends.h"
  
  #include "ser_phy_debug_comm.h"
--
 +#include "ser_config.h"
- #if defined(APP_USBD_ENABLED) && APP_USBD_ENABLED
- #include "app_usbd_serial_num.h"
+ 
+-#if defined(APP_USBD_ENABLED) && APP_USBD_ENABLED
+-#include "app_usbd_serial_num.h"
 -#ifdef BOARD_PCA10059
-+#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
++#if defined(NRF_DFU_TRIGGER_USB_INTERFACE_NUM) && defined(QSPI_ENABLED)
++#define BOARD_DETECTION 1
++#else
++#define BOARD_DETECTION 0
++#endif
++
++#if BOARD_DETECTION
  #include "nrf_dfu_trigger_usb.h"
++#include "nrf_drv_qspi.h"
++#define PCA10056_PIN_RESET 24
++#define PCA10059_PIN_RESET 19
  #endif
 +
-+#ifdef QSPI_ENABLED
-+#include "nrf_drv_qspi.h"
-+#endif
++
++#if defined(APP_USBD_ENABLED) && APP_USBD_ENABLED
++#include "app_usbd_serial_num.h"
  #include "app_usbd.h"
  
  static volatile bool m_usb_started;
  
-+#define PCA10056_PIN_RESET 24
-+#define PCA10059_PIN_RESET 19
- 
+-
  static void usbd_user_evt_handler(app_usbd_event_type_t event)
  {
-@@ -120,9 +126,6 @@ static void usbd_init(void)
+     switch (event)
+@@ -120,9 +131,6 @@ static void usbd_init(void)
  
  static void usbd_enable(void)
  {
@@ -36644,7 +36652,7 @@ index fc7996c..811dcc4 100644
      APP_ERROR_CHECK(app_usbd_power_events_enable()); 
  
      /* Process USB events until USB is started. This is related to the fact that
-@@ -138,16 +141,68 @@ static void usbd_enable(void)
+@@ -138,16 +146,68 @@ static void usbd_enable(void)
  }
  #endif //APP_USBD_ENABLED
  
@@ -36716,7 +36724,7 @@ index fc7996c..811dcc4 100644
      while (app_usbd_event_queue_process())
      {
          /* Nothing to do */
-@@ -155,18 +210,50 @@ static void on_idle(void)
+@@ -155,18 +215,48 @@ static void on_idle(void)
  #endif
  }
  
@@ -36745,11 +36753,9 @@ index fc7996c..811dcc4 100644
      NRF_LOG_INFO("BLE connectivity started");
  
 -    bsp_board_init(BSP_INIT_LEDS);
-+#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
++#if BOARD_DETECTION
 +    uint32_t pin_reset = PCA10059_PIN_RESET;
-+#endif
 +
-+#if QSPI_ENABLED
 +    nrf_drv_qspi_config_t config = NRF_DRV_QSPI_DEFAULT_CONFIG;
 +
 +    //Using qspi memory to de
@@ -36765,11 +36771,11 @@ index fc7996c..811dcc4 100644
 +        pin_reset = PCA10059_PIN_RESET;
 +        //pca10059 assumed when no qspi memory
 +    }
-+#endif
++#endif //BOARD_DETECTION
  
  #if (defined(SER_PHY_HCI_DEBUG_ENABLE) || defined(SER_PHY_DEBUG_APP_ENABLE))
      debug_init(NULL);
-@@ -192,6 +279,8 @@ int main(void)
+@@ -192,6 +282,8 @@ int main(void)
      }
  
      nrf_drv_clock_hfclk_request(NULL);
@@ -36778,18 +36784,18 @@ index fc7996c..811dcc4 100644
      while (!nrf_drv_clock_hfclk_is_running())
      {}
  
-@@ -199,6 +288,10 @@ int main(void)
+@@ -199,6 +291,10 @@ int main(void)
      usbd_init();
  #endif
  
-+#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
-+    APP_ERROR_CHECK(nrf_dfu_trigger_usb_init(pin_reset));
++#if BOARD_DETECTION
++        APP_ERROR_CHECK(nrf_dfu_trigger_usb_init(pin_reset));
 +#endif
 +
      /* Open serialization HAL Transport layer and subscribe for HAL Transport events. */
      err_code = ser_hal_transport_open(ser_conn_hal_transport_event_handle);
      APP_ERROR_CHECK(err_code);
-@@ -210,12 +303,14 @@ int main(void)
+@@ -210,12 +306,14 @@ int main(void)
      err_code = nrf_sdh_enable_request();
      APP_ERROR_CHECK(err_code);
  
@@ -36805,7 +36811,7 @@ index fc7996c..811dcc4 100644
          /* Process SoftDevice events. */
          app_sched_execute();
          if (nrf_sdh_is_suspended())
-@@ -235,6 +330,7 @@ int main(void)
+@@ -235,6 +333,7 @@ int main(void)
          APP_ERROR_CHECK(err_code);
  
          on_idle();
@@ -36813,10 +36819,10 @@ index fc7996c..811dcc4 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index 611a3b6..65e784e 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index 611a3b6..0a1645f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36837,36 +36843,10 @@ index 611a3b6..65e784e 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..19a16d1 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -37137,10 +37117,10 @@ index c5caa64..19a16d1 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37152,21 +37132,10 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37175,10 +37144,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..d1bb196 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37199,36 +37168,10 @@ index f67446c..d1bb196 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37499,10 +37442,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37514,21 +37457,10 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37537,10 +37469,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..d1bb196 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37561,36 +37493,10 @@ index f67446c..d1bb196 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37861,10 +37767,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37876,21 +37782,10 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37899,10 +37794,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..d1bb196 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..57c5fcf 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37923,36 +37818,10 @@ index f67446c..d1bb196 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..cad5969 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -38223,10 +38092,10 @@ index 17cad13..cad5969 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -38238,21 +38107,10 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -38261,11 +38119,11 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -38529,11 +38387,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..7d40943
+index 0000000..7110f07
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -38613,6 +38471,12 @@ index 0000000..7d40943
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -38625,12 +38489,6 @@ index 0000000..7d40943
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -38641,11 +38499,11 @@ index 0000000..7d40943
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..19a16d1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4558 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -43205,11 +43063,11 @@ index 0000000..19a16d1
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -43365,11 +43223,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -43379,11 +43237,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -43398,9 +43256,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -43434,11 +43292,11 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -43703,11 +43561,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..04f6cc8
+index 0000000..9e0c093
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -43787,6 +43645,12 @@ index 0000000..04f6cc8
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -43799,12 +43663,6 @@ index 0000000..04f6cc8
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -43815,11 +43673,11 @@ index 0000000..04f6cc8
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..ffe8c67
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4579 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -48400,11 +48258,11 @@ index 0000000..ffe8c67
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -48561,11 +48419,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -48575,11 +48433,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -48594,9 +48452,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -48630,10 +48488,10 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index e8a3735..9a410b0 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index e8a3735..7b95e77 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48652,36 +48510,10 @@ index e8a3735..9a410b0 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..3119381 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -48952,10 +48784,10 @@ index 6539e77..3119381 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48965,21 +48797,10 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48988,10 +48809,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..9ce3ba9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49010,36 +48831,10 @@ index 40d23f1..9ce3ba9 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49310,10 +49105,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49323,21 +49118,10 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49346,10 +49130,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..9ce3ba9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49368,36 +49152,10 @@ index 40d23f1..9ce3ba9 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49668,10 +49426,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49681,21 +49439,10 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49704,10 +49451,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..9ce3ba9 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..6b8f0fb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49726,36 +49473,10 @@ index 40d23f1..9ce3ba9 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..f0c345a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -50026,10 +49747,10 @@ index 7b74df4..f0c345a 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -50039,21 +49760,10 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -50062,11 +49772,11 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..29138b1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -50350,11 +50060,11 @@ index 0000000..29138b1
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..12fd23c
+index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -50434,6 +50144,12 @@ index 0000000..12fd23c
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -50446,12 +50162,6 @@ index 0000000..12fd23c
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -50462,11 +50172,11 @@ index 0000000..12fd23c
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..14a8586
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -55691,11 +55401,11 @@ index 0000000..14a8586
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..bd45579
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
@@ -55866,11 +55576,11 @@ index 0000000..bd45579
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -55880,11 +55590,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -55899,9 +55609,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -55935,11 +55645,11 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..8d850ae
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 @@ -0,0 +1,283 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -56224,11 +55934,11 @@ index 0000000..8d850ae
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..3d81a92
+index 0000000..1a80caf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -56308,6 +56018,12 @@ index 0000000..3d81a92
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -56320,12 +56036,6 @@ index 0000000..3d81a92
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -56336,11 +56046,11 @@ index 0000000..3d81a92
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..f0b6542
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5244 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -61586,11 +61296,11 @@ index 0000000..f0b6542
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..d93607c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 @@ -0,0 +1,170 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
@@ -61762,11 +61472,11 @@ index 0000000..d93607c
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -61776,11 +61486,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -61795,9 +61505,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -61831,10 +61541,10 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 index 87059cc..0d8cc08 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 @@ -85,6 +85,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -61843,10 +61553,10 @@ index 87059cc..0d8cc08 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..6816cb2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -61865,36 +61575,10 @@ index b877f5a..6816cb2 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 index 793e569..d43945e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -62315,10 +61999,10 @@ index 793e569..d43945e 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..0221ede 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62336,21 +62020,10 @@ index f64c3a0..0221ede 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62359,10 +62032,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 index f5648fe..98f1192 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62371,10 +62044,10 @@ index f5648fe..98f1192 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..5af9fbd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62393,36 +62066,10 @@ index d3acaad..5af9fbd 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62843,10 +62490,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..430528f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62864,21 +62511,10 @@ index a71ed2f..430528f 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62887,10 +62523,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 index e498e6c..1147b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62899,10 +62535,10 @@ index e498e6c..1147b6f 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..5af9fbd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62921,36 +62557,10 @@ index d3acaad..5af9fbd 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -63371,10 +62981,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..44ff831 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63392,21 +63002,10 @@ index a95d1a5..44ff831 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63415,10 +63014,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 index aad2de3..d3b8468 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 @@ -81,6 +81,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -63427,10 +63026,10 @@ index aad2de3..d3b8468 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..5af9fbd 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..0b2a7eb 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63449,36 +63048,10 @@ index d3acaad..5af9fbd 100644
  }
  
  SECTIONS
-@@ -63,12 +70,6 @@ SECTIONS
-     KEEP(*(SORT(.log_const_data*)))
-     PROVIDE(__stop_log_const_data = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -81,6 +82,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 index 36b0fe4..bc8c8d0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -63899,10 +63472,10 @@ index 36b0fe4..bc8c8d0 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..29b2865 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63920,21 +63493,10 @@ index 228cf40..29b2865 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-index a801e6e..85d547f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+index a801e6e..3d9a769 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-@@ -10,9 +10,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63943,10 +63505,10 @@ index a801e6e..85d547f 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 index 07cf7c6..b4c2628 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -25,6 +25,7 @@ SRC_FILES += \
    $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
    $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
@@ -64015,10 +63577,10 @@ index 07cf7c6..b4c2628 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..6816cb2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -64037,36 +63599,10 @@ index b877f5a..6816cb2 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 index 994863b..14a8586 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -46,6 +46,102 @@
  #ifdef USE_APP_CONFIG
  #include "app_config.h"
@@ -64613,10 +64149,10 @@ index 994863b..14a8586 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 index 571ebbb..6be7f69 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -15,8 +15,8 @@
        arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
        arm_target_device_name="nRF52840_xxAA"
@@ -64661,21 +64197,10 @@ index 571ebbb..6be7f69 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -64684,11 +64209,11 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..b704d10
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -64972,11 +64497,11 @@ index 0000000..b704d10
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..12fd23c
+index 0000000..a7a64cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -65056,6 +64581,12 @@ index 0000000..12fd23c
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -65068,12 +64599,6 @@ index 0000000..12fd23c
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -65084,11 +64609,11 @@ index 0000000..12fd23c
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..c244199
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -70313,11 +69838,11 @@ index 0000000..c244199
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..735cba9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -70488,11 +70013,11 @@ index 0000000..735cba9
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -70502,11 +70027,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..d9b36f6
+index 0000000..95c368d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -70521,9 +70046,9 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -70557,10 +70082,10 @@ index 0000000..d9b36f6
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..b4bde15 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -96,6 +96,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -70585,10 +70110,10 @@ index 33053bc..b4bde15 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..6816cb2 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..150d772 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -70607,36 +70132,10 @@ index b877f5a..6816cb2 100644
  }
  
  SECTIONS
-@@ -69,12 +76,6 @@ SECTIONS
-     KEEP(*(.nrf_balloc))
-     PROVIDE(__stop_nrf_balloc = .);
-   } > FLASH
--  .sdh_stack_observers :
--  {
--    PROVIDE(__start_sdh_stack_observers = .);
--    KEEP(*(SORT(.sdh_stack_observers*)))
--    PROVIDE(__stop_sdh_stack_observers = .);
--  } > FLASH
-   .sdh_req_observers :
-   {
-     PROVIDE(__start_sdh_req_observers = .);
-@@ -87,6 +88,12 @@ SECTIONS
-     KEEP(*(SORT(.sdh_state_observers*)))
-     PROVIDE(__stop_sdh_state_observers = .);
-   } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
-   .log_backends :
-   {
-     PROVIDE(__start_log_backends = .);
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 index bb385de..c244199 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -133,7 +133,7 @@
  // <i> gaps. Tailor this value to adhere to this limitation.
  
@@ -71075,10 +70574,10 @@ index bb385de..c244199 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..e6a0b2c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -71105,21 +70604,10 @@ index c7771fd..e6a0b2c 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..d9b36f6 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..95c368d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-@@ -11,9 +11,9 @@
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
--    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
-     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
-     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
++++ nRF5_SDK_15.2.0_f1f9329/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -71128,10 +70616,10 @@ index 6b7653b..d9b36f6 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_39354f6/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_f1f9329/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_39354f6/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_f1f9329/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -71206,11 +70694,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_39354f6/examples/readme.txt nRF5_SDK_15.2.0_39354f6/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_f1f9329/examples/readme.txt nRF5_SDK_15.2.0_f1f9329/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_39354f6/examples/readme.txt
++++ nRF5_SDK_15.2.0_f1f9329/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -71226,10 +70714,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_39354f6/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_f1f9329/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_39354f6/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_f1f9329/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif
@@ -71299,9 +70787,3 @@ index bba3d13..139d375 100644
      if (nrfx_power_usb_handler_get() != NULL)
      {
          ret_code_t err_code = nrf_drv_power_sd_usbevt_enable(true);
-diff --git nRF5_SDK_15.2.0_39354f6/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_39354f6.patch nRF5_SDK_15.2.0_39354f6/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_39354f6.patch
-new file mode 100644
-index 0000000..e69de29
-diff --git nRF5_SDK_15.2.0_39354f6/patch-summary.txt nRF5_SDK_15.2.0_39354f6/patch-summary.txt
-new file mode 100644
-index 0000000..e69de29

--- a/hex/nRF5_SDK_15.2.0_connectivity.patch
+++ b/hex/nRF5_SDK_15.2.0_connectivity.patch
@@ -1,7 +1,7 @@
-diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_e18d5d2/components/boards/pca10056.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h nRF5_SDK_15.2.0_39354f6/components/boards/pca10056.h
 index 6b3f92f..7fbfbca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/boards/pca10056.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/boards/pca10056.h
++++ nRF5_SDK_15.2.0_39354f6/components/boards/pca10056.h
 @@ -90,6 +90,8 @@ extern "C" {
  #define RTS_PIN_NUMBER 5
  #define HWFC           true
@@ -11,10 +11,10 @@ index 6b3f92f..7fbfbca 100644
  #define BSP_QSPI_SCK_PIN   19
  #define BSP_QSPI_CSN_PIN   17
  #define BSP_QSPI_IO0_PIN   20
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 index 755581d..23b34db 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
++++ nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.c
 @@ -50,10 +50,6 @@
  #include "nrf_log.h"
  NRF_LOG_MODULE_REGISTER();
@@ -62,10 +62,10 @@ index 755581d..23b34db 100644
      m_dfu_info.wAddress       = CODE_START;
      m_dfu_info.wFirmwareSize  = CODE_SIZE;
      m_dfu_info.wVersionMajor  = APP_VERSION_MAJOR;
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 index 5906a80..8befbe9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
++++ nRF5_SDK_15.2.0_39354f6/components/libraries/bootloader/dfu/nrf_dfu_trigger_usb.h
 @@ -63,11 +63,12 @@
   *
   * @note  If @ref APP_USBD_CONFIG_EVENT_QUEUE_ENABLE is on (1), USB events must be handled manually.
@@ -80,10 +80,10 @@ index 5906a80..8befbe9 100644
  
  /** @} */
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_e18d5d2/components/libraries/log/src/nrf_log_ctrl_internal.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h nRF5_SDK_15.2.0_39354f6/components/libraries/log/src/nrf_log_ctrl_internal.h
 index 3478d9f..660652b 100644
 --- nRF5_SDK_15.2.0_9412b96/components/libraries/log/src/nrf_log_ctrl_internal.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/libraries/log/src/nrf_log_ctrl_internal.h
++++ nRF5_SDK_15.2.0_39354f6/components/libraries/log/src/nrf_log_ctrl_internal.h
 @@ -79,7 +79,7 @@
  #else // NRF_MODULE_ENABLED(NRF_LOG)
  #define NRF_LOG_INTERNAL_PROCESS()            false
@@ -93,10 +93,10 @@ index 3478d9f..660652b 100644
  #define NRF_LOG_INTERNAL_HANDLERS_SET(default_handler, bytes_handler) \
      UNUSED_PARAMETER(default_handler); UNUSED_PARAMETER(bytes_handler)
  #define NRF_LOG_INTERNAL_FINAL_FLUSH()
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 index 033d974..94ff331 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble.c
 @@ -44,6 +44,7 @@
  #include "ser_sd_transport.h"
  #include "app_error.h"
@@ -123,10 +123,10 @@ index 033d974..94ff331 100644
      tx_buf_alloc(&p_buffer, &buffer_length);
  
      const uint32_t err_code = ble_enable_req_enc(&(p_buffer[1]),
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 index 1fbb06f..c60d92d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/middleware/app_mw_ble_gap.c
 @@ -1069,7 +1069,9 @@ uint32_t _sd_ble_gap_scan_stop(void)
                                                         &buffer_length);
      //@note: Should never fail.
@@ -219,10 +219,10 @@ index 1fbb06f..c60d92d 100644
      const uint32_t err_code = ble_gap_adv_set_configure_req_enc(p_adv_handle, p_adv_data, p_adv_params,
                                                                  &(p_buffer[1]), &buffer_length);
      //@note: Should never fail.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 index cb0bd94..849a24d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.c
 @@ -56,9 +56,22 @@ typedef struct {
  static adv_set_t m_adv_sets[4]; //todo configurable number of adv sets.
  
@@ -372,10 +372,10 @@ index cb0bd94..849a24d 100644
  }
 +
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 index 58a0870..f2edf11 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/app_ble_gap_sec_keys.h
 @@ -53,6 +53,7 @@
  #include "ble_types.h"
  
@@ -447,10 +447,10 @@ index 58a0870..f2edf11 100644
  #endif
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 index 2eac945..24bd2cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_app.c
 @@ -650,6 +650,7 @@ uint32_t ble_gap_scan_start_rsp_dec(uint8_t const * const p_buf,
                                      uint32_t * const      p_result_code)
  {
@@ -467,10 +467,10 @@ index 2eac945..24bd2cf 100644
      SER_RSP_DEC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 index c8cbc94..8b83d5d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/ble/serializers/ble_gap_evt_app.c
 @@ -42,6 +42,7 @@
  #include "app_util.h"
  #include "app_ble_gap_sec_keys.h"
@@ -534,10 +534,10 @@ index c8cbc94..8b83d5d 100644
      SER_EVT_DEC_END;
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/common/conn_systemreset.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/common/conn_systemreset.c
 index ca012d2..f1088c4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/application/codecs/common/conn_systemreset.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/application/codecs/common/conn_systemreset.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/application/codecs/common/conn_systemreset.c
 @@ -56,8 +56,9 @@ uint32_t conn_systemreset(void)
      }
  
@@ -550,10 +550,10 @@ index ca012d2..f1088c4 100644
  
      err_code = ser_sd_transport_cmd_write(p_tx_buf, tx_buf_len, NULL);
      if (err_code != NRF_SUCCESS)
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ble_serialization.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/ble_serialization.h
 index dc37234..0787032 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ble_serialization.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ble_serialization.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/ble_serialization.h
 @@ -58,7 +58,7 @@ typedef enum
      SER_PKT_TYPE_EVT,         /**< Event packet type. */
      SER_PKT_TYPE_DTM_CMD,     /**< DTM Command packet type. */
@@ -576,10 +576,10 @@ index dc37234..0787032 100644
  #define  LOW16(a) ((uint16_t)((a & 0x0000FFFF) >> 0))
  #define HIGH16(a) ((uint16_t)((a & 0xFFFF0000) >> 16))
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_config.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_config.h
 index 2e6d502..0f6c4a9 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_config.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_config.h
 @@ -66,8 +66,8 @@ extern "C" {
  
  /** Max packets size in serialization HAL Transport layer (packets before adding PHY header i.e.
@@ -610,10 +610,10 @@ index 2e6d502..0f6c4a9 100644
  #ifdef __cplusplus
  }
  #endif
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_dbg_sd_str.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_dbg_sd_str.c
 index 5fbf555..b7390f3 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/ser_dbg_sd_str.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/ser_dbg_sd_str.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/ser_dbg_sd_str.c
 @@ -54,10 +54,10 @@
  
  #if NRF_MODULE_ENABLED(NRF_LOG) && defined(BLE_STACK_SUPPORT_REQD)
@@ -657,10 +657,10 @@ index 5fbf555..b7390f3 100644
      "SD_EVT_UNKNOWN",                          /*0x27*/
      "SD_EVT_UNKNOWN",                          /*0x28*/
      "SD_EVT_UNKNOWN",                          /*0x29*/
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 index bd8943d..eed27e8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_gap_struct_serialization.c
 @@ -453,9 +453,7 @@ uint32_t ble_gap_evt_connected_t_enc(void const * const p_void_struct,
      SER_PUSH_uint8(&p_struct->role);
      SER_PUSH_FIELD(&p_struct->conn_params, ble_gap_conn_params_t_enc);
@@ -713,10 +713,10 @@ index bd8943d..eed27e8 100644
  
      SER_STRUCT_DEC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 index 37f43ac..40ddda2 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/struct_ser/ble/ble_struct_serialization.c
 @@ -46,8 +46,11 @@
  #include "ble_types.h"
  #include "ble.h"
@@ -764,10 +764,10 @@ index 37f43ac..40ddda2 100644
  #endif
      SER_PULL_len16data(&p_struct->p_data, &p_struct->len);
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.c
 index 9bcc818..5d97f88 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.c
 @@ -44,7 +44,7 @@
  #include "ser_config.h"
  #include "ser_phy.h"
@@ -800,10 +800,10 @@ index 9bcc818..5d97f88 100644
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler)
  {
      uint32_t err_code = NRF_SUCCESS;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.h
 index d4da8b4..55d99d8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_hal_transport.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_hal_transport.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_hal_transport.h
 @@ -162,6 +162,8 @@ typedef void (*ser_hal_transport_events_handler_t)(ser_hal_transport_evt_t event
   */
  uint32_t ser_hal_transport_open(ser_hal_transport_events_handler_t events_handler);
@@ -813,10 +813,10 @@ index d4da8b4..55d99d8 100644
  
  /**@brief Function for closing a transport channel.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 index 06e7f9c..164a375 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/config/ser_phy_config_conn.h
 @@ -69,10 +69,10 @@ extern "C" {
  /* UART configuration */
  #define UART_IRQ_PRIORITY                       APP_IRQ_PRIORITY_LOWEST
@@ -832,10 +832,10 @@ index 06e7f9c..164a375 100644
  
  
  #ifdef __cplusplus
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 index 20e1eef..6996889 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.c
 @@ -51,6 +51,17 @@
  #include "nrf_soc.h"
  #include "ser_config.h"
@@ -1131,10 +1131,10 @@ index 20e1eef..6996889 100644
      }
      return err_code;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 index ab7f337..409491d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci.h
 @@ -129,6 +129,8 @@ typedef void (*ser_phy_hci_slip_event_handler_t)(ser_phy_hci_slip_evt_t *p_event
   */
  uint32_t ser_phy_hci_slip_open(ser_phy_hci_slip_event_handler_t events_handler);
@@ -1144,10 +1144,10 @@ index ab7f337..409491d 100644
  
  /**@brief A function for transmitting a HCI SLIP packet.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 index 857792b..7ad0537 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip.c
 @@ -189,6 +189,7 @@ static void tx_buf_fill(void)
          {
              can_continue = tx_buf_put(tx_escaped_data);
@@ -1232,10 +1232,10 @@ index 857792b..7ad0537 100644
  
      APP_ERROR_CHECK(nrf_drv_uart_rx(&m_uart, m_rx_buf, 1));
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 index ddbf926..d11c83e 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/common/transport/ser_phy/ser_phy_hci_slip_cdc.c
 @@ -67,10 +67,10 @@ NRF_LOG_MODULE_REGISTER();
  static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
                                      app_usbd_cdc_acm_user_event_t event);
@@ -1347,10 +1347,10 @@ index ddbf926..d11c83e 100644
  
      return NRF_SUCCESS;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 index f8e4666..c7807ad 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble.c
 @@ -41,7 +41,7 @@
  #include "conn_mw_ble.h"
  #include "ble_serialization.h"
@@ -1369,10 +1369,10 @@ index f8e4666..c7807ad 100644
  #else
      err_code = ble_enable_req_dec(p_rx_buf, rx_buf_len);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 index 6999f20..940c5af 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/middleware/conn_mw_ble_gap.c
 @@ -136,14 +136,22 @@ uint32_t conn_mw_ble_gap_scan_start(uint8_t const * const p_rx_buf,
      err_code = ble_gap_scan_start_req_dec(p_rx_buf, rx_buf_len, &p_scan_params, &p_adv_report_buffer);
      SER_ASSERT(err_code == NRF_SUCCESS, err_code);
@@ -1421,10 +1421,10 @@ index 6999f20..940c5af 100644
     SER_ASSERT(err_code == NRF_SUCCESS, err_code);
  
     return err_code;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 index ffe2ffe..5355070 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_event_enc.c
 @@ -46,6 +46,7 @@
  #include "ble_serialization.h"
  #include "app_util.h"
@@ -1442,10 +1442,10 @@ index ffe2ffe..5355070 100644
      switch (p_event->header.evt_id)
      {
  #if defined(NRF_SD_BLE_API_VERSION) && NRF_SD_BLE_API_VERSION < 4
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 index ff9a3ad..674a0bf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.c
 @@ -671,10 +671,14 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
  }
  
@@ -1475,10 +1475,10 @@ index ff9a3ad..674a0bf 100644
      SER_RSP_ENC_END;
  }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 index f1eaa4d..3bfaf36 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_conn.h
 @@ -850,6 +850,9 @@ uint32_t ble_gap_scan_start_req_dec(uint8_t const * const     p_buf,
   * @retval NRF_ERROR_INVALID_LENGTH   Encoding failure. Incorrect buffer length.
   */
@@ -1497,10 +1497,10 @@ index f1eaa4d..3bfaf36 100644
                                             uint8_t const * const p_adv_handle);
  
  #ifndef S112
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 index 9267b39..a96cff8 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/ble_gap_evt_conn.c
 @@ -43,6 +43,7 @@
  #include "ble_serialization.h"
  #include "cond_field_serialization.h"
@@ -1548,10 +1548,10 @@ index 9267b39..a96cff8 100644
  
      SER_EVT_ENC_END;
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 index 3f8c122..8b21066 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.c
 @@ -54,7 +54,25 @@ typedef struct
  
  ble_data_item_t m_ble_data_pool[8];
@@ -1636,10 +1636,10 @@ index 3f8c122..8b21066 100644
  }
  #endif
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 index 875de9a..348b54d 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_gap_sec_keys.h
 @@ -51,7 +51,7 @@
  
  #include "ble_gap.h"
@@ -1671,10 +1671,10 @@ index 875de9a..348b54d 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 index 2a54512..68623e4 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.c
 @@ -46,6 +46,16 @@
  
  sercon_ble_user_mem_t m_conn_user_mem_table[SER_MAX_CONNECTIONS];
@@ -1692,10 +1692,10 @@ index 2a54512..68623e4 100644
  uint32_t conn_ble_user_mem_context_create(uint32_t *p_index)
  {
    uint32_t err_code = NRF_ERROR_NO_MEM;
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 index bb53a2d..3de2b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/codecs/ble/serializers/conn_ble_user_mem.h
 @@ -70,6 +70,9 @@ typedef struct
    uint8_t              mem_table[64];      /**< Memory table. */
  } sercon_ble_user_mem_t;
@@ -1706,10 +1706,10 @@ index bb53a2d..3de2b6f 100644
  /**@brief Allocates instance in m_user_mem_table[] for storage.
   *
   * @param[out]    p_index             Pointer to the index of allocated instance.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_event_encoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_event_encoder.c
 index d784754..7d8e424 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_event_encoder.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_event_encoder.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_event_encoder.c
 @@ -46,6 +46,7 @@
  #include "ser_hal_transport.h"
  #include "ser_conn_event_encoder.h"
@@ -1746,10 +1746,10 @@ index d784754..7d8e424 100644
      }
      else
      {
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.c
 index f656ee2..f6656ea 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.c
 @@ -48,6 +48,8 @@
  #include "nrf_sdh.h"
  #ifdef BLE_STACK_SUPPORT_REQD
@@ -1782,10 +1782,10 @@ index f656ee2..f6656ea 100644
      {
          // Queue is full. Do not pull new events.
          nrf_sdh_suspend();
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.h
 index cc5777a..3f17f2f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_handlers.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_handlers.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_handlers.h
 @@ -77,7 +77,7 @@ extern "C" {
  #endif
  
@@ -1805,10 +1805,10 @@ index cc5777a..3f17f2f 100644
  /**@brief A function for processing BLE SoftDevice events.
   *
   * @details BLE events are put into application scheduler queue to be processed at a later time.
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_pkt_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_pkt_decoder.c
 index c8a899c..d3e3fca 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_pkt_decoder.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_pkt_decoder.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_pkt_decoder.c
 @@ -86,9 +86,9 @@ uint32_t ser_conn_received_pkt_process(
                  break;
              }
@@ -1821,10 +1821,10 @@ index c8a899c..d3e3fca 100644
                  break;
              }
  
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 index fcf4235..efc7244 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.c
 @@ -39,9 +39,92 @@
   */
  #include "nrf_nvic.h"
@@ -1921,10 +1921,10 @@ index fcf4235..efc7244 100644
 +        break;
 +    }
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 index 6e9eb9c..2b654e1 100644
 --- nRF5_SDK_15.2.0_9412b96/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
++++ nRF5_SDK_15.2.0_39354f6/components/serialization/connectivity/ser_conn_reset_cmd_decoder.h
 @@ -58,7 +58,7 @@
  #define SER_CONN_RESET_CMD_DECODER_H__
  
@@ -1945,10 +1945,10 @@ index 6e9eb9c..2b654e1 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh.c
 index 63e7fea..f2fa7cf 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh.c
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh.c
 @@ -204,7 +204,11 @@ ret_code_t nrf_sdh_enable_request(void)
          .source       = NRF_SDH_CLOCK_LF_SRC,
          .rc_ctiv      = NRF_SDH_CLOCK_LF_RC_CTIV,
@@ -1975,10 +1975,10 @@ index 63e7fea..f2fa7cf 100644
      // Enable event interrupt.
      // Interrupt priority has already been set by the stack.
      softdevices_evt_irq_enable();
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.c
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.c
 index d8ac161..db6379f 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.c
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.c
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.c
 @@ -102,8 +102,9 @@ ret_code_t nrf_sdh_ble_app_ram_start_get(uint32_t * p_app_ram_start)
  
  ret_code_t nrf_sdh_ble_default_cfg_set(uint8_t conn_cfg_tag, uint32_t * p_ram_start)
@@ -2055,10 +2055,10 @@ index d8ac161..db6379f 100644
  
  /**@brief       Function for polling BLE events.
   *
-diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.h
+diff --git nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.h
 index 2970807..7c08450 100644
 --- nRF5_SDK_15.2.0_9412b96/components/softdevice/common/nrf_sdh_ble.h
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/common/nrf_sdh_ble.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/common/nrf_sdh_ble.h
 @@ -62,6 +62,12 @@
  extern "C" {
  #endif
@@ -2085,11 +2085,11 @@ index 2970807..7c08450 100644
  
  #ifdef __cplusplus
  }
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble.h
 new file mode 100644
 index 0000000..168d655
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble.h
 @@ -0,0 +1,681 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2772,11 +2772,11 @@ index 0000000..168d655
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_err.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_err.h
 new file mode 100644
 index 0000000..9e70176
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_err.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_err.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -2868,11 +2868,11 @@ index 0000000..9e70176
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gap.h
 new file mode 100644
 index 0000000..54a33f0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gap.h
 @@ -0,0 +1,1917 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -4791,11 +4791,11 @@ index 0000000..54a33f0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatt.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatt.h
 new file mode 100644
 index 0000000..42d6cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatt.h
 @@ -0,0 +1,220 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5017,11 +5017,11 @@ index 0000000..42d6cb6
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gattc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gattc.h
 new file mode 100644
 index 0000000..859dcdf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gattc.h
 @@ -0,0 +1,660 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -5683,11 +5683,11 @@ index 0000000..859dcdf
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatts.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatts.h
 new file mode 100644
 index 0000000..535332b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_gatts.h
 @@ -0,0 +1,778 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6467,11 +6467,11 @@ index 0000000..535332b
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_hci.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_hci.h
 new file mode 100644
 index 0000000..4c7a5d5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_hci.h
 @@ -0,0 +1,131 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6604,11 +6604,11 @@ index 0000000..4c7a5d5
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_l2cap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..a180840
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_l2cap.h
 @@ -0,0 +1,202 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6812,11 +6812,11 @@ index 0000000..a180840
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_ranges.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_ranges.h
 new file mode 100644
 index 0000000..854898c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_ranges.h
 @@ -0,0 +1,138 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -6956,11 +6956,11 @@ index 0000000..854898c
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_types.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_types.h
 new file mode 100644
 index 0000000..f5ccdb7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/ble_types.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/ble_types.h
 @@ -0,0 +1,213 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7175,11 +7175,11 @@ index 0000000..f5ccdb7
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..31a3a23
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,217 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7398,11 +7398,11 @@ index 0000000..31a3a23
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error.h
 new file mode 100644
 index 0000000..55ce59e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error.h
 @@ -0,0 +1,87 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7491,11 +7491,11 @@ index 0000000..55ce59e
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..3881071
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_sdm.h
 @@ -0,0 +1,67 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7564,11 +7564,11 @@ index 0000000..3881071
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..b876fc4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_error_soc.h
 @@ -0,0 +1,82 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -7652,11 +7652,11 @@ index 0000000..b876fc4
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_nvic.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..40a6f84
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_nvic.h
 @@ -0,0 +1,485 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8143,11 +8143,11 @@ index 0000000..40a6f84
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sd_def.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..58e699e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -8177,11 +8177,11 @@ index 0000000..58e699e
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..bb98ce0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_sdm.h
 @@ -0,0 +1,331 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -8514,11 +8514,11 @@ index 0000000..bb98ce0
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_soc.h
 new file mode 100644
 index 0000000..2e9e820
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_soc.h
 @@ -0,0 +1,906 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9426,11 +9426,11 @@ index 0000000..2e9e820
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_svc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c7e3fbe
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers/nrf_svc.h
 @@ -0,0 +1,88 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -9520,11 +9520,11 @@ index 0000000..c7e3fbe
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gap.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gap.h
 new file mode 100644
 index 0000000..e07ccef
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gap.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gap.h
 @@ -0,0 +1,1919 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -11445,11 +11445,11 @@ index 0000000..e07ccef
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gattc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 new file mode 100644
 index 0000000..9cd75e2
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/ble_gattc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/ble_gattc.h
 @@ -0,0 +1,674 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12125,11 +12125,11 @@ index 0000000..9cd75e2
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/nrf_nvic.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 new file mode 100644
 index 0000000..a29d008
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/nrf_nvic.h
 @@ -0,0 +1,546 @@
 +/*
 + * Copyright (c) Nordic Semiconductor ASA
@@ -12677,20 +12677,20 @@ index 0000000..a29d008
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/test.rb nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 new file mode 100644
 index 0000000..126407c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/hex/s132_nrf52_3.0.0_softdevice.hex
 @@ -0,0 +1,7694 @@
 +:020000040000FA
 +:1000000000040020E508000079050000C508000094
@@ -20386,11 +20386,11 @@ index 0000000..126407c
 +:10E720000100683720FB349B5F80041F80001002CB
 +:10E730002C01337F0102A029024410E431E00100E2
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..74140a9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/armgcc/armgcc_s132v3_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -20425,11 +20425,11 @@ index 0000000..74140a9
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..0cc668a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v3/toolchain/iar/iar_s132v3_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -20467,11 +20467,11 @@ index 0000000..0cc668a
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble.h
 new file mode 100644
 index 0000000..ed16f6d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble.h
 @@ -0,0 +1,628 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21101,11 +21101,11 @@ index 0000000..ed16f6d
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_err.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_err.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_err.h
 new file mode 100644
 index 0000000..2699abc
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_err.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_err.h
 @@ -0,0 +1,91 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -21198,11 +21198,11 @@ index 0000000..2699abc
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gap.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gap.h
 new file mode 100644
 index 0000000..fa61bb9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gap.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gap.h
 @@ -0,0 +1,2189 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -23393,11 +23393,11 @@ index 0000000..fa61bb9
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatt.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatt.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatt.h
 new file mode 100644
 index 0000000..f1651c8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatt.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatt.h
 @@ -0,0 +1,228 @@
 +/*
 + * Copyright (c) 2013 - 2017, Nordic Semiconductor ASA
@@ -23627,11 +23627,11 @@ index 0000000..f1651c8
 +#endif // BLE_GATT_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gattc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gattc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gattc.h
 new file mode 100644
 index 0000000..f1428cd
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gattc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gattc.h
 @@ -0,0 +1,707 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -24340,11 +24340,11 @@ index 0000000..f1428cd
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatts.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatts.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatts.h
 new file mode 100644
 index 0000000..1bba73d
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_gatts.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_gatts.h
 @@ -0,0 +1,841 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25187,11 +25187,11 @@ index 0000000..1bba73d
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_hci.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_hci.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_hci.h
 new file mode 100644
 index 0000000..b48d706
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_hci.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_hci.h
 @@ -0,0 +1,135 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -25328,11 +25328,11 @@ index 0000000..b48d706
 +#endif // BLE_HCI_H__
 +
 +/** @} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_l2cap.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_l2cap.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_l2cap.h
 new file mode 100644
 index 0000000..96d833a
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_l2cap.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_l2cap.h
 @@ -0,0 +1,507 @@
 +/*
 + * Copyright (c) 2011 - 2017, Nordic Semiconductor ASA
@@ -25841,11 +25841,11 @@ index 0000000..96d833a
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_ranges.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_ranges.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_ranges.h
 new file mode 100644
 index 0000000..9bff917
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_ranges.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_ranges.h
 @@ -0,0 +1,156 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26003,11 +26003,11 @@ index 0000000..9bff917
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_types.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_types.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_types.h
 new file mode 100644
 index 0000000..cd5fbaf
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/ble_types.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/ble_types.h
 @@ -0,0 +1,215 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26224,11 +26224,11 @@ index 0000000..cd5fbaf
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 new file mode 100644
 index 0000000..ea231b3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf52/nrf_mbr.h
 @@ -0,0 +1,241 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26471,11 +26471,11 @@ index 0000000..ea231b3
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error.h
 new file mode 100644
 index 0000000..09d3044
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2014 - 2017, Nordic Semiconductor ASA
@@ -26567,11 +26567,11 @@ index 0000000..09d3044
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_sdm.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_sdm.h
 new file mode 100644
 index 0000000..85e08f3
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_sdm.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_sdm.h
 @@ -0,0 +1,70 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26643,11 +26643,11 @@ index 0000000..85e08f3
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_soc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_soc.h
 new file mode 100644
 index 0000000..ea9825e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_error_soc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_error_soc.h
 @@ -0,0 +1,85 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -26734,11 +26734,11 @@ index 0000000..ea9825e
 +  @}
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_nvic.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_nvic.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_nvic.h
 new file mode 100644
 index 0000000..1705cb6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_nvic.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_nvic.h
 @@ -0,0 +1,486 @@
 +/*
 + * Copyright (c) 2016 - 2017, Nordic Semiconductor ASA
@@ -27226,11 +27226,11 @@ index 0000000..1705cb6
 +#endif // NRF_NVIC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sd_def.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sd_def.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sd_def.h
 new file mode 100644
 index 0000000..7bf0ff0
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sd_def.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sd_def.h
 @@ -0,0 +1,28 @@
 +/* Copyright (c) 2015 - 2018 Nordic Semiconductor ASA. All Rights Reserved.
 + *
@@ -27260,11 +27260,11 @@ index 0000000..7bf0ff0
 +#endif
 +
 +#endif /* NRF_SD_DEF_H__ */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sdm.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sdm.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sdm.h
 new file mode 100644
 index 0000000..09eaecb
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_sdm.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_sdm.h
 @@ -0,0 +1,357 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -27623,11 +27623,11 @@ index 0000000..09eaecb
 +/**
 +  @}
 +*/
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_soc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_soc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_soc.h
 new file mode 100644
 index 0000000..60fff94
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_soc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_soc.h
 @@ -0,0 +1,934 @@
 +/*
 + * Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
@@ -28563,11 +28563,11 @@ index 0000000..60fff94
 +#endif // NRF_SOC_H__
 +
 +/**@} */
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_svc.h
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_svc.h nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_svc.h
 new file mode 100644
 index 0000000..c26ce74
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers/nrf_svc.h
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers/nrf_svc.h
 @@ -0,0 +1,90 @@
 +/*
 + * Copyright (c) 2012 - 2017, Nordic Semiconductor ASA
@@ -28659,20 +28659,20 @@ index 0000000..c26ce74
 +}
 +#endif
 +#endif  // NRF_SVC__
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers_replacement/test.rb
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers_replacement/test.rb nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers_replacement/test.rb
 new file mode 100644
 index 0000000..f58ae1e
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/headers_replacement/test.rb
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/headers_replacement/test.rb
 @@ -0,0 +1,2 @@
 +a = 'xxx const * const*'
 +puts a.gsub('const','')
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 new file mode 100644
 index 0000000..757b5f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/hex/s132_nrf52_5.1.0_softdevice.hex
 @@ -0,0 +1,7843 @@
 +:020000040000FA
 +:1000000000040020E90800007D050000C908000088
@@ -36517,11 +36517,11 @@ index 0000000..757b5f6
 +:10F070001B201C041AA20401980912BF237F01025D
 +:04F080006B290000F8
 +:00000001FF
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 new file mode 100644
 index 0000000..cb45d8b
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/armgcc/armgcc_s132v5_nrf52832_xxaa.ld
 @@ -0,0 +1,33 @@
 +/* Linker script to configure memory regions. */
 +
@@ -36556,11 +36556,11 @@ index 0000000..cb45d8b
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
+diff --git nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 new file mode 100644
 index 0000000..55701b7
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
++++ nRF5_SDK_15.2.0_39354f6/components/softdevice/s132v5/toolchain/iar/iar_s132v5_nrf52832_xxaa.icf
 @@ -0,0 +1,36 @@
 +/*###ICF### Section handled by ICF editor, don't touch! ****/
 +/*-Editor annotation file-*/
@@ -36598,10 +36598,10 @@ index 0000000..55701b7
 +                        block CSTACK,
 +                        block HEAP };
 +
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/main.c
-index fc7996c..56a819e 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/main.c
+index fc7996c..811dcc4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/main.c
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/main.c
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/main.c
 @@ -57,22 +57,28 @@
  #include "ser_conn_handlers.h"
  #include "boards.h"
@@ -36745,13 +36745,13 @@ index fc7996c..56a819e 100644
      NRF_LOG_INFO("BLE connectivity started");
  
 -    bsp_board_init(BSP_INIT_LEDS);
-+    nrf_drv_qspi_config_t config = NRF_DRV_QSPI_DEFAULT_CONFIG;
-+
 +#ifdef NRF_DFU_TRIGGER_USB_INTERFACE_NUM
 +    uint32_t pin_reset = PCA10059_PIN_RESET;
 +#endif
 +
 +#if QSPI_ENABLED
++    nrf_drv_qspi_config_t config = NRF_DRV_QSPI_DEFAULT_CONFIG;
++
 +    //Using qspi memory to de
 +    err_code = nrf_drv_qspi_init(&config, NULL, NULL);
 +    if (err_code == NRF_SUCCESS)
@@ -36813,10 +36813,10 @@ index fc7996c..56a819e 100644
      }
  }
  /** @} */
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index 611a3b6..0a1645f 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index 611a3b6..65e784e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -36837,10 +36837,36 @@ index 611a3b6..0a1645f 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
+@@ -69,12 +76,6 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -87,6 +88,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 index c5caa64..19a16d1 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -37111,10 +37137,10 @@ index c5caa64..19a16d1 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 index 7eccb28..8a0e048 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/ble_connectivity_s132_hci_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37126,10 +37152,21 @@ index 7eccb28..8a0e048 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+index 6b7653b..d9b36f6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37138,10 +37175,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..57c5fcf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..d1bb196 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37162,10 +37199,36 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37436,10 +37499,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 index 918459a..0eb8650 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/ble_connectivity_s132_spi_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37451,10 +37514,21 @@ index 918459a..0eb8650 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37463,10 +37537,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..57c5fcf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..d1bb196 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37487,10 +37561,36 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 index 878122b..9342e94 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/config/sdk_config.h
 @@ -747,6 +747,136 @@
  
  // </e>
@@ -37761,10 +37861,10 @@ index 878122b..9342e94 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 index 4f3e9db..13cae61 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/ble_connectivity_s132_spi_5W_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -37776,10 +37876,21 @@ index 4f3e9db..13cae61 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_spi_5W/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -37788,10 +37899,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index f67446c..57c5fcf 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index f67446c..d1bb196 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -6,11 +6,18 @@ GROUP(-lgcc -lc -lnosys)
  MEMORY
  {
@@ -37812,10 +37923,36 @@ index f67446c..57c5fcf 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 index 17cad13..cad5969 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/config/sdk_config.h
 @@ -518,6 +518,136 @@
  
  // </e>
@@ -38086,10 +38223,10 @@ index 17cad13..cad5969 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 index 400fec8..8c8b417 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/ble_connectivity_s132_uart_pca10040.emProject
 @@ -27,8 +27,8 @@
        linker_printf_width_precision_supported="Yes"
        linker_printf_fmt_level="long"
@@ -38101,10 +38238,21 @@ index 400fec8..8c8b417 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132_uart/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -38113,11 +38261,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..c33f1b4
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/Makefile
 @@ -0,0 +1,262 @@
 +PROJECT_NAME     := ble_connectivity_132v3_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -38381,11 +38529,11 @@ index 0000000..c33f1b4
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..7110f07
+index 0000000..7d40943
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -38465,12 +38613,6 @@ index 0000000..7110f07
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -38483,6 +38625,12 @@ index 0000000..7110f07
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -38493,11 +38641,11 @@ index 0000000..7110f07
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..19a16d1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/config/sdk_config.h
 @@ -0,0 +1,4558 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -43057,11 +43205,11 @@ index 0000000..19a16d1
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 new file mode 100644
 index 0000000..e320c53
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emProject
 @@ -0,0 +1,154 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_hci_pca10040" target="8" version="2">
@@ -43217,11 +43365,11 @@ index 0000000..e320c53
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 new file mode 100644
 index 0000000..c05cfb5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/ble_connectivity_132v3_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -43231,11 +43379,11 @@ index 0000000..c05cfb5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..d9b36f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v3_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -43250,9 +43398,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -43286,11 +43434,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..25fcc18
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/Makefile
 @@ -0,0 +1,263 @@
 +PROJECT_NAME     := ble_connectivity_132v5_hci_pca10040
 +TARGETS          := nrf52832_xxaa
@@ -43555,11 +43703,11 @@ index 0000000..25fcc18
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..9e0c093
+index 0000000..04f6cc8
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -43639,12 +43787,6 @@ index 0000000..9e0c093
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -43657,6 +43799,12 @@ index 0000000..9e0c093
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -43667,11 +43815,11 @@ index 0000000..9e0c093
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..ffe8c67
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/config/sdk_config.h
 @@ -0,0 +1,4579 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -48252,11 +48400,11 @@ index 0000000..ffe8c67
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 new file mode 100644
 index 0000000..ec91733
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emProject
 @@ -0,0 +1,155 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_hci_pca10040" target="8" version="2">
@@ -48413,11 +48561,11 @@ index 0000000..ec91733
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 new file mode 100644
 index 0000000..811c3c5
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/ble_connectivity_132v5_hci_pca10040.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -48427,11 +48575,11 @@ index 0000000..811c3c5
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..d9b36f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040/ser_s132v5_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -48446,9 +48594,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -48482,10 +48630,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index e8a3735..7b95e77 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index e8a3735..9a410b0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48504,10 +48652,36 @@ index e8a3735..7b95e77 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
+@@ -69,12 +76,6 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -87,6 +88,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 index 6539e77..3119381 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -48778,10 +48952,10 @@ index 6539e77..3119381 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 index bbf3d52..2a6c303 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/ble_connectivity_s112_hci_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -48791,10 +48965,21 @@ index bbf3d52..2a6c303 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+index 6b7653b..d9b36f6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -48803,10 +48988,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..6b8f0fb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..9ce3ba9 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -48825,10 +49010,36 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49099,10 +49310,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 index 89c1d8f..0dc51b4 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/ble_connectivity_s112_spi_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49112,10 +49323,21 @@ index 89c1d8f..0dc51b4 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49124,10 +49346,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..6b8f0fb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..9ce3ba9 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49146,10 +49368,36 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 index 4adb2af..00e28ae 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/config/sdk_config.h
 @@ -598,6 +598,136 @@
  
  // </e>
@@ -49420,10 +49668,10 @@ index 4adb2af..00e28ae 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 index d1b0172..552d665 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/ble_connectivity_s112_spi_5W_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49433,10 +49681,21 @@ index d1b0172..552d665 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_spi_5W/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49445,10 +49704,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index 40d23f1..6b8f0fb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index 40d23f1..9ce3ba9 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x19000, LENGTH = 0x17000
@@ -49467,10 +49726,36 @@ index 40d23f1..6b8f0fb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 index 7b74df4..f0c345a 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/config/sdk_config.h
 @@ -397,6 +397,136 @@
  
  // </e>
@@ -49741,10 +50026,10 @@ index 7b74df4..f0c345a 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 index 79da171..3d7b71f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/ble_connectivity_s112_uart_pca10040e.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -49754,10 +50039,21 @@ index 79da171..3d7b71f 100644
        project_directory=""
        project_type="Executable" />
        <folder Name="Segger Startup Files">
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10040e/ser_s112_uart/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -49766,11 +50062,11 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..29138b1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -50054,11 +50350,11 @@ index 0000000..29138b1
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..a7a64cd
+index 0000000..12fd23c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -50138,12 +50434,6 @@ index 0000000..a7a64cd
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -50156,6 +50446,12 @@ index 0000000..a7a64cd
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -50166,11 +50462,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..14a8586
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -55395,11 +55691,11 @@ index 0000000..14a8586
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..bd45579
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10056" target="8" version="2">
@@ -55570,11 +55866,11 @@ index 0000000..bd45579
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..ce75e3c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -55584,11 +55880,11 @@ index 0000000..ce75e3c
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..d9b36f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -55603,9 +55899,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -55639,11 +55935,11 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..8d850ae
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/Makefile
 @@ -0,0 +1,283 @@
 +PROJECT_NAME     := ble_connectivity_132v5_usb_hci_pca10056
 +TARGETS          := nrf52840_xxaa
@@ -55928,11 +56224,11 @@ index 0000000..8d850ae
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..1a80caf
+index 0000000..3d81a92
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -56012,12 +56308,6 @@ index 0000000..1a80caf
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -56030,6 +56320,12 @@ index 0000000..1a80caf
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -56040,11 +56336,11 @@ index 0000000..1a80caf
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..f0b6542
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5244 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -61290,11 +61586,11 @@ index 0000000..f0b6542
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 new file mode 100644
 index 0000000..d93607c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emProject
 @@ -0,0 +1,170 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v5_usb_hci_pca10056" target="8" version="2">
@@ -61466,11 +61762,11 @@ index 0000000..d93607c
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 new file mode 100644
 index 0000000..6c26dd1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/ble_connectivity_132v5_usb_hci_pca10056.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -61480,11 +61776,11 @@ index 0000000..6c26dd1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..d9b36f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s132v5_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -61499,9 +61795,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -61535,10 +61831,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 index 87059cc..0d8cc08 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/Makefile
 @@ -85,6 +85,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -61547,10 +61843,10 @@ index 87059cc..0d8cc08 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..150d772 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..6816cb2 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -61569,10 +61865,36 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
+@@ -69,12 +76,6 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -87,6 +88,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 index 793e569..d43945e 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -61993,10 +62315,10 @@ index 793e569..d43945e 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 index f64c3a0..0221ede 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/ble_connectivity_s140_hci_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62014,10 +62336,21 @@ index f64c3a0..0221ede 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+index 6b7653b..d9b36f6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62026,10 +62359,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 index f5648fe..98f1192 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62038,10 +62371,10 @@ index f5648fe..98f1192 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..0b2a7eb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..5af9fbd 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62060,10 +62393,36 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62484,10 +62843,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 index a71ed2f..430528f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/ble_connectivity_s140_spi_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62505,10 +62864,21 @@ index a71ed2f..430528f 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -62517,10 +62887,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 index e498e6c..1147b6f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/Makefile
 @@ -83,6 +83,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_gpiote.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -62529,10 +62899,10 @@ index e498e6c..1147b6f 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_spis.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..0b2a7eb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..5af9fbd 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -62551,10 +62921,36 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 index ba4721d..0c83e4d 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/config/sdk_config.h
 @@ -347,6 +347,134 @@
  
  // </e>
@@ -62975,10 +63371,10 @@ index ba4721d..0c83e4d 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 index a95d1a5..44ff831 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/ble_connectivity_s140_spi_5W_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -62996,10 +63392,21 @@ index a95d1a5..44ff831 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_spis.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_spi_5W/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63008,10 +63415,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 index aad2de3..d3b8468 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/Makefile
 @@ -81,6 +81,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_clock.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -63020,10 +63427,10 @@ index aad2de3..d3b8468 100644
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uart.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_uarte.c \
    $(PROJ_DIR)/main.c \
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-index d3acaad..0b2a7eb 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
+index d3acaad..5af9fbd 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63042,10 +63449,36 @@ index d3acaad..0b2a7eb 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
+@@ -63,12 +70,6 @@ SECTIONS
+     KEEP(*(SORT(.log_const_data*)))
+     PROVIDE(__stop_log_const_data = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -81,6 +82,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 index 36b0fe4..bc8c8d0 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/config/sdk_config.h
 @@ -240,6 +240,134 @@
  
  // </e>
@@ -63466,10 +63899,10 @@ index 36b0fe4..bc8c8d0 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 index 228cf40..29b2865 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/ble_connectivity_s140_uart_pca10056.emProject
 @@ -28,7 +28,7 @@
        linker_printf_fmt_level="long"
        linker_section_placement_file="flash_placement.xml"
@@ -63487,10 +63920,21 @@ index 228cf40..29b2865 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-index a801e6e..3d9a769 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+index a801e6e..85d547f 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_uart/ses/flash_placement.xml
+@@ -10,9 +10,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_soc_observers" inputsections="*(SORT(.sdh_soc_observers*))" address_symbol="__start_sdh_soc_observers" end_symbol="__stop_sdh_soc_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -42,4 +42,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -63499,10 +63943,10 @@ index a801e6e..3d9a769 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 index 07cf7c6..b4c2628 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/Makefile
 @@ -25,6 +25,7 @@ SRC_FILES += \
    $(SDK_ROOT)/components/libraries/usbd/app_usbd.c \
    $(SDK_ROOT)/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c \
@@ -63571,10 +64015,10 @@ index 07cf7c6..b4c2628 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..150d772 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..6816cb2 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -63593,10 +64037,36 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
+@@ -69,12 +76,6 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -87,6 +88,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 index 994863b..14a8586 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/config/sdk_config.h
 @@ -46,6 +46,102 @@
  #ifdef USE_APP_CONFIG
  #include "app_config.h"
@@ -64143,10 +64613,10 @@ index 994863b..14a8586 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 index 571ebbb..6be7f69 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10056.emProject
 @@ -15,8 +15,8 @@
        arm_simulator_memory_simulation_parameter="RWX 00000000,00100000,FFFFFFFF;RWX 20000000,00010000,CDCDCDCD"
        arm_target_device_name="nRF52840_xxAA"
@@ -64191,10 +64661,21 @@ index 571ebbb..6be7f69 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..d9b36f6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10056/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -64203,11 +64684,11 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 new file mode 100644
 index 0000000..b704d10
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/Makefile
 @@ -0,0 +1,282 @@
 +PROJECT_NAME     := ble_connectivity_132v3_usb_hci_pca10059
 +TARGETS          := nrf52840_xxaa
@@ -64491,11 +64972,11 @@ index 0000000..b704d10
 +CMSIS_CONFIG_TOOL := $(SDK_ROOT)/external_tools/cmsisconfig/CMSIS_Configuration_Wizard.jar
 +sdk_config:
 +	java -jar $(CMSIS_CONFIG_TOOL) $(SDK_CONFIG_FILE)
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 new file mode 100644
-index 0000000..a7a64cd
+index 0000000..12fd23c
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -0,0 +1,106 @@
 +/* Linker script to configure memory regions. */
 +
@@ -64575,12 +65056,6 @@ index 0000000..a7a64cd
 +    KEEP(*(.nrf_balloc))
 +    PROVIDE(__stop_nrf_balloc = .);
 +  } > FLASH
-+  .sdh_stack_observers :
-+  {
-+    PROVIDE(__start_sdh_stack_observers = .);
-+    KEEP(*(SORT(.sdh_stack_observers*)))
-+    PROVIDE(__stop_sdh_stack_observers = .);
-+  } > FLASH
 +  .sdh_req_observers :
 +  {
 +    PROVIDE(__start_sdh_req_observers = .);
@@ -64593,6 +65068,12 @@ index 0000000..a7a64cd
 +    KEEP(*(SORT(.sdh_state_observers*)))
 +    PROVIDE(__stop_sdh_state_observers = .);
 +  } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
 +  .log_backends :
 +  {
 +    PROVIDE(__start_log_backends = .);
@@ -64603,11 +65084,11 @@ index 0000000..a7a64cd
 +} INSERT AFTER .text
 +
 +INCLUDE "nrf_common.ld"
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 new file mode 100644
 index 0000000..c244199
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/config/sdk_config.h
 @@ -0,0 +1,5223 @@
 +/**
 + * Copyright (c) 2017 - 2018, Nordic Semiconductor ASA
@@ -69832,11 +70313,11 @@ index 0000000..c244199
 +// <<< end of configuration section >>>
 +#endif //SDK_CONFIG_H
 +
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 new file mode 100644
 index 0000000..735cba9
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emProject
 @@ -0,0 +1,169 @@
 +<!DOCTYPE CrossStudio_Project_File>
 +<solution Name="ble_connectivity_132v3_usb_hci_pca10059" target="8" version="2">
@@ -70007,11 +70488,11 @@ index 0000000..735cba9
 +    c_preprocessor_definitions="DEBUG; DEBUG_NRF"
 +    gcc_optimization_level="None"/>
 +</solution>
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 new file mode 100644
 index 0000000..22c73f1
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/ble_connectivity_132v3_usb_hci_pca10059.emSession
 @@ -0,0 +1,7 @@
 +<!DOCTYPE CrossStudio_Session_File>
 +<session>
@@ -70021,11 +70502,11 @@ index 0000000..22c73f1
 +  </Files>
 +</session>
 \ No newline at end of file
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
+diff --git nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 new file mode 100644
-index 0000000..95c368d
+index 0000000..d9b36f6
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s132v3_usb_hci/ses/flash_placement.xml
 @@ -0,0 +1,49 @@
 +<!DOCTYPE Linker_Placement_File>
 +<Root name="Flash Section Placement">
@@ -70040,9 +70521,9 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
-+    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
 +    <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
@@ -70076,10 +70557,10 @@ index 0000000..95c368d
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
 +</Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 index 33053bc..b4bde15 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/Makefile
 @@ -96,6 +96,7 @@ SRC_FILES += \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power.c \
    $(SDK_ROOT)/modules/nrfx/drivers/src/nrfx_power_clock.c \
@@ -70104,10 +70585,10 @@ index 33053bc..b4bde15 100644
  ASMFLAGS += -DSOFTDEVICE_PRESENT
  ASMFLAGS += -DSWI_DISABLE0
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-index b877f5a..150d772 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
+index b877f5a..6816cb2 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/armgcc/ble_connectivity_gcc_nrf52.ld
 @@ -7,10 +7,17 @@ MEMORY
  {
    FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xda000
@@ -70126,10 +70607,36 @@ index b877f5a..150d772 100644
  }
  
  SECTIONS
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
+@@ -69,12 +76,6 @@ SECTIONS
+     KEEP(*(.nrf_balloc))
+     PROVIDE(__stop_nrf_balloc = .);
+   } > FLASH
+-  .sdh_stack_observers :
+-  {
+-    PROVIDE(__start_sdh_stack_observers = .);
+-    KEEP(*(SORT(.sdh_stack_observers*)))
+-    PROVIDE(__stop_sdh_stack_observers = .);
+-  } > FLASH
+   .sdh_req_observers :
+   {
+     PROVIDE(__start_sdh_req_observers = .);
+@@ -87,6 +88,12 @@ SECTIONS
+     KEEP(*(SORT(.sdh_state_observers*)))
+     PROVIDE(__stop_sdh_state_observers = .);
+   } > FLASH
++  .sdh_stack_observers :
++  {
++    PROVIDE(__start_sdh_stack_observers = .);
++    KEEP(*(SORT(.sdh_stack_observers*)))
++    PROVIDE(__stop_sdh_stack_observers = .);
++  } > FLASH
+   .log_backends :
+   {
+     PROVIDE(__start_log_backends = .);
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 index bb385de..c244199 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/config/sdk_config.h
 @@ -133,7 +133,7 @@
  // <i> gaps. Tailor this value to adhere to this limitation.
  
@@ -70568,10 +71075,10 @@ index bb385de..c244199 100644
  // <o> NRF_BLE_BMS_BLE_OBSERVER_PRIO  
  // <i> Priority with which BLE events are dispatched to the Bond Management Service.
  
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 index c7771fd..e6a0b2c 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/ble_connectivity_s140_usb_hci_pca10059.emProject
 @@ -16,7 +16,7 @@
        arm_target_device_name="nRF52840_xxAA"
        arm_target_interface_type="SWD"
@@ -70598,10 +71105,21 @@ index c7771fd..e6a0b2c 100644
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uart.c" />
        <file file_name="../../../../../../modules/nrfx/drivers/src/nrfx_uarte.c" />
      </folder>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-index 6b7653b..95c368d 100644
+diff --git nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+index 6b7653b..d9b36f6 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
++++ nRF5_SDK_15.2.0_39354f6/examples/connectivity/ble_connectivity/pca10059/ser_s140_usb_hci/ses/flash_placement.xml
+@@ -11,9 +11,9 @@
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_queue" inputsections="*(.nrf_queue*)" address_symbol="__start_nrf_queue" end_symbol="__stop_nrf_queue" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_const_data" inputsections="*(SORT(.log_const_data*))" address_symbol="__start_log_const_data" end_symbol="__stop_log_const_data" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".nrf_balloc" inputsections="*(.nrf_balloc*)" address_symbol="__start_nrf_balloc" end_symbol="__stop_nrf_balloc" />
+-    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_req_observers" inputsections="*(SORT(.sdh_req_observers*))" address_symbol="__start_sdh_req_observers" end_symbol="__stop_sdh_req_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_state_observers" inputsections="*(SORT(.sdh_state_observers*))" address_symbol="__start_sdh_state_observers" end_symbol="__stop_sdh_state_observers" />
++    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".sdh_stack_observers" inputsections="*(SORT(.sdh_stack_observers*))" address_symbol="__start_sdh_stack_observers" end_symbol="__stop_sdh_stack_observers" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_backends" inputsections="*(SORT(.log_backends*))" address_symbol="__start_log_backends" end_symbol="__stop_log_backends" />
+     <ProgramSection alignment="4" keep="Yes" load="No" name=".nrf_sections" address_symbol="__start_nrf_sections" />
+     <ProgramSection alignment="4" keep="Yes" load="Yes" name=".log_dynamic_data"  inputsections="*(SORT(.log_dynamic_data*))" runin=".log_dynamic_data_run"/>
 @@ -43,4 +43,7 @@
      <ProgramSection alignment="8" size="__STACKSIZE__" load="No" place_from_segment_end="Yes" name=".stack"  address_symbol="__StackLimit" end_symbol="__StackTop"/>
      <ProgramSection alignment="8" size="__STACKSIZE_PROCESS__" load="No" name=".stack_process" />
@@ -70610,10 +71128,10 @@ index 6b7653b..95c368d 100644
 +    <ProgramSection alignment="4" keep="Yes" load="Yes" name=".connectivity_version_info" address_symbol="__start_connectivity_version_info" end_symbol="__stop_connectivity_version_info" start = "0x50000" size="0x18" />
 +  </MemorySegment>
  </Root>
-diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_e18d5d2/examples/dfu/dfu_public_key.c
+diff --git nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c nRF5_SDK_15.2.0_39354f6/examples/dfu/dfu_public_key.c
 index e483589..8629005 100644
 --- nRF5_SDK_15.2.0_9412b96/examples/dfu/dfu_public_key.c
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/dfu/dfu_public_key.c
++++ nRF5_SDK_15.2.0_39354f6/examples/dfu/dfu_public_key.c
 @@ -1,30 +1,51 @@
 +/**
 + * Copyright (c) 2010 - 2018, Nordic Semiconductor ASA
@@ -70688,11 +71206,11 @@ index e483589..8629005 100644
 -#else
 -#error "Debug public key not valid for production. Please see https://github.com/NordicSemiconductor/pc-nrfutil/blob/master/README.md to generate it"
 -#endif
-diff --git nRF5_SDK_15.2.0_e18d5d2/examples/readme.txt nRF5_SDK_15.2.0_e18d5d2/examples/readme.txt
+diff --git nRF5_SDK_15.2.0_39354f6/examples/readme.txt nRF5_SDK_15.2.0_39354f6/examples/readme.txt
 new file mode 100644
 index 0000000..ac71eca
 --- /dev/null
-+++ nRF5_SDK_15.2.0_e18d5d2/examples/readme.txt
++++ nRF5_SDK_15.2.0_39354f6/examples/readme.txt
 @@ -0,0 +1,14 @@
 +Matrix shows which board is supported by given example
 +
@@ -70708,10 +71226,10 @@ index 0000000..ac71eca
 +--------------------------------------------------------------------------
 +connectivity\ble_connectivity  |  *   |      |  *   |  *   |      |  *   |
 +--------------------------------------------------------------------------
-diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_e18d5d2/integration/nrfx/legacy/nrf_drv_power.c
+diff --git nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c nRF5_SDK_15.2.0_39354f6/integration/nrfx/legacy/nrf_drv_power.c
 index bba3d13..139d375 100644
 --- nRF5_SDK_15.2.0_9412b96/integration/nrfx/legacy/nrf_drv_power.c
-+++ nRF5_SDK_15.2.0_e18d5d2/integration/nrfx/legacy/nrf_drv_power.c
++++ nRF5_SDK_15.2.0_39354f6/integration/nrfx/legacy/nrf_drv_power.c
 @@ -47,6 +47,14 @@
  #include "nrf_sdh_soc.h"
  #endif
@@ -70781,3 +71299,9 @@ index bba3d13..139d375 100644
      if (nrfx_power_usb_handler_get() != NULL)
      {
          ret_code_t err_code = nrf_drv_power_sd_usbevt_enable(true);
+diff --git nRF5_SDK_15.2.0_39354f6/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_39354f6.patch nRF5_SDK_15.2.0_39354f6/nRF5_SDK_15.2.0_9412b96-to-nRF5_SDK_15.2.0_39354f6.patch
+new file mode 100644
+index 0000000..e69de29
+diff --git nRF5_SDK_15.2.0_39354f6/patch-summary.txt nRF5_SDK_15.2.0_39354f6/patch-summary.txt
+new file mode 100644
+index 0000000..e69de29


### PR DESCRIPTION
This PR allows using the same connectivity firmware with Nordic USB CDC support for both PCA10056 and PCA10059.

The algorithm for detecting if it is PCA10056 or PCA10059 is to check if it is possible to communicate with the QSPI chip. PCA10059 does not have a QSPI chip. 
