### PR TITLE
Port ble_app_ipsp_initiator example to pc-ble-driver

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -51,5 +51,6 @@ endif()
 
 setup_example(heart_rate_monitor)
 setup_example(heart_rate_collector)
+setup_example(ble_app_ipsp_initiator)
 
 message(STATUS "Compiled examples are installed in directory \"${CMAKE_INSTALL_BINDIR}\"")

--- a/examples/ble_app_ipsp_initiator/main.c
+++ b/examples/ble_app_ipsp_initiator/main.c
@@ -1,0 +1,486 @@
+/**
+ * Copyright (c) 2013 - 2019, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/** @file
+ *
+ * @defgroup ble_sdk_6lowpan_eval_main 6LoWPAN Adaptation Layer.
+ * @{
+ * @ingroup ble_sdk_6lowpan_eval
+ * @brief 6LoWPAN Adaptation Layer Example.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#if NRF_SD_BLE_API >= 6
+//TODO:
+#include "ble_srv_common.h"
+#include "ble_ipsp.h"
+
+#include "sd_rpc.h"
+
+/** Definitions */
+#define DEFAULT_BAUD_RATE 1000000 /**< The baud rate to be used for serial communication with nRF5 device. */
+
+#ifdef _WIN32
+#define DEFAULT_UART_PORT_NAME "COM1"
+#endif
+#ifdef __APPLE__
+#define DEFAULT_UART_PORT_NAME "/dev/tty.usbmodem00000"
+#endif
+#ifdef __linux__
+#define DEFAULT_UART_PORT_NAME "/dev/ttyACM0"
+#endif
+
+/** Global variables */
+static adapter_t *m_adapter = NULL;
+
+//TODO: app_error.h
+#define APP_ERROR_CHECK(err_code) {if (err_code !=  NRF_SUCCESS) printf("APP_ERROR_CHECK:%d (%d)\n", __LINE__, err_code); }
+//TODO: nrf_log.h
+#define NRF_LOG_INFO printf
+
+
+#define APP_IPSP_TAG                        35                                                      /**< Identifier for L2CAP configuration with the softdevice. */
+#define APP_IPSP_INITIATOR_PRIO             1                                                       /**< Priority with the SDH on receiving events from the softdevice. */
+//#define SCANNING_LED                        BSP_LED_0_MASK                                          /**< Is on when device is scanning. */
+//#define CONNECTED_LED                       BSP_LED_1_MASK                                          /**< Is on when device is connected. */
+#define BUTTON_DETECTION_DELAY              APP_TIMER_TICKS(50)
+#define SCAN_INTERVAL                       0x00A0                                                  /**< Determines scan interval in units of 0.625 millisecond. */
+#define SCAN_WINDOW                         0x0050                                                  /**< Determines scan window in units of 0.625 millisecond. */
+#define MIN_CONNECTION_INTERVAL             MSEC_TO_UNITS(30, UNIT_1_25_MS)                         /**< Determines maximum connection interval in millisecond. */
+#define MAX_CONNECTION_INTERVAL             MSEC_TO_UNITS(60, UNIT_1_25_MS)                         /**< Determines maximum connection interval in millisecond. */
+#define SLAVE_LATENCY                       0                                                       /**< Determines slave latency in counts of connection events. */
+#define SUPERVISION_TIMEOUT                 MSEC_TO_UNITS(4000, UNIT_10_MS)                         /**< Determines supervision time-out in units of 10 millisecond. */
+#define DEAD_BEEF                           0xDEADBEEF                                              /**< Value used as error code on stack dump, can be used to identify stack location on stack unwind. */
+
+#define APP_ENABLE_LOGS                 1                                                           /**< Enable logs in the application. */
+
+#if (APP_ENABLE_LOGS == 1)
+
+#define APPL_LOG  NRF_LOG_INFO
+#define APPL_DUMP NRF_LOG_RAW_HEXDUMP_INFO
+#define APPL_ADDR IPV6_ADDRESS_LOG
+
+#else // APP_ENABLE_LOGS
+
+#define APPL_LOG(...)
+#define APPL_DUMP(...)
+#define APPL_ADDR(...)
+
+#endif // APP_ENABLE_LOGS
+
+static ble_ipsp_handle_t    m_handle;
+static uint16_t             m_conn_handle = BLE_CONN_HANDLE_INVALID;
+static const ble_gap_addr_t m_peer_addr =
+{
+    .addr_type = BLE_GAP_ADDR_TYPE_PUBLIC,
+    .addr = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x00}
+};
+
+
+/**
+ * @brief Scan parameters requested for scanning and connection.
+ */
+static const ble_gap_scan_params_t m_scan_param =
+{
+     .active         = 0,                          // Passive scanning.
+     .filter_policy  = BLE_GAP_SCAN_FP_ACCEPT_ALL, // Do not use whitelist.
+     .interval       = (uint16_t)SCAN_INTERVAL,    // Scan interval.
+     .window         = (uint16_t)SCAN_WINDOW,      // Scan window.
+     .timeout        = 0,                          // Never stop scanning unless explicit asked to.
+     .scan_phys      = BLE_GAP_PHY_AUTO            // Automatic PHY selection.
+};
+
+
+/**
+ * @brief Connection parameters requested for connection.
+ */
+static const ble_gap_conn_params_t m_connection_param =
+{
+    .min_conn_interval = (uint16_t)MIN_CONNECTION_INTERVAL,   // Minimum connection
+    .max_conn_interval = (uint16_t)MAX_CONNECTION_INTERVAL,   // Maximum connection
+    .slave_latency     = 0,                                   // Slave latency
+    .conn_sup_timeout  = (uint16_t)SUPERVISION_TIMEOUT        // Supervision time-out
+};
+
+
+/**@brief Function for handling the Application's BLE Stack events.
+ *
+ * @param[in]   p_ble_evt   Bluetooth stack event.
+ */
+static void on_ble_evt(ble_evt_t const * p_ble_evt)
+{
+    switch (p_ble_evt->header.evt_id)
+    {
+        case BLE_GAP_EVT_CONNECTED:
+            APPL_LOG("Connected, handle 0x%04X.\n", p_ble_evt->evt.gap_evt.conn_handle);
+            m_conn_handle = p_ble_evt->evt.gap_evt.conn_handle;
+
+            if (m_conn_handle != BLE_CONN_HANDLE_INVALID)
+            {
+                ble_ipsp_handle_t ipsp_handle;
+                ipsp_handle.conn_handle = m_conn_handle;
+                uint32_t err_code = ble_ipsp_connect(m_adapter, &ipsp_handle);
+                if (err_code != NRF_SUCCESS
+                    && err_code != NRF_ERROR_BLE_IPSP_CHANNEL_ALREADY_EXISTS) {
+                    APPL_LOG("ble_ipsp_connect fail %x", err_code);
+                }
+            }
+            else
+            {
+                APPL_LOG("No physical link exists with peer");
+            }
+
+            break;
+        case BLE_GAP_EVT_DISCONNECTED:
+            APPL_LOG("Disconnected.");
+
+            m_conn_handle = BLE_CONN_HANDLE_INVALID;
+            break;
+        default:
+            printf("on_ble_evt - default\n");
+            break;
+    }
+}
+
+/**@brief IPSP event handler.
+ * @param[in] p_handle Identifies the connection and channel on which the event occurred.
+ * @param[in] p_evt    Event and related parameters (if any).
+ *
+ * @returns    NRF_SUCCESS.
+ */
+static uint32_t app_ipsp_event_handler(ble_ipsp_handle_t const * p_handle,
+                                       ble_ipsp_evt_t const    * p_evt)
+{
+    switch (p_evt->evt_id)
+    {
+        case BLE_IPSP_EVT_CHANNEL_CONNECTED:
+        {
+            APPL_LOG("[0x%04X]:[0x%04X] BLE_IPSP_EVT_CHANNEL_CONNECTED Event. Result "
+                     "0x%08lX", p_handle->conn_handle, p_handle->cid, p_evt->evt_result);
+            if (p_evt->evt_result == NRF_SUCCESS)
+            {
+                m_handle = (*p_handle);
+            }
+            break;
+        }
+        case BLE_IPSP_EVT_CHANNEL_DISCONNECTED:
+        {
+            APPL_LOG("[0x%04X]:[0x%04X] BLE_IPSP_EVT_CHANNEL_DISCONNECTED Event. Result "
+                     "0x%08lX", p_handle->conn_handle, p_handle->cid, p_evt->evt_result);
+            break;
+        }
+
+        default:
+        {
+            APPL_LOG("[0x%04X]:[0x%04X] Unknown Event 0x%04X. Result 0x%08lX",
+                     p_evt->evt_id, p_handle->conn_handle, p_handle->cid, p_evt->evt_result);
+            break;
+        }
+    }
+    return NRF_SUCCESS;
+}
+
+
+/**@brief Function for dispatching a BLE stack event to all modules with a BLE stack event handler.
+ *
+ * @details This function is called from the BLE Stack event interrupt handler after a BLE stack
+ *          event has been received.
+ *
+ * @param[in]   p_ble_evt   Bluetooth stack event.
+ */
+static void ble_evt_dispatch(adapter_t * adapter, ble_evt_t * p_ble_evt)
+{
+    ble_ipsp_evt_handler(p_ble_evt);
+    on_ble_evt(p_ble_evt);
+}
+
+
+/**@brief Function for initializing the BLE stack.
+ *
+ * @details Initializes the SoftDevice and the BLE event interrupt.
+ */
+static void ble_stack_init(void)
+{
+    uint32_t     err_code = NRF_SUCCESS;
+    uint32_t     ram_start = 0;
+    ble_cfg_t    ble_cfg;
+
+    if (err_code == NRF_SUCCESS)
+    {
+        // Configure the maximum number of connections.
+        memset(&ble_cfg, 0, sizeof(ble_cfg));
+        ble_cfg.gap_cfg.role_count_cfg.periph_role_count  = 0;
+        ble_cfg.gap_cfg.role_count_cfg.central_role_count = BLE_IPSP_MAX_CHANNELS;
+        ble_cfg.gap_cfg.role_count_cfg.central_sec_count  = 0;
+        err_code = sd_ble_cfg_set(m_adapter, BLE_GAP_CFG_ROLE_COUNT, &ble_cfg, ram_start);
+    }
+
+    if (err_code == NRF_SUCCESS)
+    {
+        memset(&ble_cfg, 0, sizeof(ble_cfg));
+
+        // Configure total number of connections.
+        ble_cfg.conn_cfg.conn_cfg_tag                     = APP_IPSP_TAG;
+        ble_cfg.conn_cfg.params.gap_conn_cfg.conn_count   = BLE_IPSP_MAX_CHANNELS;
+        ble_cfg.conn_cfg.params.gap_conn_cfg.event_length = BLE_GAP_EVENT_LENGTH_DEFAULT;
+        err_code = sd_ble_cfg_set(m_adapter, BLE_CONN_CFG_GAP, &ble_cfg, ram_start);
+
+    }
+
+    if (err_code ==  NRF_SUCCESS)
+    {
+        memset(&ble_cfg, 0, sizeof(ble_cfg));
+
+         // Configure the number of custom UUIDS.
+        ble_cfg.common_cfg.vs_uuid_cfg.vs_uuid_count = 0;
+        err_code = sd_ble_cfg_set(m_adapter, BLE_COMMON_CFG_VS_UUID, &ble_cfg, ram_start);
+    }
+
+    if (err_code == NRF_SUCCESS)
+    {
+        memset(&ble_cfg, 0, sizeof(ble_cfg));
+
+        // Set L2CAP channel configuration
+
+        // @note The TX MPS and RX MPS of initiator and acceptor are not symmetrically set.
+        // This will result in effective MPS of 50 in reach direction when using the initiator and
+        // acceptor example against each other. In the IPSP, the TX MPS is set to a higher value
+        // as Linux which is the border router for 6LoWPAN examples uses default RX MPS of 230
+        // bytes. Setting TX MPS of 212 in place of 50 results in better credit and hence bandwidth
+        // utilization.
+        ble_cfg.conn_cfg.conn_cfg_tag                        = APP_IPSP_TAG;
+        ble_cfg.conn_cfg.params.l2cap_conn_cfg.rx_mps        = BLE_IPSP_RX_MPS;
+        ble_cfg.conn_cfg.params.l2cap_conn_cfg.rx_queue_size = BLE_IPSP_RX_BUFFER_COUNT;
+        ble_cfg.conn_cfg.params.l2cap_conn_cfg.tx_mps        = BLE_IPSP_TX_MPS;
+        ble_cfg.conn_cfg.params.l2cap_conn_cfg.tx_queue_size = 1;
+        ble_cfg.conn_cfg.params.l2cap_conn_cfg.ch_count      = 1; // One L2CAP channel per link.
+        err_code = sd_ble_cfg_set(m_adapter, BLE_CONN_CFG_L2CAP, &ble_cfg, ram_start);
+    }
+
+    if (err_code == NRF_SUCCESS)
+    {
+        memset(&ble_cfg, 0, sizeof(ble_cfg));
+
+        // Set the ATT table size.
+        ble_cfg.gatts_cfg.attr_tab_size.attr_tab_size = 256;
+        err_code = sd_ble_cfg_set(m_adapter, BLE_GATTS_CFG_ATTR_TAB_SIZE, &ble_cfg, ram_start);
+    }
+
+    if (err_code ==  NRF_SUCCESS)
+    {
+        err_code = sd_ble_enable(m_adapter, &ram_start);
+        switch (err_code) {
+            case NRF_SUCCESS:
+                break;
+            case NRF_ERROR_INVALID_STATE:
+                printf("BLE stack already enabled\n");
+                fflush(stdout);
+                break;
+            default:
+                printf("Failed to enable BLE stack. Error code: %d\n", err_code);
+                fflush(stdout);
+                break;
+        }
+    }
+
+    APP_ERROR_CHECK(err_code);
+}
+
+
+static void services_init()
+{
+    ble_ipsp_init_t init_param;
+    init_param.evt_handler = app_ipsp_event_handler;
+
+    uint32_t err_code = ble_ipsp_init(m_adapter, &init_param);
+    APP_ERROR_CHECK(err_code);
+
+    ble_gap_addr_t m_my_addr;
+
+    m_my_addr.addr[5]   = 0x00;
+    m_my_addr.addr[4]   = 0x11;
+    m_my_addr.addr[3]   = 0x22;
+    m_my_addr.addr[2]   = 0x33;
+    m_my_addr.addr[1]   = 0x44;
+    m_my_addr.addr[0]   = 0x55;
+    m_my_addr.addr_type = BLE_GAP_ADDR_TYPE_PUBLIC;
+
+    err_code = sd_ble_gap_addr_set(m_adapter, &m_my_addr);
+    APP_ERROR_CHECK(err_code);
+}
+
+/**@brief Function for handling error message events from sd_rpc.
+ *
+ * @param[in] adapter The transport adapter.
+ * @param[in] code Error code that the error message is associated with.
+ * @param[in] message The error message that the callback is associated with.
+ */
+static void status_handler(adapter_t * adapter, sd_rpc_app_status_t code, const char * message)
+{
+    printf("Status: %d, message: %s\n", (uint32_t)code, message);
+    fflush(stdout);
+}
+
+
+/**@brief Function for handling the log message events from sd_rpc.
+ *
+ * @param[in] adapter The transport adapter.
+ * @param[in] severity Level of severity that the log message is associated with.
+ * @param[in] message The log message that the callback is associated with.
+ */
+static void log_handler(adapter_t * adapter, sd_rpc_log_severity_t severity, const char * message)
+{
+    switch (severity)
+    {
+        case SD_RPC_LOG_ERROR:
+            printf("Error: %s\n", message);
+            fflush(stdout);
+            break;
+
+        case SD_RPC_LOG_WARNING:
+            printf("Warning: %s\n", message);
+            fflush(stdout);
+            break;
+
+        case SD_RPC_LOG_INFO:
+            printf("Info: %s\n", message);
+            fflush(stdout);
+            break;
+
+        default:
+            printf("Log: %s\n", message);
+            fflush(stdout);
+            break;
+    }
+}
+
+/**@brief Function for initializing serial communication with the target nRF5 Bluetooth slave.
+ *
+ * @param[in] serial_port The serial port the target nRF5 device is connected to.
+ *
+ * @return The new transport adapter.
+ */
+static adapter_t * adapter_init(char * serial_port, uint32_t baud_rate)
+{
+    physical_layer_t  * phy;
+    data_link_layer_t * data_link_layer;
+    transport_layer_t * transport_layer;
+
+    phy = sd_rpc_physical_layer_create_uart(serial_port,
+                                            baud_rate,
+                                            SD_RPC_FLOW_CONTROL_NONE,
+                                            SD_RPC_PARITY_NONE);
+    data_link_layer = sd_rpc_data_link_layer_create_bt_three_wire(phy, 250);
+    transport_layer = sd_rpc_transport_layer_create(data_link_layer, 1500);
+    return sd_rpc_adapter_create(transport_layer);
+}
+
+#endif
+
+/**
+ * @brief Function for application main entry.
+ */
+int main(void)
+{
+    #if NRF_SD_BLE_API >= 6
+    uint32_t error_code;
+    char *   serial_port = DEFAULT_UART_PORT_NAME;
+    uint32_t baud_rate = DEFAULT_BAUD_RATE;
+
+    printf("Serial port used: %s\n", serial_port);
+    printf("Baud rate used: %d\n", baud_rate);
+    fflush(stdout);
+
+    m_adapter =  adapter_init(serial_port, baud_rate);
+    sd_rpc_log_handler_severity_filter_set(m_adapter, SD_RPC_LOG_INFO);
+    error_code = sd_rpc_open(m_adapter, status_handler, ble_evt_dispatch, log_handler);
+
+    if (error_code != NRF_SUCCESS)
+    {
+        printf("Failed to open nRF BLE Driver. Error code: 0x%02X\n", error_code);
+        fflush(stdout);
+        return error_code;
+    }
+
+    ble_stack_init();
+    services_init();
+
+    uint32_t err_code;
+    if (m_conn_handle == BLE_CONN_HANDLE_INVALID)
+    {
+        err_code = sd_ble_gap_connect(m_adapter, &m_peer_addr,
+                                      &m_scan_param, &m_connection_param, APP_IPSP_TAG);
+        if (err_code != NRF_SUCCESS)
+        {
+            APPL_LOG("Connection Request Failed, reason 0x%08lX", err_code);
+        }
+        APP_ERROR_CHECK(err_code);
+    }
+    else
+    {
+        APPL_LOG("Connection exists with peer");
+    }
+
+    for (;;)
+    {
+        char c = (char)getchar();
+        if (c == 'q' || c == 'Q')
+        {
+            error_code = sd_rpc_close(m_adapter);
+
+            if (error_code != NRF_SUCCESS)
+            {
+                printf("Failed to close nRF BLE Driver. Error code: 0x%02X\n", error_code);
+                fflush(stdout);
+                return error_code;
+            }
+
+            printf("Closed\n");
+            fflush(stdout);
+
+            return NRF_SUCCESS;
+        }
+    }
+    #endif
+}
+
+/**
+ * @}
+ */

