### PR TITLE
Make tidy target use .clang-tidy config, enable clang-tidy on win32

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -54,12 +54,12 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
@@ -89,10 +89,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
-RawStringFormats: 
-  - Delimiter:       pb
-    Language:        TextProto
-    BasedOnStyle:    google
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,3 @@
 ---
 Checks: '*,-llvm-header-guard,-llvm-include-order,-llvm-namespace-comment,-readability-else-after-return,-misc-macro-parentheses,-clang-analyzer-alpha.core.CastToStruct,-modernize-raw-string-literal,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,-google-readability-namespace-comments,-google-readability-braces-around-statements,-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references,-fuchsia-default-arguments'
-WarningsAsErrors: ''
-HeaderFilterRegex: '.*'
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,22 +1,5 @@
 ---
-Checks: "-*,\
--llvm-header-guard,\
--llvm-include-order,\
--llvm-namespace-comment,\
--readability-else-after-return,\
--misc-macro-parentheses,\
--clang-analyzer-alpha.core.CastToStruct,\
--modernize-raw-string-literal,\
--cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
--cppcoreguidelines-pro-bounds-constant-array-index,\
--cppcoreguidelines-pro-bounds-pointer-arithmetic,\
--cppcoreguidelines-pro-type-member-init,\
--cppcoreguidelines-pro-type-reinterpret-cast,\
--cppcoreguidelines-pro-type-vararg,\
--google-readability-namespace-comments,\
--google-readability-braces-around-statements,-readability-braces-around-statements,\
--google-readability-todo,\
--google-runtime-int,\
--google-runtime-references,\
-"
+Checks: '*,-llvm-header-guard,-llvm-include-order,-llvm-namespace-comment,-readability-else-after-return,-misc-macro-parentheses,-clang-analyzer-alpha.core.CastToStruct,-modernize-raw-string-literal,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-vararg,-google-readability-namespace-comments,-google-readability-braces-around-statements,-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references,-fuchsia-default-arguments'
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
 ...

--- a/cmake/clang-dev-tools.cmake
+++ b/cmake/clang-dev-tools.cmake
@@ -18,7 +18,7 @@ if(WIN32)
     endif()
 endif()
 
-find_program(CLANG_TIDY NAMES run-clang-tidy.py run-clang-tidy-6.0.py)
+find_program(CLANG_TIDY NAMES run-clang-tidy-7.py run-clang-tidy.py)
 
 if(NOT CLANG_TIDY)
     message(STATUS "Did not find clang-tidy, target tidy is disabled.")

--- a/cmake/clang-dev-tools.cmake
+++ b/cmake/clang-dev-tools.cmake
@@ -1,54 +1,50 @@
 if(WIN32)
-	# CMAKE_EXPORT_COMPILE_COMMANDS is not working on Windows
-	message(STATUS "clang-tidy is not supported on Windows")
+    if (NOT CMAKE_GENERATOR STREQUAL "Ninja")
+        set(NOT_SUPPORTED_MESSAGE "clang-tidy is only supported with Ninja generator on Microsoft Windows.")
+        message(STATUS "${NOT_SUPPORTED_MESSAGE}")
 
-	# For the target not to fail:
-	add_custom_target(tidy COMMAND echo "not supported on Windows")
+        # For the target not to fail:
+        add_custom_target(tidy COMMAND echo "${NOT_SUPPORTED_MESSAGE}")
+        return()
+    else()
+        find_package (Python COMPONENTS Interpreter)
 
-else()
-	find_program(CLANG_TIDY NAMES run-clang-tidy.py run-clang-tidy-6.0.py)
-	if(NOT CLANG_TIDY)
-
-		message(STATUS "Did not find clang-tidy, target tidy is disabled.")
-		message(STATUS "If clang-tidy is installed, make sure run-clang-tidy.py is in PATH")
-
-		# For the target not to fail:
-		add_custom_target(tidy COMMAND echo "Clang-tidy is not installed")
-
-	else()
-		message(STATUS "Found clang-tidy, use \"make tidy\" to run it.")
-
-		# This will create build/compile_commands.json
-		set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-		set(CLANG_TIDY_CHECKS "*")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-llvm-header-guard")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-llvm-include-order")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-llvm-namespace-comment")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-readability-else-after-return")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-misc-macro-parentheses")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-clang-analyzer-alpha.core.CastToStruct")
-		# Modernize
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-modernize-raw-string-literal")
-		# CPP Core Guidelines
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-cppcoreguidelines-pro-bounds-array-to-pointer-decay")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-cppcoreguidelines-pro-bounds-constant-array-index")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-cppcoreguidelines-pro-bounds-pointer-arithmetic")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-cppcoreguidelines-pro-type-member-init") # as of https://llvm.org/bugs/show_bug.cgi?id=31039
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-cppcoreguidelines-pro-type-reinterpret-cast")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-cppcoreguidelines-pro-type-vararg")
-		# Google
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-google-readability-namespace-comments")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-google-readability-braces-around-statements,-readability-braces-around-statements")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-google-readability-todo")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-google-runtime-int")
-		set(CLANG_TIDY_CHECKS "${CLANG_TIDY_CHECKS},-google-runtime-references")
-		set(CLANG_TIDY_CHECKS "-checks='${CLANG_TIDY_CHECKS}'")
-
-		add_custom_target(tidy
-			COMMAND ${CLANG_TIDY} ${CLANG_TIDY_CHECKS}
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/build/
-		)
-	endif()
+        if(NOT Python_Interpreter_FOUND)
+            set(PYTHON_MISSING_MESSAGE "Python interpreter not found, it is required for run-clang-tidy.py")
+            message(STATUS "${PYTHON_MISSING_MESSAGE}")
+            add_custom_target(tidy COMMAND echo "${PYTHON_MISSING_MESSAGE}")
+            return()
+        endif()
+    endif()
 endif()
 
+find_program(CLANG_TIDY NAMES run-clang-tidy.py run-clang-tidy-6.0.py)
+
+if(NOT CLANG_TIDY)
+    message(STATUS "Did not find clang-tidy, target tidy is disabled.")
+    message(STATUS "If clang-tidy is installed, make sure run-clang-tidy.py and clang-tidy is in PATH")
+
+    # For the target not to fail:
+    add_custom_target(tidy COMMAND echo "Clang-tidy is not installed")
+else()
+    message(STATUS "Found clang-tidy, use \"cmake --build . --target tidy\" to run it.")
+
+    # This will create build/compile_commands.json
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+    # Configuration of rules are picked up from .clang-tidy
+    message(STATUS "Picking up clang-tidy rules from ${CMAKE_SOURCE_DIR}/.clang-tidy")
+    set(CLANG_TIDY_ARGS "-header-filter=.*")
+
+    if (WIN32)
+        add_custom_target(tidy
+            COMMAND ${Python_EXECUTABLE} ${CLANG_TIDY} ${CLANG_TIDY_ARGS} .
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    else()
+        add_custom_target(tidy
+            COMMAND ${CLANG_TIDY} ${CLANG_TIDY_ARGS} .
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        )
+    endif()
+endif()


### PR DESCRIPTION
To avoid maintaining the clang-tidy rule configuration in both .clang-tidy and in CMake, this patch removes the config in the CMake files.

The clang-tidy configuration is updated. The fuchsia-default-arguments check, which is hard to accommodate and not so relevant for this project, is disabled.

Support for using clang-tidy on Windows is also added (if the Ninja generator is used)