### PR TITLE
Check if status callback returns errors

### DIFF
--- a/src/sd_api_v6/ble_gap_impl.cpp
+++ b/src/sd_api_v6/ble_gap_impl.cpp
@@ -336,9 +336,7 @@ uint32_t sd_ble_gap_privacy_get(adapter_t *adapter, ble_gap_privacy_params_t *p_
     return gap_encode_decode(adapter, encode_function, decode_function);
 }
 
-uint32_t sd_ble_gap_adv_stop(adapter_t *adapter, uint8_t adv_handle
-
-)
+uint32_t sd_ble_gap_adv_stop(adapter_t *adapter, uint8_t adv_handle)
 {
     encode_function_t encode_function = [&](uint8_t *buffer, uint32_t *length) -> uint32_t {
         return ble_gap_adv_stop_req_enc(adv_handle, buffer, length);

--- a/test/softdevice_api/testcase_issue_gh_112.cpp
+++ b/test/softdevice_api/testcase_issue_gh_112.cpp
@@ -532,6 +532,22 @@ TEST_CASE(CREATE_TEST_NAME_AND_TAGS(issue_gh_112,
             }
         });
 
+    c->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+        if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+            code == PKT_UNEXPECTED)
+        {
+            centralError = true;
+        }
+    });
+
+    p->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+        if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+            code == PKT_UNEXPECTED)
+        {
+            peripheralError = true;
+        }
+    });
+
     // Open the adapters
     REQUIRE(c->open() == NRF_SUCCESS);
     REQUIRE(p->open() == NRF_SUCCESS);

--- a/test/softdevice_api/testcase_phy_update.cpp
+++ b/test/softdevice_api/testcase_phy_update.cpp
@@ -275,6 +275,22 @@ TEST_CASE(CREATE_TEST_NAME_AND_TAGS(phy_update, [known_issue][PCA10056][PCA10059
             }
         });
 
+        c->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+            if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+                code == PKT_UNEXPECTED)
+            {
+                error = true;
+            }
+        });
+
+        p->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+            if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+                code == PKT_UNEXPECTED)
+            {
+                error = true;
+            }
+        });
+
         // Open the adapters
         REQUIRE(c->open() == NRF_SUCCESS);
         REQUIRE(p->open() == NRF_SUCCESS);

--- a/test/softdevice_api/testcase_rssi.cpp
+++ b/test/softdevice_api/testcase_rssi.cpp
@@ -340,6 +340,22 @@ TEST_CASE(CREATE_TEST_NAME_AND_TAGS(rssi, [PCA10028][PCA10031][PCA10040][PCA1005
         }
     });
 
+    c->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+        if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+            code == PKT_UNEXPECTED)
+        {
+            centralError = true;
+        }
+    });
+
+    p->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+        if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+            code == PKT_UNEXPECTED)
+        {
+            peripheralError = true;
+        }
+    });
+
     // Open the adapters
     REQUIRE(c->open() == NRF_SUCCESS);
     REQUIRE(p->open() == NRF_SUCCESS);

--- a/test/softdevice_api/testcase_security.cpp
+++ b/test/softdevice_api/testcase_security.cpp
@@ -286,6 +286,22 @@ TEST_CASE(CREATE_TEST_NAME_AND_TAGS(security, [PCA10028][PCA10031][PCA10040][PCA
             }
         });
 
+        c->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+            if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+                code == PKT_UNEXPECTED)
+            {
+                error = true;
+            }
+        });
+
+        p->setStatusCallback([&](const sd_rpc_app_status_t code, const std::string &message) {
+            if (code == PKT_DECODE_ERROR || code == PKT_SEND_MAX_RETRIES_REACHED ||
+                code == PKT_UNEXPECTED)
+            {
+                error = true;
+            }
+        });
+
         // Open the adapters
         REQUIRE(c->open() == NRF_SUCCESS);
         REQUIRE(p->open() == NRF_SUCCESS);


### PR DESCRIPTION
Some tests did not have a check for status callback errors.
This PR adds a check of the status errors and make the test fail is they are of type:
PKT_DECODE_ERROR
PKT_SEND_MAX_RETRIES_REACHED
PKT_UNEXPECTED