--- a/include/common/ble_ipsp.h
+++ b/include/common/ble_ipsp.h
@@ -1,0 +1,304 @@
+/**
+ * Copyright (c) 2014 - 2019, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/** @file
+ *
+ * @defgroup ble_ipsp Internet Protocol Support Profile
+ * @{
+ * @ingroup iot_sdk_6lowpan
+ * @brief Internet Protocol Support Profile.
+ *
+ * @details This module implements the Internet Protocol Support Profile creating and managing
+ *          transport for 6lowpan.
+ *          GATT is used to discover if IPSP is supported or not, but no IP data is exchanged
+ *          over GATT. To exchange data, LE L2CAP Credit Mode is used. The PSM used for the channel
+ *          is BLE_IPSP_PSM and is defined by the specification. The MTU mandated by the
+ *          specification is 1280 bytes.
+ *
+ * @note Attention!
+ *  To maintain compliance with Nordic Semiconductor ASA's Bluetooth profile
+ *  qualification listings, this section of source code must not be modified.
+ */
+
+#ifndef BLE_IPSP_H__
+#define BLE_IPSP_H__
+
+#include <stdint.h>
+#include "ble.h"
+
+// ================================================================================================
+#include <stdio.h>
+
+//TODO: sdk_errors.h
+/**
+ * @defgroup sdk_err_base Base defined for SDK Modules
+ * @{
+ */
+#define NRF_ERROR_SDK_ERROR_BASE         (NRF_ERROR_BASE_NUM + 0x8000)   /**< Base value defined for SDK module identifiers. */
+#define NRF_ERROR_SDK_COMMON_ERROR_BASE  (NRF_ERROR_BASE_NUM + 0x0080)   /**< Base error value to be used for SDK error values. */
+/** @} */
+
+/**
+ * @defgroup sdk_module_codes Codes reserved as identification for module where the error occurred.
+ * @{
+ */
+#define NRF_ERROR_MEMORY_MANAGER_ERR_BASE   (0x8100)    /**< Base address for Memory Manager related errors. */
+#define NRF_ERROR_PERIPH_DRIVERS_ERR_BASE   (0x8200)    /**< Base address for Peripheral drivers related errors. */
+#define NRF_ERROR_GAZELLE_ERR_BASE          (0x8300)    /**< Base address for Gazelle related errors. */
+#define NRF_ERROR_BLE_IPSP_ERR_BASE         (0x8400)    /**< Base address for BLE IPSP related errors. */
+#define NRF_ERROR_CRYPTO_ERR_BASE           (0x8500)    /**< Base address for crypto related errors. */
+/** @} */
+
+/**
+ * @defgroup sdk_common_errors Codes reserved as identification for common errors.
+ * @{
+ */
+#define NRF_ERROR_MODULE_NOT_INITIALIZED     (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0000) ///< Module not initialized
+#define NRF_ERROR_MUTEX_INIT_FAILED          (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0001) ///< Mutex initialization failed
+#define NRF_ERROR_MUTEX_LOCK_FAILED          (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0002) ///< Mutex lock failed
+#define NRF_ERROR_MUTEX_UNLOCK_FAILED        (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0003) ///< Mutex unlock failed
+#define NRF_ERROR_MUTEX_COND_INIT_FAILED     (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0004) ///< Mutex conditional initialization failed
+#define NRF_ERROR_MODULE_ALREADY_INITIALIZED (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0005) ///< Module already initialized
+#define NRF_ERROR_STORAGE_FULL               (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0006) ///< Storage full
+#define NRF_ERROR_API_NOT_IMPLEMENTED        (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0010) ///< API not implemented
+#define NRF_ERROR_FEATURE_NOT_ENABLED        (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0011) ///< Feature not enabled
+#define NRF_ERROR_IO_PENDING                 (NRF_ERROR_SDK_COMMON_ERROR_BASE + 0x0012) ///< Input/Output pending
+/** @} */
+
+/**
+ * @defgroup ble_ipsp_errors IPSP codes
+ * @brief Error and status codes specific to IPSP.
+ * @{
+ */
+#define NRF_ERROR_BLE_IPSP_RX_PKT_TRUNCATED       (NRF_ERROR_BLE_IPSP_ERR_BASE + 0x0000)
+#define NRF_ERROR_BLE_IPSP_CHANNEL_ALREADY_EXISTS (NRF_ERROR_BLE_IPSP_ERR_BASE + 0x0001)
+#define NRF_ERROR_BLE_IPSP_LINK_DISCONNECTED      (NRF_ERROR_BLE_IPSP_ERR_BASE + 0x0002)
+#define NRF_ERROR_BLE_IPSP_PEER_REJECTED          (NRF_ERROR_BLE_IPSP_ERR_BASE + 0x0003)
+/* @} */
+// ================================================================================================
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief Maximum IPSP channels required to be supported. */
+#define BLE_IPSP_MAX_CHANNELS                              1
+
+/**@brief Maximum Transmit Unit on IPSP channel. */
+#define BLE_IPSP_MTU                                       1280
+
+/**@brief Receive MPS used by IPSP. */
+#define BLE_IPSP_RX_MPS                                    50
+
+/**@brief Transmission MPS used by IPSP.
+ *
+ * @note The actual MPS used is minimum of this value and the one requested by
+ *       the peer during the channel setup. Here, the value used is
+ *       (23 + 27 * 7).
+ */
+#define BLE_IPSP_TX_MPS                                    212
+
+/**@brief Maximum data size that can be received.
+ *
+ * @details Maximum data size that can be received on the IPSP channel.
+ *          Modify this values to intentionally set a receive size less
+ *          than the MTU set on the channel.
+ */
+#define BLE_IPSP_RX_BUFFER_SIZE                            1280
+
+/**@brief Maximum number of receive buffers.
+ *
+ * @details Maximum number of receive buffers to be used per IPSP channel.
+ *          Each receive buffer is of size @ref BLE_IPSP_RX_BUFFER_SIZE.
+ *          This configuration has implications on the number of SDUs that can
+ *          be received while an SDU is being consumed by the application
+ *          (6LoWPAN/IP Stack).
+ */
+#define BLE_IPSP_RX_BUFFER_COUNT                           4
+
+/**@brief L2CAP Protocol Service Multiplexers number. */
+#define BLE_IPSP_PSM                                       0x0023
+
+
+/**@brief IPSP event identifier type. */
+typedef enum
+{
+    BLE_IPSP_EVT_CHANNEL_CONNECTED,                                                                 /**< Channel connection event. */
+    BLE_IPSP_EVT_CHANNEL_DISCONNECTED,                                                              /**< Channel disconnection event. */
+    BLE_IPSP_EVT_CHANNEL_DATA_RX,                                                                   /**< Data received on channel event. */
+    BLE_IPSP_EVT_CHANNEL_DATA_TX_COMPLETE                                                           /**< Requested data transmission complete on channel event. */
+} ble_ipsp_evt_type_t;
+
+
+/**@brief IPSP event parameter. */
+typedef struct
+{
+    ble_l2cap_evt_t const   * p_l2cap_evt;                                                          /**< L2CAP event parameters. */
+    ble_gap_addr_t  const   * p_peer;                                                               /**< Peer device address. */
+} ble_ipsp_event_param_t;
+
+
+/**@brief IPSP event and associated parameter type. */
+typedef struct
+{
+    ble_ipsp_evt_type_t         evt_id;                                                             /**< Identifier event type. */
+    ble_ipsp_event_param_t    * p_evt_param;                                                        /**< Parameters associated with the event. */
+    uint32_t                    evt_result;                                                         /**< Result of the event.
+                                                                                                      \n The event result is SDK_ERR_RX_PKT_TRUNCATED for @ref BLE_IPSP_EVT_CHANNEL_DATA_RX,
+                                                                                                      \n implies that an incomplete SDU was received due to insufficient RX buffer size.
+                                                                                                      \n The size determined by @ref BLE_IPSP_RX_BUFFER_SIZE. */
+} ble_ipsp_evt_t;
+
+
+/**@brief IPSP handle. */
+typedef struct
+{
+    uint16_t    conn_handle;                                                                        /**< Identifies the link on which the IPSP channel is established. */
+    uint16_t    cid;                                                                                /**< Identifies the IPSP logical channel. */
+} ble_ipsp_handle_t;
+
+
+/**@brief Profile event handler type.
+ *
+ * @param[in] p_handle Identifies the connection and channel on which the event occurred.
+ * @param[in] p_evt    Event and related parameters (if any).
+ *
+ * @returns    Provision for the application to indicate if the event was successfully processed or
+ *             not. Currently not used.
+ */
+typedef uint32_t (*ble_ipsp_evt_handler_t) (ble_ipsp_handle_t const * p_handle,
+                                            ble_ipsp_evt_t    const * p_evt);
+
+
+/**@brief IPSP initialization structure.
+ *
+ * @details IPSP initialization structure containing all options and data needed to
+ *          initialize the profile.
+ */
+typedef struct
+{
+    ble_ipsp_evt_handler_t    evt_handler;                                                          /**< Event notification callback registered with the module to receive asynchronous events. */
+} ble_ipsp_init_t;
+
+
+/**@brief Function for initializing the Internet Protocol Support Profile.
+ *
+ * @param[in] p_init   Information needed to initialize the service.
+ *
+ * @retval NRF_SUCCESS If initialization of the service was successful, else,
+ *                     an error code indicating reason for failure.
+ */
+uint32_t ble_ipsp_init(adapter_t *m_adapter, ble_ipsp_init_t const * p_init);
+
+
+/**@brief Function for requesting a channel creation for the Internet Protocol Support Profile.
+ *
+ * @details Channel creation for Internet Protocol Support Profile (IPSP) is requested using this
+ *          API. Connection handle provided in p_handle parameter identifies the peer with which
+ *          the IPSP channel is being requested.
+ *          NRF_SUCCESS return value by the API is only indicative of request procedure having
+ *          succeeded. Result of channel establishment is known when the
+ *          @ref BLE_IPSP_EVT_CHANNEL_CONNECTED event is notified.
+ *          Therefore, the application must wait for @ref BLE_IPSP_EVT_CHANNEL_CONNECTED event on
+ *          successful return of this API.
+ *
+ * @param[in] p_handle Indicates the connection handle on which IPSP channel is to be created.
+ *
+ * @retval NRF_SUCCESS If initialization of the service was successful, else,
+ *                     an error code indicating reason for failure.
+ */
+uint32_t ble_ipsp_connect(adapter_t *m_adapter, ble_ipsp_handle_t const * p_handle);
+
+
+/**@brief Function for sending IP data to peer.
+ *
+ * @param[in] p_handle Instance of the logical channel and peer for which the data is intended.
+ * @param[in] p_data   Pointer to memory containing the data to be transmitted.
+ *                     @note This memory must be resident and should not be freed unless
+ *                     @ref BLE_IPSP_EVT_CHANNEL_DATA_TX_COMPLETE event is notified.
+ * @param[in] data_len Length/size of data to be transferred.
+ *
+ * @retval NRF_SUCCESS If initialization of the service was successful, else,
+ *                     an error code indicating reason for failure.
+ */
+uint32_t ble_ipsp_send(ble_ipsp_handle_t const * p_handle,
+                       uint8_t           const * p_data,
+                       uint16_t                  data_len);
+
+
+/**@brief Function for disconnecting IP transport.
+ *
+ * @param[in] p_handle Identifies IPSP transport.
+ *
+ * @retval NRF_SUCCESS If initialization of the service was successful, else,
+ *                     an error code indicating reason for failure.
+ */
+uint32_t ble_ipsp_disconnect(adapter_t *m_adapter, ble_ipsp_handle_t const * p_handle);
+
+
+/**@brief Function to accept incoming connections from a peer.
+ *
+ * @param[in] conn_handle Identifies the link with the peer.
+ */
+void ble_ipsp_incoming_channel_accept(uint16_t conn_handle);
+
+
+/**@brief Function to reject incoming connections from a peer.
+ *
+ * @param[in] conn_handle Identifies the link with the peer.
+ */
+void ble_ipsp_incoming_channel_reject(uint16_t conn_handle);
+
+
+/**@brief BLE event handler of the module.
+ *
+ * @param[in] p_evt BLE event to be handled.
+ *
+ * @retval NRF_SUCCESS If initialization of the service was successful, else,
+ *                     an error code indicating reason for failure.
+ */
+void ble_ipsp_evt_handler(ble_evt_t const * p_evt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BLE_IPSP_H__
+
+/** @} */

--- a/include/common/ble_srv_common.h
+++ b/include/common/ble_srv_common.h
@@ -1,0 +1,409 @@
+/**
+ * Copyright (c) 2012 - 2019, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/** @file
+ *
+ * @defgroup ble_sdk_srv_common Common service definitions
+ * @{
+ * @ingroup ble_sdk_srv
+ * @brief Constants, type definitions, and functions that are common to all services.
+ */
+
+#ifndef BLE_SRV_COMMON_H__
+#define BLE_SRV_COMMON_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "ble_types.h"
+#include "/home/rychu/rychu_home/workspace/Nordic/pc-ble-driver/src/sd_api_common/sdk/components/libraries/util/app_util.h"
+#include "ble.h"
+#include "ble_gap.h"
+#include "ble_gatt.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup UUID_SERVICES Service UUID definitions
+ * @{ */
+#define BLE_UUID_ALERT_NOTIFICATION_SERVICE                      0x1811     /**< Alert Notification service UUID. */
+#define BLE_UUID_BATTERY_SERVICE                                 0x180F     /**< Battery service UUID. */
+#define BLE_UUID_BLOOD_PRESSURE_SERVICE                          0x1810     /**< Blood Pressure service UUID. */
+#define BLE_UUID_CURRENT_TIME_SERVICE                            0x1805     /**< Current Time service UUID. */
+#define BLE_UUID_CYCLING_SPEED_AND_CADENCE                       0x1816     /**< Cycling Speed and Cadence service UUID. */
+#define BLE_UUID_LOCATION_AND_NAVIGATION_SERVICE                 0x1819     /**< Location and Navigation service UUID. */
+#define BLE_UUID_DEVICE_INFORMATION_SERVICE                      0x180A     /**< Device Information service UUID. */
+#define BLE_UUID_GLUCOSE_SERVICE                                 0x1808     /**< Glucose service UUID. */
+#define BLE_UUID_HEALTH_THERMOMETER_SERVICE                      0x1809     /**< Health Thermometer service UUID. */
+#define BLE_UUID_HEART_RATE_SERVICE                              0x180D     /**< Heart Rate service UUID. */
+#define BLE_UUID_HUMAN_INTERFACE_DEVICE_SERVICE                  0x1812     /**< Human Interface Device service UUID. */
+#define BLE_UUID_IMMEDIATE_ALERT_SERVICE                         0x1802     /**< Immediate Alert service UUID. */
+#define BLE_UUID_LINK_LOSS_SERVICE                               0x1803     /**< Link Loss service UUID. */
+#define BLE_UUID_NEXT_DST_CHANGE_SERVICE                         0x1807     /**< Next Dst Change service UUID. */
+#define BLE_UUID_PHONE_ALERT_STATUS_SERVICE                      0x180E     /**< Phone Alert Status service UUID. */
+#define BLE_UUID_REFERENCE_TIME_UPDATE_SERVICE                   0x1806     /**< Reference Time Update service UUID. */
+#define BLE_UUID_RUNNING_SPEED_AND_CADENCE                       0x1814     /**< Running Speed and Cadence service UUID. */
+#define BLE_UUID_SCAN_PARAMETERS_SERVICE                         0x1813     /**< Scan Parameters service UUID. */
+#define BLE_UUID_TX_POWER_SERVICE                                0x1804     /**< TX Power service UUID. */
+#define BLE_UUID_IPSP_SERVICE                                    0x1820     /**< Internet Protocol Support service UUID. */
+#define BLE_UUID_BMS_SERVICE                                     0x181E     /**< BOND MANAGEMENT service UUID*/
+#define BLE_UUID_CGM_SERVICE                                     0x181F     /**< Continuous Glucose Monitoring service UUID*/
+#define BLE_UUID_PLX_SERVICE                                     0x1822     /**< Pulse Oximeter Service UUID*/
+#define BLE_UUID_OTS_SERVICE                                     0x1825     /**< Object Transfer Service UUID*/
+
+/** @} */
+
+/** @defgroup UUID_CHARACTERISTICS Characteristic UUID definitions
+ * @{ */
+#define BLE_UUID_REMOVABLE_CHAR                                  0x2A3A     /**< Removable characteristic UUID. */
+#define BLE_UUID_SERVICE_REQUIRED_CHAR                           0x2A3B     /**< Service Required characteristic UUID. */
+#define BLE_UUID_ALERT_CATEGORY_ID_CHAR                          0x2A43     /**< Alert Category Id characteristic UUID. */
+#define BLE_UUID_ALERT_CATEGORY_ID_BIT_MASK_CHAR                 0x2A42     /**< Alert Category Id Bit Mask characteristic UUID. */
+#define BLE_UUID_ALERT_LEVEL_CHAR                                0x2A06     /**< Alert Level characteristic UUID. */
+#define BLE_UUID_ALERT_NOTIFICATION_CONTROL_POINT_CHAR           0x2A44     /**< Alert Notification Control Point characteristic UUID. */
+#define BLE_UUID_ALERT_STATUS_CHAR                               0x2A3F     /**< Alert Status characteristic UUID. */
+#define BLE_UUID_BATTERY_LEVEL_CHAR                              0x2A19     /**< Battery Level characteristic UUID. */
+#define BLE_UUID_BLOOD_PRESSURE_FEATURE_CHAR                     0x2A49     /**< Blood Pressure Feature characteristic UUID. */
+#define BLE_UUID_BLOOD_PRESSURE_MEASUREMENT_CHAR                 0x2A35     /**< Blood Pressure Measurement characteristic UUID. */
+#define BLE_UUID_BODY_SENSOR_LOCATION_CHAR                       0x2A38     /**< Body Sensor Location characteristic UUID. */
+#define BLE_UUID_BOOT_KEYBOARD_INPUT_REPORT_CHAR                 0x2A22     /**< Boot Keyboard Input Report characteristic UUID. */
+#define BLE_UUID_BOOT_KEYBOARD_OUTPUT_REPORT_CHAR                0x2A32     /**< Boot Keyboard Output Report characteristic UUID. */
+#define BLE_UUID_BOOT_MOUSE_INPUT_REPORT_CHAR                    0x2A33     /**< Boot Mouse Input Report characteristic UUID. */
+#define BLE_UUID_CURRENT_TIME_CHAR                               0x2A2B     /**< Current Time characteristic UUID. */
+#define BLE_UUID_DATE_TIME_CHAR                                  0x2A08     /**< Date Time characteristic UUID. */
+#define BLE_UUID_DAY_DATE_TIME_CHAR                              0x2A0A     /**< Day Date Time characteristic UUID. */
+#define BLE_UUID_DAY_OF_WEEK_CHAR                                0x2A09     /**< Day Of Week characteristic UUID. */
+#define BLE_UUID_DST_OFFSET_CHAR                                 0x2A0D     /**< Dst Offset characteristic UUID. */
+#define BLE_UUID_EXACT_TIME_256_CHAR                             0x2A0C     /**< Exact Time 256 characteristic UUID. */
+#define BLE_UUID_FIRMWARE_REVISION_STRING_CHAR                   0x2A26     /**< Firmware Revision String characteristic UUID. */
+#define BLE_UUID_GLUCOSE_FEATURE_CHAR                            0x2A51     /**< Glucose Feature characteristic UUID. */
+#define BLE_UUID_GLUCOSE_MEASUREMENT_CHAR                        0x2A18     /**< Glucose Measurement characteristic UUID. */
+#define BLE_UUID_GLUCOSE_MEASUREMENT_CONTEXT_CHAR                0x2A34     /**< Glucose Measurement Context characteristic UUID. */
+#define BLE_UUID_HARDWARE_REVISION_STRING_CHAR                   0x2A27     /**< Hardware Revision String characteristic UUID. */
+#define BLE_UUID_HEART_RATE_CONTROL_POINT_CHAR                   0x2A39     /**< Heart Rate Control Point characteristic UUID. */
+#define BLE_UUID_HEART_RATE_MEASUREMENT_CHAR                     0x2A37     /**< Heart Rate Measurement characteristic UUID. */
+#define BLE_UUID_HID_CONTROL_POINT_CHAR                          0x2A4C     /**< Hid Control Point characteristic UUID. */
+#define BLE_UUID_HID_INFORMATION_CHAR                            0x2A4A     /**< Hid Information characteristic UUID. */
+#define BLE_UUID_IEEE_REGULATORY_CERTIFICATION_DATA_LIST_CHAR    0x2A2A     /**< IEEE Regulatory Certification Data List characteristic UUID. */
+#define BLE_UUID_INTERMEDIATE_CUFF_PRESSURE_CHAR                 0x2A36     /**< Intermediate Cuff Pressure characteristic UUID. */
+#define BLE_UUID_INTERMEDIATE_TEMPERATURE_CHAR                   0x2A1E     /**< Intermediate Temperature characteristic UUID. */
+#define BLE_UUID_LOCAL_TIME_INFORMATION_CHAR                     0x2A0F     /**< Local Time Information characteristic UUID. */
+#define BLE_UUID_MANUFACTURER_NAME_STRING_CHAR                   0x2A29     /**< Manufacturer Name String characteristic UUID. */
+#define BLE_UUID_MEASUREMENT_INTERVAL_CHAR                       0x2A21     /**< Measurement Interval characteristic UUID. */
+#define BLE_UUID_MODEL_NUMBER_STRING_CHAR                        0x2A24     /**< Model Number String characteristic UUID. */
+#define BLE_UUID_UNREAD_ALERT_CHAR                               0x2A45     /**< Unread Alert characteristic UUID. */
+#define BLE_UUID_NEW_ALERT_CHAR                                  0x2A46     /**< New Alert characteristic UUID. */
+#define BLE_UUID_PNP_ID_CHAR                                     0x2A50     /**< PNP Id characteristic UUID. */
+#define BLE_UUID_PROTOCOL_MODE_CHAR                              0x2A4E     /**< Protocol Mode characteristic UUID. */
+#define BLE_UUID_RECORD_ACCESS_CONTROL_POINT_CHAR                0x2A52     /**< Record Access Control Point characteristic UUID. */
+#define BLE_UUID_REFERENCE_TIME_INFORMATION_CHAR                 0x2A14     /**< Reference Time Information characteristic UUID. */
+#define BLE_UUID_REPORT_CHAR                                     0x2A4D     /**< Report characteristic UUID. */
+#define BLE_UUID_REPORT_MAP_CHAR                                 0x2A4B     /**< Report Map characteristic UUID. */
+#define BLE_UUID_RINGER_CONTROL_POINT_CHAR                       0x2A40     /**< Ringer Control Point characteristic UUID. */
+#define BLE_UUID_RINGER_SETTING_CHAR                             0x2A41     /**< Ringer Setting characteristic UUID. */
+#define BLE_UUID_SCAN_INTERVAL_WINDOW_CHAR                       0x2A4F     /**< Scan Interval Window characteristic UUID. */
+#define BLE_UUID_SCAN_REFRESH_CHAR                               0x2A31     /**< Scan Refresh characteristic UUID. */
+#define BLE_UUID_SERIAL_NUMBER_STRING_CHAR                       0x2A25     /**< Serial Number String characteristic UUID. */
+#define BLE_UUID_SOFTWARE_REVISION_STRING_CHAR                   0x2A28     /**< Software Revision String characteristic UUID. */
+#define BLE_UUID_SUPPORTED_NEW_ALERT_CATEGORY_CHAR               0x2A47     /**< Supported New Alert Category characteristic UUID. */
+#define BLE_UUID_SUPPORTED_UNREAD_ALERT_CATEGORY_CHAR            0x2A48     /**< Supported Unread Alert Category characteristic UUID. */
+#define BLE_UUID_SYSTEM_ID_CHAR                                  0x2A23     /**< System Id characteristic UUID. */
+#define BLE_UUID_TEMPERATURE_MEASUREMENT_CHAR                    0x2A1C     /**< Temperature Measurement characteristic UUID. */
+#define BLE_UUID_TEMPERATURE_TYPE_CHAR                           0x2A1D     /**< Temperature Type characteristic UUID. */
+#define BLE_UUID_TIME_ACCURACY_CHAR                              0x2A12     /**< Time Accuracy characteristic UUID. */
+#define BLE_UUID_TIME_SOURCE_CHAR                                0x2A13     /**< Time Source characteristic UUID. */
+#define BLE_UUID_TIME_UPDATE_CONTROL_POINT_CHAR                  0x2A16     /**< Time Update Control Point characteristic UUID. */
+#define BLE_UUID_TIME_UPDATE_STATE_CHAR                          0x2A17     /**< Time Update State characteristic UUID. */
+#define BLE_UUID_TIME_WITH_DST_CHAR                              0x2A11     /**< Time With Dst characteristic UUID. */
+#define BLE_UUID_TIME_ZONE_CHAR                                  0x2A0E     /**< Time Zone characteristic UUID. */
+#define BLE_UUID_TX_POWER_LEVEL_CHAR                             0x2A07     /**< TX Power Level characteristic UUID. */
+#define BLE_UUID_CSC_FEATURE_CHAR                                0x2A5C     /**< Cycling Speed and Cadence Feature characteristic UUID. */
+#define BLE_UUID_CSC_MEASUREMENT_CHAR                            0x2A5B     /**< Cycling Speed and Cadence Measurement characteristic UUID. */
+#define BLE_UUID_RSC_FEATURE_CHAR                                0x2A54     /**< Running Speed and Cadence Feature characteristic UUID. */
+#define BLE_UUID_SC_CTRLPT_CHAR                                  0x2A55     /**< Speed and Cadence Control Point UUID. */
+#define BLE_UUID_RSC_MEASUREMENT_CHAR                            0x2A53     /**< Running Speed and Cadence Measurement characteristic UUID. */
+#define BLE_UUID_SENSOR_LOCATION_CHAR                            0x2A5D     /**< Sensor Location characteristic UUID. */
+#define BLE_UUID_EXTERNAL_REPORT_REF_DESCR                       0x2907     /**< External Report Reference descriptor UUID. */
+#define BLE_UUID_REPORT_REF_DESCR                                0x2908     /**< Report Reference descriptor UUID. */
+#define BLE_UUID_LN_FEATURE_CHAR                                 0x2A6A     /**< Location Navigation Service, Feature characteristic UUID. */
+#define BLE_UUID_LN_POSITION_QUALITY_CHAR                        0x2A69     /**< Location Navigation Service, Position quality UUID. */
+#define BLE_UUID_LN_LOCATION_AND_SPEED_CHAR                      0x2A67     /**< Location Navigation Service, Location and Speed characteristic UUID. */
+#define BLE_UUID_LN_NAVIGATION_CHAR                              0x2A68     /**< Location Navigation Service, Navigation characteristic UUID. */
+#define BLE_UUID_LN_CONTROL_POINT_CHAR                           0x2A6B     /**< Location Navigation Service, Control point characteristic UUID. */
+#define BLE_UUID_BMS_CTRLPT                                      0x2AA4     /**< BMS Control Point characteristic UUID. */
+#define BLE_UUID_BMS_FEATURE                                     0x2AA5     /**< BMS Feature characteristic UUID. */
+#define BLE_UUID_CGM_MEASUREMENT                                 0x2AA7     /**< CGM Service, Measurement characteristic UUID*/
+#define BLE_UUID_CGM_FEATURE                                     0x2AA8     /**< CGM Service, Feature characteristic UUID*/
+#define BLE_UUID_CGM_STATUS                                      0x2AA9     /**< CGM Service, Status characteristic UUID*/
+#define BLE_UUID_CGM_SESSION_START_TIME                          0x2AAA     /**< CGM Service, session start time characteristic UUID*/
+#define BLE_UUID_CGM_SESSION_RUN_TIME                            0x2AAB     /**< CGM Service, session run time characteristic UUID*/
+#define BLE_UUID_CGM_SPECIFIC_OPS_CTRLPT                         0x2AAC     /**< CGM Service, specific ops ctrlpt characteristic UUID*/
+#define BLE_UUID_PLX_SPOT_CHECK_MEAS                             0x2A5E     /**< PLX Service, spot check measurement characteristic UUID*/
+#define BLE_UUID_PLX_CONTINUOUS_MEAS                             0x2A5F     /**< PLX Service, continuous measurement characteristic UUID*/
+#define BLE_UUID_PLX_FEATURES                                    0x2A60     /**< PLX Service, feature characteristic UUID*/
+#define BLE_UUID_OTS_FEATURES                                    0x2ABD     /**< OTS Service, feature characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_NAME                                 0x2ABE     /**< OTS Service, Object Name characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_TYPE                                 0x2ABF     /**< OTS Service, Object Type characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_SIZE                                 0x2AC0     /**< OTS Service, Object Size characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_FIRST_CREATED                        0x2AC1     /**< OTS Service, Object First Created characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_LAST_MODIFIED                        0x2AC2     /**< OTS Service, Object Last Modified characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_ID                                   0x2AC3     /**< OTS Service, Object ID characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_PROPERTIES                           0x2AC4     /**< OTS Service, Object Properties characteristic UUID*/
+#define BLE_UUID_OTS_OACP                                        0x2AC5     /**< OTS Service, Object Action Control Point characteristic UUID*/
+#define BLE_UUID_OTS_OLCP                                        0x2AC6     /**< OTS Service, Object List Control Point characteristic UUID*/
+#define BLE_UUID_OTS_LF                                          0x2AC7     /**< OTS Service, Object List Filter characteristic UUID*/
+#define BLE_UUID_OTS_OBJECT_CHANGED                              0x2AC8     /**< OTS Service, Object Changed characteristic UUID*/
+
+
+
+
+/** @} */
+
+/** @defgroup ALERT_LEVEL_VALUES Definitions for the Alert Level characteristic values
+ * @{ */
+#define BLE_CHAR_ALERT_LEVEL_NO_ALERT                            0x00       /**< No Alert. */
+#define BLE_CHAR_ALERT_LEVEL_MILD_ALERT                          0x01       /**< Mild Alert. */
+#define BLE_CHAR_ALERT_LEVEL_HIGH_ALERT                          0x02       /**< High Alert. */
+/** @} */
+
+#define BLE_SRV_ENCODED_REPORT_REF_LEN                           2          /**< The length of an encoded Report Reference Descriptor. */
+#define BLE_CCCD_VALUE_LEN                                       2          /**< The length of a CCCD value. */
+
+/**@brief Type definition for error handler function that will be called in case of an error in
+ *        a service or a service library module. */
+typedef void (*ble_srv_error_handler_t) (uint32_t nrf_error);
+
+
+
+/**@brief Value of a Report Reference descriptor.
+ *
+ * @details This is mapping information that maps the parent characteristic to the Report ID(s) and
+ *          Report Type(s) defined within a Report Map characteristic.
+ */
+typedef struct
+{
+    uint8_t report_id;                                  /**< Non-zero value if there is more than one instance of the same Report Type */
+    uint8_t report_type;                                /**< Type of Report characteristic (see @ref BLE_HIDS_REPORT_TYPE) */
+} ble_srv_report_ref_t;
+
+/**@brief UTF-8 string data type.
+ *
+ * @note The type can only hold a pointer to the string data (i.e. not the actual data).
+ */
+typedef struct
+{
+    uint16_t  length;                                   /**< String length. */
+    uint8_t * p_str;                                    /**< String data. */
+} ble_srv_utf8_str_t;
+
+
+/**@brief Security settings structure.
+ * @details This structure contains the security options needed during initialization of the
+ *          service.
+ */
+typedef struct
+{
+    ble_gap_conn_sec_mode_t read_perm;                  /**< Read permissions. */
+    ble_gap_conn_sec_mode_t write_perm;                 /**< Write permissions. */
+} ble_srv_security_mode_t;
+
+/**@brief Security settings structure.
+ * @details This structure contains the security options needed during initialization of the
+ *          service. It can be used when the characteristics contains a CCCD.
+ */
+typedef struct
+{
+    ble_gap_conn_sec_mode_t cccd_write_perm;            /**< Write permissions for Client Characteristic Configuration Descriptor. */
+    ble_gap_conn_sec_mode_t read_perm;                  /**< Read permissions. */
+    ble_gap_conn_sec_mode_t write_perm;                 /**< Write permissions. */
+} ble_srv_cccd_security_mode_t;
+
+/**@brief Function for decoding a CCCD value, and then testing if notification is
+ *        enabled.
+ *
+ * @param[in]   p_encoded_data   Buffer where the encoded CCCD is stored.
+ *
+ * @retval      TRUE If notification is enabled.
+ * @retval      FALSE Otherwise.
+ */
+bool ble_srv_is_notification_enabled(uint8_t const * p_encoded_data);
+
+
+/**@brief Function for decoding a CCCD value, and then testing if indication is
+ *        enabled.
+ *
+ * @param[in]   p_encoded_data   Buffer where the encoded CCCD is stored.
+ *
+ * @retval      TRUE If indication is enabled.
+ * @retval      FALSE Otherwise.
+ */
+bool ble_srv_is_indication_enabled(uint8_t const * p_encoded_data);
+
+
+/**@brief Function for encoding a Report Reference Descriptor.
+ *
+ * @param[in]   p_encoded_buffer  The buffer of the encoded data.
+ * @param[in]   p_report_ref      Report Reference value to be encoded.
+ *
+ * @return      Length of the encoded data.
+ */
+uint8_t ble_srv_report_ref_encode(uint8_t *                    p_encoded_buffer,
+                                  const ble_srv_report_ref_t * p_report_ref);
+
+/**@brief Function for making a UTF-8 structure refer to an ASCII string.
+ *
+ * @param[out]  p_utf8   UTF-8 structure to be set.
+ * @param[in]   p_ascii  ASCII string to be referred to.
+ */
+void ble_srv_ascii_to_utf8(ble_srv_utf8_str_t * p_utf8, char * p_ascii);
+
+
+/**@brief Security Access enumeration.
+ * @details This enumeration gives the possible requirements for accessing a characteristic value.
+ */
+typedef enum
+{
+    SEC_NO_ACCESS    = 0,            /**< Not possible to access. */
+    SEC_OPEN         = 1,            /**< Access open. */
+    SEC_JUST_WORKS   = 2,            /**< Access possible with 'Just Works' security at least. */
+    SEC_MITM         = 3,            /**< Access possible with 'MITM' security at least. */
+    SEC_SIGNED       = 4,            /**< Access possible with 'signed' security at least. */
+    SEC_SIGNED_MITM  = 5             /**< Access possible with 'signed and MITM' security at least. */
+}security_req_t;
+
+
+/**@brief Characteristic User Descriptor parameters.
+ * @details This structure contains the parameters for User Descriptor.
+ */
+typedef struct
+{
+    uint16_t               max_size;                      /**< Maximum size of the user descriptor*/
+    uint16_t               size;                          /**< Size of the user descriptor*/
+    uint8_t                *p_char_user_desc;             /**< User descriptor content, pointer to a UTF-8 encoded string (non-NULL terminated)*/
+    bool                   is_var_len;                    /**< Indicates if the user descriptor has variable length.*/
+    ble_gatt_char_props_t  char_props;                    /**< user descriptor properties.*/
+    bool                   is_defered_read;               /**< Indicate if deferred read operations are supported.*/
+    bool                   is_defered_write;              /**< Indicate if deferred write operations are supported.*/
+    security_req_t         read_access;                   /**< Security requirement for reading the user descriptor.*/
+    security_req_t         write_access;                  /**< Security requirement for writing the user descriptor.*/
+    bool                   is_value_user;                 /**< Indicate if the content of the characteristic is to be stored in the application (user) or in the stack.*/
+}ble_add_char_user_desc_t;
+
+
+/**@brief Add characteristic parameters structure.
+ * @details This structure contains the parameters needed to use the @ref characteristic_add function.
+ */
+typedef struct
+{
+    uint16_t                    uuid;                     /**< Characteristic UUID (16 bits UUIDs).*/
+    uint8_t                     uuid_type;                /**< Base UUID. If 0, the Bluetooth SIG UUID will be used. Otherwise, this should be a value returned by @ref sd_ble_uuid_vs_add when adding the base UUID.*/
+    uint16_t                    max_len;                  /**< Maximum length of the characteristic value.*/
+    uint16_t                    init_len;                 /**< Initial length of the characteristic value.*/
+    uint8_t *                   p_init_value;             /**< Initial encoded value of the characteristic.*/
+    bool                        is_var_len;               /**< Indicates if the characteristic value has variable length.*/
+    ble_gatt_char_props_t       char_props;               /**< Characteristic properties.*/
+    ble_gatt_char_ext_props_t   char_ext_props;           /**< Characteristic extended properties.*/
+    bool                        is_defered_read;          /**< Indicate if deferred read operations are supported.*/
+    bool                        is_defered_write;         /**< Indicate if deferred write operations are supported.*/
+    security_req_t              read_access;              /**< Security requirement for reading the characteristic value.*/
+    security_req_t              write_access;             /**< Security requirement for writing the characteristic value.*/
+    security_req_t              cccd_write_access;        /**< Security requirement for writing the characteristic's CCCD.*/
+    bool                        is_value_user;            /**< Indicate if the content of the characteristic is to be stored in the application (user) or in the stack.*/
+    ble_add_char_user_desc_t    *p_user_descr;            /**< Pointer to user descriptor if needed*/
+    ble_gatts_char_pf_t         *p_presentation_format;   /**< Pointer to characteristic format if needed*/
+} ble_add_char_params_t;
+
+
+/**@brief Add descriptor parameters structure.
+ * @details This structure contains the parameters needed to use the @ref descriptor_add function.
+ */
+typedef struct
+{
+    uint16_t       uuid;                     /**< descriptor UUID (16 bits UUIDs).*/
+    uint8_t        uuid_type;                /**< Base UUID. If 0, the Bluetooth SIG UUID will be used. Otherwise, this should be a value returned by @ref sd_ble_uuid_vs_add when adding the base UUID.*/
+    bool           is_defered_read;          /**< Indicate if deferred read operations are supported.*/
+    bool           is_defered_write;         /**< Indicate if deferred write operations are supported.*/
+    bool           is_var_len;               /**< Indicates if the descriptor value has variable length.*/
+    security_req_t read_access;              /**< Security requirement for reading the descriptor value.*/
+    security_req_t write_access;             /**< Security requirement for writing the descriptor value.*/
+    bool           is_value_user;            /**< Indicate if the content of the characteristic is to be stored in the application (user) or in the stack.*/
+    uint16_t       init_len;                 /**< Initial descriptor value length in bytes. */
+    uint16_t       init_offs;                /**< Initial descriptor value offset in bytes. If different from zero, the first init_offs bytes of the attribute value will be left uninitialized. */
+    uint16_t       max_len;                  /**< Maximum descriptor value length in bytes, see @ref BLE_GATTS_ATTR_LENS_MAX for maximum values. */
+    uint8_t*       p_value;                  /**< Pointer to the value of the descriptor*/
+} ble_add_descr_params_t;
+
+
+/**@brief Function for adding a characteristic to a given service.
+ *
+ * If no pointer is given for the initial value,
+ * the initial length parameter will be ignored and the initial length will be 0.
+ *
+ * @param[in]  service_handle Handle of the service to which the characteristic is to be added.
+ * @param[in]  p_char_props   Information needed to add the characteristic.
+ * @param[out] p_char_handle  Handle of the added characteristic.
+ *
+ * @retval      NRF_SUCCESS If the characteristic was added successfully. Otherwise, an error code is returned.
+ */
+uint32_t characteristic_add(uint16_t                   service_handle,
+                            ble_add_char_params_t *    p_char_props,
+                            ble_gatts_char_handles_t * p_char_handle);
+
+
+/**@brief Function for adding a characteristic's descriptor to a given characteristic.
+ *
+ * @param[in]  char_handle    Handle of the characteristic to which the descriptor is to be added, if @ref BLE_GATT_HANDLE_INVALID is used, it will be placed sequentially.
+ * @param[in]  p_descr_props  Information needed to add the descriptor.
+ * @param[out] p_descr_handle Handle of the added descriptor.
+ *
+ * @retval      NRF_SUCCESS If the characteristic was added successfully. Otherwise, an error code is returned.
+ */
+uint32_t descriptor_add(uint16_t                   char_handle,
+                        ble_add_descr_params_t *   p_descr_props,
+                        uint16_t *                 p_descr_handle);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BLE_SRV_COMMON_H__
+
+/** @} */

--- a/src/sd_api_common/sdk/components/ble_services/ble_ipsp/ble_ipsp.c
+++ b/src/sd_api_common/sdk/components/ble_services/ble_ipsp/ble_ipsp.c
@@ -1,0 +1,611 @@
+/**
+ * Copyright (c) 2014 - 2019, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/* Attention!
+ * To maintain compliance with Nordic Semiconductor ASA's Bluetooth profile
+ * qualification listings, this section of source code must not be modified.
+ */
+#include <stdbool.h>
+#include <string.h>
+#include "nordic_common.h"
+#include "nrf.h"
+#include "ble_ipsp.h"
+#include "ble_srv_common.h"
+
+
+/**
+ * @defgroup ble_ipsp_log Module's Log Macros
+ * @details Macros used for creating module logs which can be useful in understanding handling
+ *          of events or actions on API requests. These are intended for debugging purposes and
+ *          can be enabled by defining the IOT_BLE_IPSP_CONFIG_LOG_ENABLED to 1.
+ * @note If NRF_LOG_ENABLED is disabled, having IOT_BLE_IPSP_CONFIG_LOG_ENABLED
+ *       has no effect.
+ * @{
+ */
+
+#if IOT_BLE_IPSP_CONFIG_LOG_ENABLED
+
+#define NRF_LOG_MODULE_NAME ipsp
+
+#define NRF_LOG_LEVEL       IOT_BLE_IPSP_CONFIG_LOG_LEVEL
+#define NRF_LOG_INFO_COLOR  IOT_BLE_IPSP_CONFIG_INFO_COLOR
+#define NRF_LOG_DEBUG_COLOR IOT_BLE_IPSP_CONFIG_DEBUG_COLOR
+
+#include "nrf_log.h"
+NRF_LOG_MODULE_REGISTER();
+
+#define BLE_IPSP_TRC        NRF_LOG_DEBUG                                                           /**< Used for getting trace of execution in the module. */
+#define BLE_IPSP_ERR        NRF_LOG_ERROR                                                           /**< Used for logging errors in the module. */
+#define BLE_IPSP_DUMP       NRF_LOG_HEXDUMP_DEBUG                                                   /**< Used for dumping octet information to get details of bond information etc. */
+
+#define BLE_IPSP_ENTRY()                  BLE_IPSP_TRC(">> %s", __func__)
+#define BLE_IPSP_EXIT()                   BLE_IPSP_TRC("<< %s", __func__)
+#define BLE_IPSP_EXIT_WITH_RESULT(result) BLE_IPSP_TRC("<< %s, result 0x%08lX", __func__, result)
+
+#else // IOT_BLE_IPSP_CONFIG_LOG_ENABLED
+
+// #define BLE_IPSP_TRC(...)                                                                           /**< Disables traces. */
+// #define BLE_IPSP_DUMP(...)                                                                          /**< Disables dumping of octet streams. */
+// #define BLE_IPSP_ERR(...)                                                                           /**< Disables error logs. */
+
+#define BLE_IPSP_TRC printf
+#define BLE_IPSP_ERR printf
+
+#define BLE_IPSP_ENTRY(...)
+#define BLE_IPSP_EXIT(...)
+#define BLE_IPSP_EXIT_WITH_RESULT(...)
+
+#endif // IOT_BLE_IPSP_CONFIG_LOG_ENABLED
+
+#define IPSP_ANY_CID 0xFFFE                                                                         /**< Identifier for any channel. Usage: Search for existing channel on a connection handle. */
+
+/**
+ * @defgroup api_param_check API Parameters check macros.
+ *
+ * @details Macros that verify parameters passed to the module in the APIs. These macros
+ *          could be mapped to nothing in final versions of code to save execution and size.
+ *          BLE_HPS_DISABLE_API_PARAM_CHECK should be defined to disable these checks.
+ *
+ * @{
+ */
+#if (BLE_IPSP_DISABLE_API_PARAM_CHECK == 0)
+
+/**@brief Macro to check is module is initialized before requesting one of the module procedures. */
+#define VERIFY_MODULE_IS_INITIALIZED()                                                             \
+        if (m_evt_handler == NULL)                                                                 \
+        {                                                                                          \
+            return (NRF_ERROR_MODULE_NOT_INITIALIZED + NRF_ERROR_BLE_IPSP_ERR_BASE);               \
+        }
+
+/**@brief Macro to check is module is initialized before requesting one of the module
+         procedures but does not use any return code. */
+#define VERIFY_MODULE_IS_INITIALIZED_VOID()                                                        \
+        if (m_evt_handler == NULL)                                                                 \
+        {                                                                                          \
+            return;                                                                                \
+        }
+
+/**@brief Verify NULL parameters are not passed to API by application. */
+#define NULL_PARAM_CHECK(PARAM)                                                                    \
+        if ((PARAM) == NULL)                                                                       \
+        {                                                                                          \
+            return (NRF_ERROR_NULL + NRF_ERROR_BLE_IPSP_ERR_BASE);                                 \
+        }
+
+/**@brief Verify the connection handle passed to the API. */
+#define VERIFY_CON_HANDLE(CON_HANDLE)                                                              \
+        if ((CON_HANDLE) == BLE_CONN_HANDLE_INVALID)                                               \
+        {                                                                                          \
+            return (NRF_ERROR_INVALID_PARAM + NRF_ERROR_BLE_IPSP_ERR_BASE);                        \
+        }
+
+#else // BLE_IPSP_DISABLE_API_PARAM_CHECK
+
+#define VERIFY_MODULE_IS_INITIALIZED()
+#define VERIFY_MODULE_IS_INITIALIZED_VOID()
+#define NULL_PARAM_CHECK(PARAM)
+#define VERIFY_CON_HANDLE(CON_HANDLE)
+
+#endif //BLE_IPSP_DISABLE_API_PARAM_CHECK
+
+/**
+ * @defgroup ble_ipsp_mutex_lock_unlock Module's Mutex Lock/Unlock Macros.
+ *
+ * @details Macros used to lock and unlock modules. Currently, SDK does not use mutexes but
+ *          framework is provided in case the need to use an alternative architecture arises.
+ * @{
+ */
+#define BLE_IPSP_MUTEX_LOCK()
+#define BLE_IPSP_MUTEX_UNLOCK()
+/** @} */
+
+#define IPSP_MAX_CONNECTED_DEVICES    BLE_IPSP_MAX_CHANNELS                                         /**< Table for maximum number of connected devices the module will keep track of. */
+#define RX_BUFFER_TOTAL_SIZE          (BLE_IPSP_RX_BUFFER_SIZE * BLE_IPSP_RX_BUFFER_COUNT)          /**< Total receive buffer size reserved for each IPSP channel. */
+#define MAX_L2CAP_RX_BUFFER           (RX_BUFFER_TOTAL_SIZE * BLE_IPSP_MAX_CHANNELS)                /**< Total receive buffer received for all channels. */
+#define INVALID_CHANNEL_INSTANCE      0xFF                                                          /**< Indicates channel instance is invalid. */
+
+
+/**@brief IPSP Channel States. */
+typedef enum
+{
+    CHANNEL_IDLE,                                                                                   /**< Indicates the channel is free and not in use. */
+    CHANNEL_CONNECTING,                                                                             /**< Indicates the channel creation is requested and is awaiting a response. */
+    CHANNEL_CONNECTED,                                                                              /**< Indicates the channel is connected and ready for data exchange. */
+    CHANNEL_DISCONNECTING                                                                           /**< Indicates the channel is in the process of being disconnected. */
+} channel_state_t;
+
+
+/**@brief Possible response actions for an incoming channel. Default is to accept. */
+typedef enum
+{
+    INCOMING_CHANNEL_ACCEPT,                                                                       /**< Indicates that the incoming channel should be accepted if all other criteria are met. */
+    INCOMING_CHANNEL_REJECT                                                                        /**< Indicates that the incoming channel for IPSP PSM should be rejected regardless of the other criteria. */
+} incoming_channel_action_t;
+
+/**@brief Data type for book keeping connected devices.
+ *
+ * @note Not all connected devices establish an L2CAP connection.
+ */
+typedef struct
+{
+    volatile incoming_channel_action_t  response;                                                   /**< Indicator if the incoming channel should be accepted or rejected. */
+    ble_gap_addr_t                      ble_addr;                                                   /**< Bluetooth device address of the peer. */
+    uint16_t                            conn_handle;                                                /**< Connection handle identifying the link with the peer. */
+} peer_connection_t;
+
+
+/**@brief IPSP Channel Information. */
+typedef struct
+{
+    uint16_t     conn_handle;                                                                       /**< Identifies the BLE link on which channel is established. BLE_CONN_HANDLE_INVALID if channel is unassigned. */
+    uint16_t     cid;                                                                               /**< L2CAP channel identifier needed to manage the channel once established. BLE_L2CAP_CID_INVALID if channel is unassigned. */
+    uint16_t     rx_buffer_status;                                                                  /**< Usage status of RX buffers. */
+    uint8_t      state;                                                                             /**< State information for the channel. See @ref channel_state_t for details. */
+    uint8_t    * p_rx_buffer;                                                                       /**< Receive buffer for the channel. */
+} channel_t;
+
+
+static ble_ipsp_evt_handler_t m_evt_handler = NULL;                                                 /**< Asynchronous event notification callback registered with the module. */
+static channel_t              m_channel[BLE_IPSP_MAX_CHANNELS];                                     /**< Table of channels managed by the module. */
+static uint8_t                m_rx_buffer[MAX_L2CAP_RX_BUFFER];                                     /**< Receive buffer reserved for all channels to receive data on the L2CAP IPSP channel. */
+static peer_connection_t      m_connected_device[IPSP_MAX_CONNECTED_DEVICES];                       /**< Table maintaining list of peer devices and the connection handle.
+                                                                                                      \n This information is needed for the 6lowpan compression and decompression.
+                                                                                                      \n And no interface exists to query the softdevice. */
+//SDK_MUTEX_DEFINE(m_ipsp_mutex)                                                                      /**< Mutex variable. Currently unused, this declaration does not occupy any space in RAM. */
+
+
+/**@brief Initialize the peer connected device in the list.
+ *
+ * @param[in] index Identifies the list element to be initialized.
+ */
+static __INLINE void connected_device_init(uint32_t index)
+{
+    memset (&m_connected_device[index].ble_addr, 0, sizeof(ble_gap_addr_t));
+    m_connected_device[index].conn_handle = BLE_CONN_HANDLE_INVALID;
+    m_connected_device[index].response    = INCOMING_CHANNEL_ACCEPT;
+}
+
+
+/**@brief Allocate an entry for the peer connected device in the list.
+ *
+ * @param[in] p_peer_addr Pointer to peer's device address.
+ * @param[in] conn_handle Connection handle identifying the link with the peer.
+ */
+static __INLINE void connected_device_allocate(ble_gap_addr_t const * p_peer_addr,
+                                               uint16_t               conn_handle)
+{
+    for (uint32_t index = 0; index < IPSP_MAX_CONNECTED_DEVICES; index++)
+    {
+        if (m_connected_device[index].conn_handle == BLE_CONN_HANDLE_INVALID)
+        {
+            m_connected_device[index].conn_handle = conn_handle;
+            memcpy(m_connected_device[index].ble_addr.addr, p_peer_addr->addr, BLE_GAP_ADDR_LEN);
+            break;
+        }
+    }
+}
+
+
+/**@brief Search for an entry for the peer connected device in the list.
+ *
+ * @param[in] conn_handle Connection handle identifying the link with the peer.
+ *
+ * @retval A valid device index in the list if found, else,
+ *         IPSP_MAX_CONNECTED_DEVICES indicating the search failed.
+ */
+static __INLINE uint32_t connected_device_search(uint16_t conn_handle)
+{
+    for (uint32_t index = 0; index < IPSP_MAX_CONNECTED_DEVICES; index++)
+    {
+        if (m_connected_device[index].conn_handle == conn_handle)
+        {
+            return index;
+        }
+    }
+    return IPSP_MAX_CONNECTED_DEVICES;
+}
+
+
+/**@brief Initialize channel.
+ *
+ * @param[in] ch_id Identifies the IPSP channel on which the procedure is requested.
+ */
+static __INLINE void channel_init(uint8_t ch_id)
+{
+    m_channel[ch_id].conn_handle      = BLE_CONN_HANDLE_INVALID;
+    m_channel[ch_id].cid              = BLE_L2CAP_CID_INVALID;
+    m_channel[ch_id].rx_buffer_status = 0;
+    m_channel[ch_id].state            = CHANNEL_IDLE;
+    m_channel[ch_id].p_rx_buffer      = &m_rx_buffer[ch_id*RX_BUFFER_TOTAL_SIZE];
+}
+
+
+/**@brief Free channel.
+ *
+ * @param[in] ch_id Identifies the IPSP channel on which the procedure is requested.
+ */
+static __INLINE void channel_free(uint8_t ch_id)
+{
+    BLE_IPSP_TRC("[Index 0x%02X]:[Conn Handle 0x%04X]:[CID 0x%04X]: Freeing channel",
+             ch_id, m_channel[ch_id].conn_handle, m_channel[ch_id].cid);
+
+    channel_init(ch_id);
+}
+
+
+/**@brief Searches the IPSP channel based on connection handle and local L2CAP channel identifier.
+ *
+ * @param[in]  conn_handle The connection handle, identifying the peer device.
+ * @param[in]  l2cap_cid   The local L2CAP channel identifier, identifying the L2CAP channel.
+ * @param[out] p_ch_id     The IPSP channel identifier, if the search succeeded, else,
+ *                         BLE_IPSP_MAX_CHANNELS indicating no IPSP channel was found.
+ */
+static __INLINE uint32_t channel_search(uint16_t conn_handle, uint16_t l2cap_cid, uint8_t * p_ch_id)
+{
+    BLE_IPSP_TRC("[Conn Handle 0x%04X]:[CID 0x%04X]: channel_search",
+             conn_handle, l2cap_cid);
+
+    for (int i = 0; i < BLE_IPSP_MAX_CHANNELS; i++)
+    {
+        BLE_IPSP_TRC("[@ Index 0x%02X] ==> Conn Handle: 0x%04X"
+                 "                            CID        : 0x%04X",
+                 i, m_channel[i].conn_handle, m_channel[i].cid);
+
+        if (m_channel[i].conn_handle == conn_handle)
+        {
+            if ((l2cap_cid == IPSP_ANY_CID) || (m_channel[i].cid == l2cap_cid))
+            {
+                BLE_IPSP_TRC("channel_search succeeded, index 0x%04X", i);
+
+                *p_ch_id = (uint8_t)i;
+                return NRF_SUCCESS;
+            }
+        }
+    }
+
+    BLE_IPSP_TRC("No matching channel found!");
+    return (NRF_ERROR_BLE_IPSP_ERR_BASE + NRF_ERROR_NOT_FOUND);
+}
+
+
+/**@brief Notify application of an event.
+ *
+ * @param[in] Identifies the IPSP instance for which the event is notified.
+ * @param[in] Describes the notified event and its parameters, if any.
+ */
+static __INLINE void app_notify(ble_ipsp_handle_t * p_handle, ble_ipsp_evt_t * p_event)
+{
+    BLE_IPSP_MUTEX_UNLOCK();
+
+    BLE_IPSP_TRC("[Conn Handle 0x%04X]:[CID 0x%04X]: Notifying application of event 0x%04X",
+             p_handle->conn_handle, p_handle->cid, p_event->evt_id);
+
+    UNUSED_VARIABLE(m_evt_handler(p_handle, p_event));
+
+    BLE_IPSP_MUTEX_LOCK();
+}
+
+
+/**@brief Verifies if the buffer is TX buffer on the channel or not.
+ *
+ * @param[in] ch_id    Identifies the IPSP channel for which the procedure is requested.
+ * @param[in] p_buffer Address of the buffer being verified to be TX or not.
+ */
+static __INLINE bool is_tx_buffer(uint32_t ch_id, const uint8_t * p_buffer)
+{
+    // If the buffer is in the RX buffer list, then it is not TX!
+    if ((p_buffer >= (uint8_t *)&m_channel[ch_id].p_rx_buffer) &&
+        (p_buffer <  (uint8_t *)&m_channel[ch_id].p_rx_buffer[RX_BUFFER_TOTAL_SIZE]))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+
+/**@brief Mark a receive buffer as not in use for a particular channel.
+ *
+ * @param[in] ch_id     Identifies the IPSP channel for which the procedure is requested.
+ * @param[in] p_buffer  The buffer to be marked as unused.
+ *
+ * @note This is a temporary state for the receive buffer before it is resubmitted to the SoftDevice.
+ */
+static __INLINE void rx_buffer_mark_unused(uint32_t ch_id, uint8_t * p_buffer)
+{
+    for (uint32_t buffer_index = 0; buffer_index < BLE_IPSP_RX_BUFFER_COUNT; buffer_index++)
+    {
+        if (&m_channel[ch_id].p_rx_buffer[buffer_index * BLE_IPSP_MTU] == p_buffer)
+        {
+            CLR_BIT(m_channel[ch_id].rx_buffer_status, buffer_index);
+        }
+    }
+}
+
+
+void ble_ipsp_evt_handler(ble_evt_t const * p_evt)
+{
+    VERIFY_MODULE_IS_INITIALIZED_VOID();
+
+    ble_ipsp_handle_t    handle;
+    ble_ipsp_evt_t       ipsp_event;
+    uint32_t             retval;
+    uint8_t              ch_id;
+    bool                 notify_event;
+    bool                 submit_rx_buffer;
+
+    ch_id                 = INVALID_CHANNEL_INSTANCE;
+    notify_event          = false;
+    submit_rx_buffer      = false;
+    retval                = NRF_SUCCESS;
+    ipsp_event.evt_result = NRF_SUCCESS;
+    handle.conn_handle    = BLE_CONN_HANDLE_INVALID;
+    handle.cid            = BLE_L2CAP_CID_INVALID;
+
+    BLE_IPSP_MUTEX_LOCK();
+
+    switch (p_evt->header.evt_id)
+    {
+        case BLE_GAP_EVT_CONNECTED:
+        {
+            printf("Received BLE Event BLE_GAP_EVT_CONNECTED\n");
+            // Create an entry in the connected devices table.
+            // This is needed to be able to fetch the peer address on IPSP channel establishment.
+            connected_device_allocate(&p_evt->evt.gap_evt.params.connected.peer_addr,
+                                      p_evt->evt.gap_evt.conn_handle);
+            break;
+        }
+#if NRF_SD_BLE_API_VERSION >= 5
+        case BLE_L2CAP_EVT_CH_SETUP_REQUEST:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_SETUP_REQUEST\n");
+            break;
+        }
+        case BLE_L2CAP_EVT_CH_SETUP:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_SETUP\n");
+            break;
+        }
+        case BLE_L2CAP_EVT_CH_SETUP_REFUSED:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_SETUP_REFUSED\n");
+            break;
+        }
+        case BLE_L2CAP_EVT_CH_RELEASED:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_RELEASED\n");
+            break;
+        }
+        case BLE_L2CAP_EVT_CH_RX:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_RX\n");
+            break;
+        }
+        case BLE_L2CAP_EVT_CH_TX:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_TX\n");
+            break;
+        }
+        case BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED:
+        {
+            printf("Received BLE Event BLE_L2CAP_EVT_CH_SDU_BUF_RELEASED\n");
+            break;
+        }
+#endif
+        case BLE_GAP_EVT_DISCONNECTED:
+        {
+            uint32_t peer_device_index = connected_device_search(handle.conn_handle);
+            if (peer_device_index < IPSP_MAX_CONNECTED_DEVICES)
+            {
+                connected_device_init(peer_device_index);
+            }
+            break;
+        }
+        default:
+            printf("Received BLE Event - default\n");
+            break;
+    }
+
+    BLE_IPSP_MUTEX_UNLOCK();
+    UNUSED_VARIABLE(retval);
+}
+
+
+uint32_t ble_ipsp_init(adapter_t *m_adapter, const ble_ipsp_init_t * p_init)
+{
+    BLE_IPSP_ENTRY();
+
+    ble_uuid_t    ble_uuid;
+    uint32_t      err_code;
+    uint16_t      handle;
+
+    NULL_PARAM_CHECK(p_init);
+    NULL_PARAM_CHECK(p_init->evt_handler);
+
+    BLE_IPSP_MUTEX_LOCK();
+
+    // Add service to indicate IPSP support.
+    BLE_UUID_BLE_ASSIGN(ble_uuid, BLE_UUID_IPSP_SERVICE);
+
+    err_code = sd_ble_gatts_service_add(m_adapter, BLE_GATTS_SRVC_TYPE_PRIMARY, &ble_uuid, &handle);
+    if (err_code != NRF_SUCCESS)
+    {
+        return err_code;
+    }
+
+    m_evt_handler = p_init->evt_handler;
+
+    // Initialize the channel.
+    for (int i = 0; i < BLE_IPSP_MAX_CHANNELS; i++)
+    {
+        channel_init(i);
+    }
+
+    // Initialize the connected peer device table.
+    for (int i = 0; i < IPSP_MAX_CONNECTED_DEVICES; i++)
+    {
+        connected_device_init(i);
+    }
+    BLE_IPSP_MUTEX_UNLOCK();
+
+    BLE_IPSP_EXIT();
+
+    return NRF_SUCCESS;
+}
+
+
+uint32_t ble_ipsp_connect(adapter_t *m_adapter, const ble_ipsp_handle_t * p_handle)
+{
+    VERIFY_MODULE_IS_INITIALIZED();
+    NULL_PARAM_CHECK(p_handle);
+    VERIFY_CON_HANDLE(p_handle->conn_handle);
+
+    uint32_t err_code;
+    uint8_t  ch_id  = INVALID_CHANNEL_INSTANCE;
+
+    BLE_IPSP_TRC("[Conn Handle 0x%04X]: >> ble_ipsp_connect\n",
+             p_handle->conn_handle);
+#if NRF_SD_BLE_API_VERSION >= 5
+    BLE_IPSP_MUTEX_LOCK();
+
+    // Check if channel already exists with the peer.
+    err_code = channel_search(p_handle->conn_handle, IPSP_ANY_CID, &ch_id);
+
+    if (err_code == NRF_SUCCESS)
+    {
+        // IPSP channel already exists.
+        BLE_IPSP_TRC("NRF_ERROR_BLE_IPSP_CHANNEL_ALREADY_EXISTS\n");
+        err_code = NRF_ERROR_BLE_IPSP_CHANNEL_ALREADY_EXISTS;
+    }
+    else
+    {
+        // Search for a free channel.
+        err_code = channel_search(BLE_CONN_HANDLE_INVALID, BLE_L2CAP_CID_INVALID, &ch_id);
+        BLE_IPSP_TRC("2 channel_search result %08X\n", err_code);
+
+        if (err_code == NRF_SUCCESS)
+        {
+            m_channel[ch_id].state = CHANNEL_CONNECTING;
+
+            ble_l2cap_ch_setup_params_t param =
+            {
+                .le_psm = BLE_IPSP_PSM,
+                .rx_params = {
+                    .rx_mtu         = BLE_IPSP_MTU,
+                    .rx_mps         = BLE_IPSP_RX_MPS,
+                    .sdu_buf =
+                    {
+                        .p_data = NULL,
+                        .len    = 0
+                    }
+                }
+            };
+            BLE_IPSP_TRC("Requesting sd_ble_l2cap_ch_setup\n");
+
+            err_code = sd_ble_l2cap_ch_setup(m_adapter, p_handle->conn_handle,
+                                             &m_channel[ch_id].cid,
+                                             &param);
+
+            if (err_code != NRF_SUCCESS)
+            {
+                BLE_IPSP_ERR("sd_ble_l2cap_ch_conn_request failed, reason %08lX\n", err_code);
+                channel_free(ch_id);
+            }
+            else
+            {
+                BLE_IPSP_TRC("Local channel id from SD %04X.\n", m_channel[ch_id].cid);
+                m_channel[ch_id].conn_handle = p_handle->conn_handle;
+            }
+        }
+        else
+        {
+            err_code = (NRF_ERROR_BLE_IPSP_ERR_BASE + NRF_ERROR_NO_MEM);
+        }
+    }
+
+    BLE_IPSP_MUTEX_UNLOCK();
+#else
+    err_code = NRF_ERROR_NOT_SUPPORTED;
+#endif
+    BLE_IPSP_EXIT_WITH_RESULT(err_code);
+
+    return err_code;
+}
+
+
+void ble_ipsp_incoming_channel_reject(uint16_t conn_handle)
+{
+    uint32_t peer_device_index = connected_device_search(conn_handle);
+
+    if (peer_device_index != IPSP_MAX_CONNECTED_DEVICES)
+    {
+        m_connected_device[peer_device_index].response = INCOMING_CHANNEL_REJECT;
+    }
+}
+
+
+void ble_ipsp_incoming_channel_accept(uint16_t conn_handle)
+{
+    uint32_t peer_device_index = connected_device_search(conn_handle);
+
+    if (peer_device_index != IPSP_MAX_CONNECTED_DEVICES)
+    {
+        m_connected_device[peer_device_index].response = INCOMING_CHANNEL_ACCEPT;
+    }
+}

