### PR TITLE
Enable use of VCPKG_ROOT env variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ else()
     set(CONNECTIVITY_VERSION "${CONNECTIVITY_VERSION}" CACHE STRING "" FORCE)
 endif()
 
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      CACHE STRING "")
+endif()
+
 project(
     nrf-ble-driver
     VERSION ${NRF_BLE_DRIVER_VERSION}


### PR DESCRIPTION
To make it easier to create project files VCPKG_ROOT environment variable can be used by projects.

Using the environment variable developer do not have to provide the -DCMAKE_TOOLCHAIN_FILE=<location> define to location of the toolchain file