### PR TITLE
Make creation of run test targets optional

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,6 +18,15 @@ function(setup_example example_directory)
             # Assume Linux
             target_link_libraries(${EXAMPLE_NAME} PRIVATE nrf_ble_driver_sd_api_v${SD_API_VER}_static "pthread")
         endif()
+
+        install(
+            TARGETS ${EXAMPLE_NAME}
+            EXPORT ${PROJECT_NAME}-targets
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/examples
+            COMPONENT Examples
+        )
     endforeach()
 endfunction(setup_example)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 find_package(Catch2 CONFIG REQUIRED)
 
 include_directories (
-    ../3rdparty
     ../include/common/sdk_compat
     ../include/common
     ../include/common/internal/transport
@@ -17,28 +16,38 @@ set(TESTS_SOFTDEVICE_V3 )
 set(TESTS_SOFTDEVICE_V5 )
 set(TESTS_SOFTDEVICE_V6 )
 
-set(CONNECTIVITY_ROOT "${CMAKE_SOURCE_DIR}/hex")
-find_program(NRFJPROG "nrfjprog")
+function(setup_test_run)
+    set(CONNECTIVITY_ROOT "${CMAKE_SOURCE_DIR}/hex")
+    find_program(NRFJPROG "nrfjprog")
 
-if(NOT NRFJPROG)
-    message(STATUS "nrfjprog not found, tests will not be ran.")
-endif()
+    if(NOT NRFJPROG)
+        message(STATUS "nrfjprog not found, tests will not be ran.")
+    endif()
 
-execute_process(
-    COMMAND ${NRFJPROG} "--version" 
-    OUTPUT_VARIABLE version_info
-    RESULT_VARIABLE result
-)
+    execute_process(
+        COMMAND ${NRFJPROG} "--version"
+        OUTPUT_VARIABLE version_info
+        RESULT_VARIABLE result
+    )
 
-message(STATUS "nrfjprog reports:\nversion:${version_info}\nexit_code:${result}\n")
+    message(STATUS "nrfjprog reports:\nversion:${version_info}\nexit_code:${result}\n")
 
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v2/connectivity_${CONNECTIVITY_VERSION}_1m_with_s130_2.0.1.hex" SD_API_V2_S130_HEX)
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v3/connectivity_${CONNECTIVITY_VERSION}_1m_with_s132_3.1.0.hex" SD_API_V3_S132_HEX)
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v3/connectivity_${CONNECTIVITY_VERSION}_usb_with_s132_3.1.0.hex" SD_API_V3_S132_PCA10056_USB_HEX)
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v5/connectivity_${CONNECTIVITY_VERSION}_1m_with_s132_5.1.0.hex" SD_API_V5_S132_HEX)
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v6/connectivity_${CONNECTIVITY_VERSION}_1m_with_s132_6.1.0.hex" SD_API_V6_S132_HEX)
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v6/connectivity_${CONNECTIVITY_VERSION}_1m_with_s140_6.1.0.hex" SD_API_V6_S140_HEX)
-file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v6/connectivity_${CONNECTIVITY_VERSION}_usb_with_s140_6.1.0.hex" SD_API_V6_S140_PCA10056_USB_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v2/connectivity_${CONNECTIVITY_VERSION}_1m_with_s130_2.0.1.hex" SD_API_V2_S130_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v3/connectivity_${CONNECTIVITY_VERSION}_1m_with_s132_3.1.0.hex" SD_API_V3_S132_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v3/connectivity_${CONNECTIVITY_VERSION}_usb_with_s132_3.1.0.hex" SD_API_V3_S132_PCA10056_USB_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v5/connectivity_${CONNECTIVITY_VERSION}_1m_with_s132_5.1.0.hex" SD_API_V5_S132_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v6/connectivity_${CONNECTIVITY_VERSION}_1m_with_s132_6.1.0.hex" SD_API_V6_S132_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v6/connectivity_${CONNECTIVITY_VERSION}_1m_with_s140_6.1.0.hex" SD_API_V6_S140_HEX)
+    file(TO_NATIVE_PATH "${CONNECTIVITY_ROOT}/sd_api_v6/connectivity_${CONNECTIVITY_VERSION}_usb_with_s140_6.1.0.hex" SD_API_V6_S140_PCA10056_USB_HEX)
+
+    set(SD_API_V2_S130_HEX ${SD_API_V2_S130_HEX} PARENT_SCOPE)
+    set(SD_API_V3_S132_HEX ${SD_API_V3_S132_HEX} PARENT_SCOPE)
+    set(SD_API_V3_S132_PCA10056_USB_HEX ${SD_API_V3_S132_PCA10056_USB_HEX} PARENT_SCOPE)
+    set(SD_API_V5_S132_HEX ${SD_API_V5_S132_HEX} PARENT_SCOPE)
+    set(SD_API_V6_S132_HEX ${SD_API_V6_S132_HEX} PARENT_SCOPE)
+    set(SD_API_V6_S140_HEX ${SD_API_V6_S140_HEX} PARENT_SCOPE)
+    set(SD_API_V6_S140_PCA10056_USB_HEX ${SD_API_V6_S140_PCA10056_USB_HEX} PARENT_SCOPE)
+endfunction(setup_test_run)
 
 function(parse_device_id device_id parse_error segger_sn serial_port)
     set(INVALID_FORMAT_MESSAGE "Device id ${device_id} is in an invalid format, must be <SEGGER_SERIAL_NUMBER>:<SERIAL_PORT>")
@@ -60,7 +69,7 @@ function(parse_device_id device_id parse_error segger_sn serial_port)
 
     set(${segger_sn} ${DEVICE_SEGGER_SN} PARENT_SCOPE)
     set(${serial_port} ${DEVICE_SERIAL_PORT} PARENT_SCOPE)
-endfunction()
+endfunction(parse_device_id)
 
 function(add_softdevice_test target_name pca device_a device_b connfw tests_reporter tests)
     # Basic sanity checks
@@ -102,15 +111,20 @@ function(add_softdevice_test target_name pca device_a device_b connfw tests_repo
 
     add_custom_command(
         OUTPUT ${COMMAND_NAME}
+        COMMAND ${CMAKE_COMMAND} -E echo "Preparing to run test target ${target_name} with connectivity ${connfw}."
+    )
 
-        COMMAND ${NRFJPROG} --version
+    add_custom_command(
+        OUTPUT ${COMMAND_NAME}
+
+        APPEND COMMAND ${NRFJPROG} --version
         COMMAND ${CMAKE_COMMAND} -E echo "Erasing ${pca}/${DEVICE_A_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_A_SEGGER_SN} --eraseall --log
         COMMAND ${CMAKE_COMMAND} -E echo "Programming ${pca}/${DEVICE_A_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_A_SEGGER_SN} --program ${connfw} --log
         COMMAND ${CMAKE_COMMAND} -E echo "Resetting ${pca}/${DEVICE_A_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_A_SEGGER_SN} --reset --log
-        COMMAND ${CMAKE_COMMAND} -E echo "Resetting of ${pca}/${DEVICE_B_SEGGER_SN} complete."
+        COMMAND ${CMAKE_COMMAND} -E echo "Resetting of ${pca}/${DEVICE_A_SEGGER_SN} complete."
 
         COMMAND ${CMAKE_COMMAND} -E echo "Erasing ${pca}/${DEVICE_B_SEGGER_SN}."
         COMMAND ${NRFJPROG} -s ${DEVICE_B_SEGGER_SN} --eraseall --log
@@ -137,7 +151,7 @@ function(add_softdevice_test target_name pca device_a device_b connfw tests_repo
     foreach(integration_test IN LISTS tests)
         add_custom_command(
             OUTPUT ${COMMAND_NAME}
-            APPEND COMMAND ${CMAKE_COMMAND} -E echo "Running tests from $<TARGET_FILE:${integration_test}> with connectivity ${connfw}."
+            APPEND COMMAND ${CMAKE_COMMAND} -E echo "Running tests in $<TARGET_FILE:${integration_test}> with connectivity ${connfw}."
         )
 
         add_custom_command(
@@ -157,13 +171,13 @@ function(add_softdevice_test target_name pca device_a device_b connfw tests_repo
             --hardware-info "hex:${connfw_filename},pca:${pca},segger_sn:${DEVICE_A_SEGGER_SN},${DEVICE_B_SEGGER_SN}"
             --reporter ${tests_reporter}
             --order lex
-            --out "$<TARGET_FILE_DIR:${integration_test}>/test-reports/${target_name}-${integration_test}.xml" || (exit 0)
+            --out "$<TARGET_FILE_DIR:${integration_test}>/test-reports/${target_name}-${integration_test}.xml" || ${CMAKE_COMMAND} -E echo "Target ${target_name} failed."
             DEPENDS ${integration_test}
         )
     endforeach()
 
     add_custom_target("${target_name}" DEPENDS ${COMMAND_NAME})
-endfunction()
+endfunction(add_softdevice_test)
 
 function(add_run_test_targets)
     # SoftDevice API version -> SoftDevice version -> PCBA
@@ -356,7 +370,7 @@ function(setup_test)
 
     file(GLOB test_util_src "util/src/*.cpp")
 
-    message(STATUS "softdevice_api_ver:${softdevice_api_ver} source_file:${source_file} source_testcases:${source_testcases} test_list:${test_list}")
+    #message(STATUS "softdevice_api_ver:${softdevice_api_ver} source_file:${source_file} source_testcases:${source_testcases} test_list:${test_list}")
 
     get_filename_component(test_name ${source_file} NAME_WE)
     set(test_name "${test_name}_v${softdevice_api_ver}")
@@ -382,6 +396,15 @@ function(setup_test)
     else()
         message(STATUS "${test_name} NOT ADDED to ${test_list} since the test is a serial port loopback test.")
     endif()
+
+    install(
+        TARGETS ${test_name}
+        EXPORT ${PROJECT_NAME}-targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/tests
+        COMPONENT Tests
+    )
 endfunction(setup_test)
 
 if(TEST_ALL)
@@ -393,13 +416,12 @@ if(TEST_TRANSPORT)
     file(GLOB transport_tests_src "transport/test_*.cpp")
 
     list(GET SD_API_VER_NUMS 0 ANY_SD_API_VERSION)
-    message(STATUS "Linking common code with SoftDevice API version ${ANY_SD_API_VERSION}")
 
     foreach(transport_test_src ${transport_tests_src})
         # Use any SD API version for linking object files common between SD API versions
         setup_test(SOURCE_FILE ${transport_test_src} SOURCE_TESTCASES "" SOFTDEVICE_API_VER ${ANY_SD_API_VERSION} TEST_LIST TESTS_SOFTDEVICE_${ANY_SD_API_VERSION})
     endforeach(transport_test_src)
-endif(TEST_TRANSPORT)
+endif()
 
 if(TEST_SOFTDEVICE_API)
     file(GLOB tests_src "softdevice_api/test_*.cpp")
@@ -411,5 +433,8 @@ if(TEST_SOFTDEVICE_API)
         endforeach(test_src)
     endforeach(SD_API_VER)
 
-    add_run_test_targets()
-endif(TEST_SOFTDEVICE_API)
+    if(CREATE_RUN_TEST_TARGETS)
+        setup_test_run()
+        add_run_test_targets()
+    endif()
+endif()


### PR DESCRIPTION
Make it possible to compile tests without having to create test run targets
Add support for tests and examples in output artifact
