### PR TITLE
Also look for devices from Nordic Semiconductor ASA in order to find nRF52840 Dongle

### DIFF
--- a/src/common/platform/win/serial_port_enum.cpp
+++ b/src/common/platform/win/serial_port_enum.cpp
@@ -123,7 +123,7 @@ std::list<SerialPortDesc> EnumSerialPorts()
             dhGetValue(L"%s", &manu, objDevice, L".Manufacturer");
 
             if ((strcmp("SEGGER", manu) == 0) || (_stricmp("arm", manu) == 0) ||
-                (_stricmp("mbed", manu) == 0))
+                (_stricmp("mbed", manu) == 0) || (_stricmp("Nordic Semiconductor ASA", manu) == 0 ))
             {
                 char *next_token          = NULL;
                 auto comname              = strtok_s(match, "()", &next_token);


### PR DESCRIPTION
The nRF52840 Dongle shows as manufactured by Nordic Semiconductor ASA on Windows, thus also look for device of that manufacturer