### PR TITLE
Remove baud wiggle

### DIFF
--- a/cmake/nrf-ble-driver.cmake
+++ b/cmake/nrf-ble-driver.cmake
@@ -53,7 +53,7 @@ endif()
 # Add or remove SD API versions here
 if(NOT SD_API_VER_NUMS)
 	#set(SD_API_VER_NUMS 2 3 5 6)
-	set(SD_API_VER_NUMS 5)
+	set(SD_API_VER_NUMS 2 3 5)
 endif()
 
 list(LENGTH SD_API_VER_NUMS SD_API_VER_COUNT)

--- a/cmake/nrf-ble-driver.cmake
+++ b/cmake/nrf-ble-driver.cmake
@@ -52,7 +52,8 @@ endif()
 
 # Add or remove SD API versions here
 if(NOT SD_API_VER_NUMS)
-    set(SD_API_VER_NUMS 2 3 5 6)
+	#set(SD_API_VER_NUMS 2 3 5 6)
+	set(SD_API_VER_NUMS 5)
 endif()
 
 list(LENGTH SD_API_VER_NUMS SD_API_VER_COUNT)

--- a/cmake/nrf-ble-driver.cmake
+++ b/cmake/nrf-ble-driver.cmake
@@ -52,8 +52,7 @@ endif()
 
 # Add or remove SD API versions here
 if(NOT SD_API_VER_NUMS)
-	#set(SD_API_VER_NUMS 2 3 5 6)
-	set(SD_API_VER_NUMS 2 3 5)
+    set(SD_API_VER_NUMS 2 3 5 6)
 endif()
 
 list(LENGTH SD_API_VER_NUMS SD_API_VER_COUNT)

--- a/include/common/internal/transport/uart_boost.h
+++ b/include/common/internal/transport/uart_boost.h
@@ -119,13 +119,16 @@ class UartBoost : public Transport
 
     UartSettingsBoost uartSettingsBoost;
     bool asyncWriteInProgress;
-    std::thread *ioServiceThread;
+    std::unique_ptr<std::thread> ioServiceThread;
 
-    asio::io_service *ioService;
-    asio::serial_port *serialPort;
+    std::unique_ptr<asio::io_service> ioService;
+    std::unique_ptr<asio::serial_port> serialPort;
+    std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>> workNotifier;
 
-    asio::io_service::work *workNotifier;
-
+    /**
+     * @brief      Purge RX and TX data in serial buffers. On WIN32, in addition, abort any overlapped operations
+     */
+    void purge();
 };
 
 #endif // UART_BOOST_H

--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -74,7 +74,7 @@ const uint8_t PACKET_RETRANSMISSIONS =
 // Other constants
 
 // Duration to wait for state ACTIVE after open is called
-const auto OPEN_WAIT_TIMEOUT = std::chrono::milliseconds(2000);
+const auto OPEN_WAIT_TIMEOUT = std::chrono::milliseconds(3000);
 // Duration to wait before continuing UART communication after reset is sent to target
 const auto RESET_WAIT_DURATION = std::chrono::milliseconds(300);
 

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -200,7 +200,7 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
         // The 200ms wait time is based on testing with PCA10028, PCA10031 and PCA10040.
         // All of these devices use the SEGGER OB which at the time of testing has firmware version
         // "J-Link OB-SAM3U128-V2-NordicSemi compiled Jan 12 2018 16:05:20"