--- a/src/sd_api_v6/ble_l2cap_impl.cpp
+++ b/src/sd_api_v6/ble_l2cap_impl.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016 Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ *   4. This software must only be used in or with a processor manufactured by Nordic
+ *   Semiconductor ASA, or in or with a processor manufactured by a third party that
+ *   is used in combination with a processor manufactured by Nordic Semiconductor.
+ *
+ *   5. Any software provided in binary or object form under this license must not be
+ *   reverse engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+
+// C++ code
+#include "adapter.h"
+#include "adapter_internal.h"
+#include "ble_common.h"
+
+// C code
+#include "ble_l2cap.h"
+#include "ble_l2cap_app.h" // Encoder/decoder functions
+
+uint32_t sd_ble_l2cap_ch_setup(adapter_t *adapter, uint16_t conn_handle,
+                               uint16_t *p_local_cid, ble_l2cap_ch_setup_params_t const *p_params)
+{
+    auto adapterLayer = static_cast<AdapterInternal *>(adapter->internal);
+    RequestReplyCodecContext context(adapterLayer->transport);
+
+    encode_function_t encode_function = [&](uint8_t *buffer, uint32_t *length) -> uint32_t {
+        return ble_l2cap_ch_setup_req_enc(conn_handle, p_local_cid, p_params, buffer, length);
+    };
+
+    decode_function_t decode_function = [&](uint8_t *buffer, uint32_t length,
+                                            uint32_t *result) -> uint32_t {
+        return ble_l2cap_ch_setup_rsp_dec(buffer, length, p_local_cid, result);
+    };
+
+    return encode_decode(adapter, encode_function, decode_function);
+}


### PR DESCRIPTION
I tried to port the example "ble_app_ipsp_initiator" to pc-ble-driver and run on Linux. The peer device is another PCA10056 device running ble_app_ipsp_acceptor. The problem is that sd_ble_l2cap_ch_setup() always returns "NRF_ERROR_RESOURCES".

However, it works fine if I just take and run ble_app_ipsp_initiator example standalone without pc-ble-driver. As far as my know, pc-ble-driver will apply some patches and build a special firmware (softdevice?) in the hex folder.

Do I need to include additional patches related to "credit based flow control L2CAP channel" to make it work?

https://devzone.nordicsemi.com/f/nordic-q-a/50645/does-the-nrf52840dk-pca10056-support-ipsp-service-serialization-e-g-sd_ble_l2cap_ch_setup-connected-with-pc-ble-driver