### PR TITLE
Fix race condition in h5_transport

### DIFF
--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -303,18 +303,19 @@ uint32_t H5Transport::send(const std::vector<uint8_t> &data) noexcept
 
         while (remainingRetransmissions--)
         {
-            logPacket(true, h5EncodedPacket);
-            const auto err_code = nextTransportLayer->send(lastPacket);
-
-            if (err_code != NRF_SUCCESS)
-                return err_code;
-
             uint8_t seqNumBefore;
 
             {
                 std::unique_lock<std::recursive_mutex> seqNumLck(seqNumMutex);
                 seqNumBefore = seqNum;
             }
+
+
+            logPacket(true, h5EncodedPacket);
+            const auto err_code = nextTransportLayer->send(lastPacket);
+
+            if (err_code != NRF_SUCCESS)
+                return err_code;
 
             // Checking for timeout. Also checking against spurios wakeup by making sure the
             // sequence number has actually increased. If the sequence number has not increased, we

--- a/src/common/transport/h5_transport.cpp
+++ b/src/common/transport/h5_transport.cpp
@@ -306,6 +306,9 @@ uint32_t H5Transport::send(const std::vector<uint8_t> &data) noexcept
             uint8_t seqNumBefore;
 
             {
+                // seqNumBefore must be assigned a value before calling send() as otherwise the 
+                // seqNum value might already have been increased if context switch happens after
+                // send() and right before assigning the seqNumBefore.
                 std::unique_lock<std::recursive_mutex> seqNumLck(seqNumMutex);
                 seqNumBefore = seqNum;
             }


### PR DESCRIPTION
Fix race condition problem that caused GATT Write commands to fail
due to NRF_ERROR_SD_RPC_NO_RESPONSE error from H5 transport.

The race condition situation happens under high cpu load when
doing GATT Write Commands in a loop using fast connection parameters.

The bug triggers when context switch happens right after call to
nextTransportLayer->send() and before assigning the seqNumBefore and
the seqNum gets incremented in another thread when ACK was received.

Fix is to assign the seqNumBefore before calling the send() to make
we are waiting for ack with correct expected sequence number.

Related Nordic DevZone thread: https://devzone.nordicsemi.com/f/nordic-q-a/80783/intermittent-error-code-32773-0x8005-nrf_error_sd_rpc_no_response-when-using-pc-ble-driver