### PR TITLE
Use Asio truly in a standalone manner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(LIB_PLATFORM_SRC_FILES ${LIB_PLATFORM_C_SRC_FILES} ${LIB_PLATFORM_CPP_SRC_FI
 
 # Add common compiler definitions
 add_definitions(
+    -DASIO_STANDALONE
     -DSD_RPC_EXPORTS
     -DHCI_LINK_CONTROL # Adds support for Link Control packets according to the HCI standard
 )


### PR DESCRIPTION
Recent versions are stated to remove boost dependency. But when I try to build on a Linux without boost installed, and latest Asio extracted from tarball, it complains for missing boost headers. 
According to https://think-async.com/Asio/AsioStandalone.html it should be able to make it actually standalone simply by adding a definition. 
This PR seems to work in my case (at least the build process passes).
I guess Nordic people didn't notice since older versions does rely on boost and it still resides in DEV environment?