### PR TITLE
Move instead of copy event from queue

### DIFF
--- a/src/common/transport/serialization_transport.cpp
+++ b/src/common/transport/serialization_transport.cpp
@@ -250,7 +250,7 @@ void SerializationTransport::eventHandlingRunner() noexcept
             while (!eventQueue.empty() && processEvents)
             {
                 // Get oldest event received from UART thread
-                const auto eventData     = eventQueue.front();
+                const auto eventData     = std::move(eventQueue.front());
                 const auto eventDataSize = static_cast<uint32_t>(eventData.size());
 
                 // Remove oldest event received from H5Transport thread


### PR DESCRIPTION
Moving instead of copying saves the work of: allocating a new block of memory on the
heap, copying the contents from the old block to the new, and then freeing the old block.