### PR TITLE
Increase timeout and retransmission values in examples

### DIFF
--- a/examples/heart_rate_collector/main.c
+++ b/examples/heart_rate_collector/main.c
@@ -229,8 +229,8 @@ static adapter_t * adapter_init(char * serial_port, uint32_t baud_rate)
                                             baud_rate,
                                             SD_RPC_FLOW_CONTROL_NONE,
                                             SD_RPC_PARITY_NONE);
-    data_link_layer = sd_rpc_data_link_layer_create_bt_three_wire(phy, 100);
-    transport_layer = sd_rpc_transport_layer_create(data_link_layer, 100);
+    data_link_layer = sd_rpc_data_link_layer_create_bt_three_wire(phy, 250);
+    transport_layer = sd_rpc_transport_layer_create(data_link_layer, 1500);
     return sd_rpc_adapter_create(transport_layer);
 }
 

--- a/examples/heart_rate_monitor/main.c
+++ b/examples/heart_rate_monitor/main.c
@@ -196,8 +196,8 @@ static adapter_t * adapter_init(char * serial_port, uint32_t baud_rate)
                                             baud_rate,
                                             SD_RPC_FLOW_CONTROL_NONE,
                                             SD_RPC_PARITY_NONE);
-    data_link_layer = sd_rpc_data_link_layer_create_bt_three_wire(phy, 100);
-    transport_layer = sd_rpc_transport_layer_create(data_link_layer, 100);
+    data_link_layer = sd_rpc_data_link_layer_create_bt_three_wire(phy, 250);
+    transport_layer = sd_rpc_transport_layer_create(data_link_layer, 1500);
     return sd_rpc_adapter_create(transport_layer);
 }
 


### PR DESCRIPTION
The examples has too low retransmission and timeout values for certain operation systems making the communication between the driver and the connectivity firmware break down when starting the connection.

Increasing the values help fixing this.
