### PR TITLE
Fix compilation error on gcc@8

### DIFF
--- a/src/common/platform/macos_osx/serial_port_enum.cpp
+++ b/src/common/platform/macos_osx/serial_port_enum.cpp
@@ -71,6 +71,7 @@
 
 #include <vector>
 #include <iostream>
+#include <cstring>
 
 #include <AvailabilityMacros.h>
 #include <sys/param.h>


### PR DESCRIPTION
Add required include (cstring)