### PR TITLE
Missing details in documentation of sd_rpc_serial_port_enum()

### DIFF
--- a/include/common/sd_rpc.h
+++ b/include/common/sd_rpc.h
@@ -59,6 +59,9 @@ extern "C" {
  * @param[in,out]  size The size of the array. The number of ports found is stored here.
  *
  * @retval NRF_SUCCESS  The serial ports were enumerated successfully.
+ * @retval NRF_ERROR_NULL size was a null pointer.
+ * @retval NRF_ERROR_DATA_SIZE The size of the array was not large enough to keep all descriptors found.
+ *                      No descriptors where copied. Call again with an larger array.
  * @retval NRF_ERROR    There was an error enumerating the serial ports.
  */
 SD_RPC_API uint32_t sd_rpc_serial_port_enum(sd_rpc_serial_port_desc_t serial_port_descs[], uint32_t *size);


### PR DESCRIPTION
Some details where left out of the documentation to `sd_rpc_serial_port_enum()` and have to gathered by reading the code itself. Maybe you want to incorporate my findings?