### PR TITLE
Fix/address sanitizer issues

### DIFF
--- a/src/common/transport/serialization_transport.cpp
+++ b/src/common/transport/serialization_transport.cpp
@@ -266,7 +266,7 @@ void SerializationTransport::eventHandlingRunner() noexcept
                 // Allocate memory to store decoded event including an unknown quantity of padding
                 auto possibleEventLength = static_cast<uint32_t>(MaxPossibleEventLength);
                 std::vector<uint8_t> eventDecodeBuffer;
-                eventDecodeBuffer.reserve(MaxPossibleEventLength);
+                eventDecodeBuffer.resize(MaxPossibleEventLength);
                 const auto event = reinterpret_cast<ble_evt_t *>(eventDecodeBuffer.data());
 
                 // Decode event

--- a/src/common/transport/slip.cpp
+++ b/src/common/transport/slip.cpp
@@ -82,6 +82,11 @@ uint32_t slip_decode(const std::vector<uint8_t> &packet, std::vector<uint8_t> &o
         else if (packet[i] == SLIP_ESC)
         {
             i++;
+            if (i == packet.size())
+            {
+                return NRF_ERROR_SD_RPC_H5_TRANSPORT_SLIP_DECODING;
+            }
+
             if (packet[i] == SLIP_ESC_END)
             {
                 out_packet.push_back(SLIP_END);


### PR DESCRIPTION
Hello,
currently it's not possible to use pc-ble-driver with binaries, that are build with the clang address sanitizer, because the sanitizer will find two tiny issues. Maybe you want to accept my fix to allow the use of the clang address sanitizer.

regards,
Torsten