### PR TITLE
Added NRF52 dongle to list of recognized devices on Linux.

### DIFF
--- a/src/common/platform/linux/serial_port_enum.cpp
+++ b/src/common/platform/linux/serial_port_enum.cpp
@@ -47,6 +47,8 @@
 
 const char* SEGGER_VENDOR_ID = "1366";
 const char* NXP_VENDOR_ID = "0d28";
+const char* NORDIC_SEMICONDUCTOR_VENDOR_ID = "1915";
+const char* NRF52_CONNECTIVITY_DONGLE_PID = "c00a";
 
 std::string to_str(const char* s)
 {
@@ -87,17 +89,20 @@ std::list<SerialPortDesc> EnumSerialPorts()
         );
 
         std::string idVendor = to_str(udev_device_get_sysattr_value(udev_usb_dev, "idVendor"));
+        std::string idProduct = to_str(udev_device_get_sysattr_value(udev_usb_dev, "idProduct"));
         std::string manufacturer = to_str(udev_device_get_sysattr_value(udev_usb_dev,"manufacturer"));
 
         if(
-          ((idVendor == SEGGER_VENDOR_ID) || (idVendor == NXP_VENDOR_ID))
-          && ((manufacturer == "SEGGER")
-              || (strncasecmp(manufacturer.c_str(), "arm", 3) == 0)
-              || (strncasecmp(manufacturer.c_str(), "mbed", 4) == 0))
+          (
+            ((idVendor == SEGGER_VENDOR_ID) || (idVendor == NXP_VENDOR_ID))
+            && ((manufacturer == "SEGGER")
+                || (strncasecmp(manufacturer.c_str(), "arm", 3) == 0)
+                || (strncasecmp(manufacturer.c_str(), "mbed", 4) == 0))
+          )
+          || ((idVendor == NORDIC_SEMICONDUCTOR_VENDOR_ID) && (idProduct == NRF52_CONNECTIVITY_DONGLE_PID))
           )
         {
             std::string serialNumber = to_str(udev_device_get_sysattr_value(udev_usb_dev, "serial"));
-            std::string idProduct = to_str(udev_device_get_sysattr_value(udev_usb_dev, "idProduct"));
 
             devices.push_back(SerialPortDesc {
               devname,


### PR DESCRIPTION
NRF52 dongle can run the Connectivity firmware and works fine with the
library. Unfortunately, the library does not recognize the port.

This is an issue in the pc-ble-driver-py, where even the examples do not
work.

I'm not sure if this is the correct way of doing that, as the previous code does not use PID, but seems good practice.

If there is interest, I'm willing to update windows/macosx as well (let me know).