-        // std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
+        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
     }
     catch (std::exception &ex)
     {

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -53,7 +53,9 @@
 
 #include <asio.hpp>
 
+#ifdef SEGGER_HWFC_WORKAROUND
 constexpr uint32_t DUMMY_BAUD_RATE = 9600;
+#endif // SEGGER_HWFC_WORKAROUND
 
 UartBoost::UartBoost(const UartCommunicationParameters &communicationParameters)
     : Transport()
@@ -123,15 +125,6 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
     {
         serialPort->open(portName);
 
-        // Wait a bit before making the device available since there are problems
-        // if data is sent right after open.
-        //
-        // Not sure if this is an OS issue or if it is an issue with the device USB stack.
-        // The 200ms wait time is based on testing with PCA10028, PCA10031 and PCA10040.
-        // All of these devices use the SEGGER OB which at the time of testing has firmware version
-        // "J-Link OB-SAM3U128-V2-NordicSemi compiled Jan 12 2018 16:05:20"
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
         const auto flowControl   = uartSettingsBoost.getBoostFlowControl();
         const auto stopBits      = uartSettingsBoost.getBoostStopBits();
         const auto parity        = uartSettingsBoost.getBoostParity();
@@ -198,6 +191,15 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
             throw std::system_error(error, "Failed to set baud rate to " + std::to_string(speed));
         }
 #endif
+
+        // Wait a bit before making the device available since there are problems
+        // if data is sent right after open.
+        //
+        // Not sure if this is an OS issue or if it is an issue with the device USB stack.
+        // The 200ms wait time is based on testing with PCA10028, PCA10031 and PCA10040.
+        // All of these devices use the SEGGER OB which at the time of testing has firmware version
+        // "J-Link OB-SAM3U128-V2-NordicSemi compiled Jan 12 2018 16:05:20"
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
     catch (std::exception &ex)
     {

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -56,7 +56,7 @@
 #ifdef SEGGER_HWFC_WORKAROUND
 constexpr uint32_t DUMMY_BAUD_RATE = 9600;
 #endif // SEGGER_HWFC_WORKAROUND
-constexpr auto SLEEP_BETWEEN_UART_SETTING = std::chrono::milliseconds(100);
+constexpr auto SLEEP_BETWEEN_UART_SETTING = std::chrono::milliseconds(200);
 
 UartBoost::UartBoost(const UartCommunicationParameters &communicationParameters)
     : Transport()

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -56,7 +56,7 @@
 #ifdef SEGGER_HWFC_WORKAROUND
 constexpr uint32_t DUMMY_BAUD_RATE = 9600;
 #endif // SEGGER_HWFC_WORKAROUND
-constexpr auto SLEEP_BETWEEN_UART_SETTING = std::chrono::milliseconds(200);
+constexpr auto SLEEP_BETWEEN_UART_SETTING = std::chrono::milliseconds(50);
 
 UartBoost::UartBoost(const UartCommunicationParameters &communicationParameters)
     : Transport()

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -200,7 +200,7 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
         // The 200ms wait time is based on testing with PCA10028, PCA10031 and PCA10040.
         // All of these devices use the SEGGER OB which at the time of testing has firmware version
         // "J-Link OB-SAM3U128-V2-NordicSemi compiled Jan 12 2018 16:05:20"
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
+        // std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
     }
     catch (std::exception &ex)
     {

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -132,13 +132,9 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
         const auto characterSize = uartSettingsBoost.getBoostCharacterSize();
 
         serialPort->set_option(flowControl);
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
         serialPort->set_option(stopBits);
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
         serialPort->set_option(parity);
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
         serialPort->set_option(characterSize);
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
 
 #ifdef SEGGER_HWFC_WORKAROUND
         // SEGGER J-LINK-OB VCOM has an issue when auto-detecting UART flow control
@@ -163,7 +159,6 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
         // Set dummy baud rate
         auto baudRate = asio::serial_port::baud_rate(DUMMY_BAUD_RATE);
         serialPort->set_option(baudRate);
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
 #else
         asio::serial_port::baud_rate baudRate;
 #endif // SEGGER_HWFC_WORKAROUND
@@ -171,7 +166,6 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
         // Set requested baud rate
         baudRate = uartSettingsBoost.getBoostBaudRate();
         serialPort->set_option(baudRate);
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
 #else // !defined(__APPLE__)
         // Workaround for setting non-standard baudrate on macOS
         // get underlying boost serial port handle and apply baud rate directly
@@ -185,7 +179,6 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
             throw std::system_error(error, "Failed to set dummy baud rate (" +
                                                std::to_string(speed) + ")");
         }
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
 #else
         speed_t speed;
 #endif // SEGGER_HWFC_WORKAROUND
@@ -198,7 +191,6 @@ uint32_t UartBoost::open(const status_cb_t &status_callback, const data_cb_t &da
             const auto error = std::error_code(errno, std::system_category());
             throw std::system_error(error, "Failed to set baud rate to " + std::to_string(speed));
         }
-        std::this_thread::sleep_for(SLEEP_BETWEEN_UART_SETTING);
 #endif
 
         // Wait a bit before making the device available since there are problems

--- a/src/common/transport/uart_boost.cpp
+++ b/src/common/transport/uart_boost.cpp
@@ -56,7 +56,7 @@
 #ifdef SEGGER_HWFC_WORKAROUND
 constexpr uint32_t DUMMY_BAUD_RATE = 9600;
 #endif // SEGGER_HWFC_WORKAROUND
-constexpr auto SLEEP_BETWEEN_UART_SETTING = std::chrono::milliseconds(50);
+constexpr auto SLEEP_BETWEEN_UART_SETTING = std::chrono::milliseconds(100);
 
 UartBoost::UartBoost(const UartCommunicationParameters &communicationParameters)
     : Transport()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 find_package(Catch2 CONFIG REQUIRED)
 
 include_directories (
-    ../3rdparty
     ../include/common/sdk_compat
     ../include/common
     ../include/common/internal/transport
@@ -102,15 +101,20 @@ function(add_softdevice_test target_name pca device_a device_b connfw tests_repo
 
     add_custom_command(
         OUTPUT ${COMMAND_NAME}
+        COMMAND ${CMAKE_COMMAND} -E echo "Preparing to run test target ${target_name} with connectivity ${connfw}."
+    )
 
-        COMMAND ${NRFJPROG} --version
+    add_custom_command(
+        OUTPUT ${COMMAND_NAME}
+
+        APPEND COMMAND ${NRFJPROG} --version
         COMMAND ${CMAKE_COMMAND} -E echo "Erasing ${pca}/${DEVICE_A_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_A_SEGGER_SN} --eraseall --log
         COMMAND ${CMAKE_COMMAND} -E echo "Programming ${pca}/${DEVICE_A_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_A_SEGGER_SN} --program ${connfw} --log
         COMMAND ${CMAKE_COMMAND} -E echo "Resetting ${pca}/${DEVICE_A_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_A_SEGGER_SN} --reset --log
-        COMMAND ${CMAKE_COMMAND} -E echo "Resetting of ${pca}/${DEVICE_B_SEGGER_SN} complete."
+        COMMAND ${CMAKE_COMMAND} -E echo "Resetting of ${pca}/${DEVICE_A_SEGGER_SN} complete."
 
         COMMAND ${CMAKE_COMMAND} -E echo "Erasing ${pca}/${DEVICE_B_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_B_SEGGER_SN} --eraseall --log
@@ -137,7 +141,7 @@ function(add_softdevice_test target_name pca device_a device_b connfw tests_repo
     foreach(integration_test IN LISTS tests)
         add_custom_command(
             OUTPUT ${COMMAND_NAME}
-            APPEND COMMAND ${CMAKE_COMMAND} -E echo "Running tests from $<TARGET_FILE:${integration_test}> with connectivity ${connfw}."
+            APPEND COMMAND ${CMAKE_COMMAND} -E echo "Running tests in $<TARGET_FILE:${integration_test}> with connectivity ${connfw}."
         )
 
         add_custom_command(
@@ -157,7 +161,7 @@ function(add_softdevice_test target_name pca device_a device_b connfw tests_repo
             --hardware-info "hex:${connfw_filename},pca:${pca},segger_sn:${DEVICE_A_SEGGER_SN},${DEVICE_B_SEGGER_SN}"
             --reporter ${tests_reporter}
             --order lex
-            --out "$<TARGET_FILE_DIR:${integration_test}>/test-reports/${target_name}-${integration_test}.xml" || (exit 0)
+            --out "$<TARGET_FILE_DIR:${integration_test}>/test-reports/${target_name}-${integration_test}.xml" || ${CMAKE_COMMAND} -E echo "Target ${target_name} failed."
             DEPENDS ${integration_test}
         )
     endforeach()


### PR DESCRIPTION
SEGGER J-Link OB has issues when the operating system and application set UART settings on the J-Link OB device without some delay between each setting.

To reduce the chance of the issue happening this PR disable the baud wiggle procedure. The baud wiggle routine was implemented because it triggered the hardware flow control detection routine in the J-Link OB which was previously caused trouble without this fix.

We have also seen that adding delays before reading/writing on UART reduce the chance of hitting the issue.